### PR TITLE
expanded test_base_getTaskData, test_base_getHyperpars, test_base_multilabel

### DIFF
--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -17,5 +17,5 @@ test_that("getHyperPars", {
   expect_true(setequal(getHyperPars(lrn), list()))
 
   lrn = makeMultilabelBinaryRelevanceWrapper("classif.rpart")  
-  expect_true(setequal(getHyperPars(lrn), list()))
+  expect_true(setequal(getHyperPars(lrn), list(xval=0)))
 })

--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -12,4 +12,10 @@ test_that("getHyperPars", {
 
   lrn = makeModelMultiplexer(list("classif.rpart", "classif.lda"))
   expect_true(setequal(names(getHyperPars(lrn)), c("classif.rpart.xval", "selected.learner")))
+
+  lrn = makeLearner("multilabel.rFerns")
+  expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
+
+  lrn = makeMultilabelBinaryRelevanceWrapper("classif.rpart")  
+  expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
 })

--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -14,8 +14,8 @@ test_that("getHyperPars", {
   expect_true(setequal(names(getHyperPars(lrn)), c("classif.rpart.xval", "selected.learner")))
 
   lrn = makeLearner("multilabel.rFerns")
-  expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
+  expect_true(setequal(getHyperPars(lrn), list()))
 
   lrn = makeMultilabelBinaryRelevanceWrapper("classif.rpart")  
-  expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
+  expect_true(setequal(getHyperPars(lrn), list()))
 })

--- a/tests/testthat/test_base_getTaskData.R
+++ b/tests/testthat/test_base_getTaskData.R
@@ -56,3 +56,23 @@ test_that("getTaskData survival", {
   expect_true(is.Surv(x$target))
   expect_equal(dim(x$target), c(150L, 2L))
 })
+
+test_that("getTaskData multilabel", {
+  df = getTaskData(multilabel.task)
+  expect_equal(df, multilabel.df)
+  cn = colnames(multilabel.df)[3:4]
+  df = getTaskData(multilabel.task, subset=1:10, features=cn)
+  expect_equal(df, multilabel.df[1:10, union(cn, multilabel.target)])
+  
+  x = getTaskData(multilabel.task, target.extra=TRUE)
+  expect_true(setequal(names(x), c("data", "target")))
+  expect_true(is.data.frame(x$data))
+  expect_true(is.data.frame(x$target))
+  expect_equal(dim(x$data), c(150L, 5L))
+  expect_equal(dim(x$target), c(150L, 2L))
+  expect_equal(names(x$target), multilabel.target)
+  expect_true(setequal(names(x$data), setdiff(names(multilabel.df), multilabel.target)))
+  
+  x = getTaskData(multilabel.task, target.extra=TRUE)
+  expect_equal(dim(x$target), c(150L, 2L))
+})

--- a/tests/testthat/test_base_multilabel.R
+++ b/tests/testthat/test_base_multilabel.R
@@ -15,6 +15,17 @@ test_that("multilabel", {
   # resample
   r = holdout(lrn, multilabel.task)
   expect_true(!is.na(r$aggr))
+  # Learner with Impute-Preprocessing
+  lrn = makeImputeWrapper(lrn, classes = list(integer = imputeMedian(), numeric = imputeMedian(), factor = imputeConstant("Const")))
+  multilabel.df2 = multilabel.df
+  multilabel.df2[c(2,10,14), c(1,5)] = NA
+  multilabel.task2 = makeMultilabelTask("multilabel", data = multilabel.df2, target = multilabel.target)
+  mod = train(lrn, multilabel.task2)
+  pred = predict(mod, multilabel.task2) 
+  # Learner with Hyperparameters
+  lrn = makeLearner("multilabel.rFerns", par.vals = list(depth=6, ferns=100))
+  mod = train(lrn, multilabel.task)
+  pred = predict(mod, multilabel.task) 
 })
 
 
@@ -60,6 +71,20 @@ test_that("MultilabelBinaryRelevanceWrapper", {
   tr = tuneThreshold(r$pred, nsub = 2L, control= list(maxit = 2L))
   expect_true(!is.na(tr$perf))
   expect_equal(length(tr$th), length(getTaskClassLevels(multilabel.task)))
+  # Learner with Impute-Preprocessing
+  lrn1 = makeLearner("classif.rpart")
+  lrn2 = makeMultilabelBinaryRelevanceWrapper(lrn1)
+  lrn2 = makeImputeWrapper(lrn2, classes = list(integer = imputeMedian(), numeric = imputeMedian(), factor = imputeConstant("Const")))
+  multilabel.df2 = multilabel.df
+  multilabel.df2[c(2,10,14), c(1,5)] = NA
+  multilabel.task2 = makeMultilabelTask("multilabel", data = multilabel.df2, target = multilabel.target)
+  mod = train(lrn2, multilabel.task2)
+  pred = predict(mod, multilabel.task2) 
+  # Learner with Hyperparameters
+  lrn1 = makeLearner("classif.rpart", par.vals = list(minsplit = 10, cp = 0.005))
+  lrn2 = makeMultilabelBinaryRelevanceWrapper(lrn1)
+  mod = train(lrn2, multilabel.task)
+  pred = predict(mod, multilabel.task) 
 })
 
 

--- a/tests/testthat/test_base_multilabel.R
+++ b/tests/testthat/test_base_multilabel.R
@@ -22,10 +22,14 @@ test_that("multilabel", {
   multilabel.task2 = makeMultilabelTask("multilabel", data = multilabel.df2, target = multilabel.target)
   mod = train(lrn, multilabel.task2)
   pred = predict(mod, multilabel.task2) 
+  p = performance(pred)
+  expect_true(!is.na(p))
   # Learner with Hyperparameters
   lrn = makeLearner("multilabel.rFerns", par.vals = list(depth=6, ferns=100))
   mod = train(lrn, multilabel.task)
   pred = predict(mod, multilabel.task) 
+  p = performance(pred)
+  expect_true(!is.na(p))
 })
 
 
@@ -80,11 +84,15 @@ test_that("MultilabelBinaryRelevanceWrapper", {
   multilabel.task2 = makeMultilabelTask("multilabel", data = multilabel.df2, target = multilabel.target)
   mod = train(lrn2, multilabel.task2)
   pred = predict(mod, multilabel.task2) 
+  p = performance(pred)
+  expect_true(!is.na(p))
   # Learner with Hyperparameters
   lrn1 = makeLearner("classif.rpart", par.vals = list(minsplit = 10, cp = 0.005))
   lrn2 = makeMultilabelBinaryRelevanceWrapper(lrn1)
   mod = train(lrn2, multilabel.task)
   pred = predict(mod, multilabel.task) 
+  p = performance(pred)
+  expect_true(!is.na(p))
 })
 
 


### PR DESCRIPTION
in test_base_getTaskData: same things for multilabel like for survival.
in test_base_getHyperpars: The default case with no hyperpars.
in test_base_multilabel: imputeWrapper and hyperpars for both cases

