### PR TITLE
clean version of converting caret tuning params

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -47,6 +47,7 @@ mlr_2.5:
 -- plotBenchmarkResult, convertBMRToRankMatrix, generateRankMatrixAsBarData, plotRankMatrixAsBar,
    generateBenchmarkSummaryData, plotBenchmarkSummary,
    friedmanTestBMR, friedmanPostHocTestBMR, generateCritDifferencesData, plotCritDifferences
+-- getCaretParamSet
 
 - new measures
 -- hamloss

--- a/R/getCaretParamSet.R
+++ b/R/getCaretParamSet.R
@@ -1,0 +1,97 @@
+#' @title Get tuning parameters from a learner of the caret R-package.
+#'
+#' @description
+#' Constructs a grid of tuning parameters from a learner of the \code{caret}
+#' R-package. These values are then converted into a list of non-tunable
+#' parameters (\code{par.vals}) and a tunable
+#' \code{\link[ParamHelpers]{ParamSet}} (\code{par.set}), which can be used by
+#' \code{\link{tuneParams}} for tuning the learner. Numerical parameters will
+#' either be specified by their lower and upper bounds or they will be
+#' discretized into specific values.
+#'
+#' @param learner [\code{character(1)}]\cr
+#'   The name of the learner from \code{caret}
+#'   (cf. \url{http://topepo.github.io/caret/modelList.html}). Note that the
+#'   names in \code{caret} often differ from the ones in \code{mlr}.
+#' @param length [\code{integer(1)}]\cr
+#'   A length / precision parameter which is used by \code{caret} for
+#'   generating the grid of tuning parameters. \code{caret} generates either as
+#'   many values per tuning parameter / dimension as defined by \code{length}
+#'   or only a single value (in case of non-tunable \code{par.vals}).
+#' @param x [\code{data.frame}]\cr
+#'   A data frame with the input data.
+#' @param y [\code{factor} | \code{numeric}]\cr
+#'   A response vector.
+#' @param discretize [\code{logical(1)}]\cr
+#'   Should the numerical parameters be discretized? Alternatively, they will
+#'   be defined by their lower and upper bounds. The default is \code{TRUE}.
+#' @return [\code{list(2)}]. A list of parameters:
+#' \itemize{
+#'   \item{\code{par.vals}} contains a list of all constant tuning parameters
+#'   \item{\code{par.set}} is a \code{\link[ParamHelpers]{ParamSet}}, containing all the configurable
+#'   tuning parameters
+#' }
+#' @export
+#' @examples
+#' library(caret)
+#' 
+#' # (1) classification (random forest) with discretized parameters
+#' getCaretParamSet("rf", length = 9L, x = iris[, -5], y = iris[, 5], discretize = TRUE)
+#' 
+#' # (2) regression (gradient boosting machine) without discretized parameters
+#' library(mlbench)
+#' data(BostonHousing)
+#' getCaretParamSet("gbm", length = 9L, x = BostonHousing[, -14],
+#'   y = BostonHousing[, 14], discretize = FALSE)
+getCaretParamSet = function(learner, length = 3, x, y, discretize = TRUE){
+  # define caret's var_seq function within this environment
+  var_seq = caret::var_seq
+  caret.grid = caret::getModelInfo(learner)[[learner]]$grid(x = x, y = y, len = length)
+
+  # transfer caret parameters into mlr parameters
+  params = lapply(colnames(caret.grid), function(i) {
+    x = sort(unique(caret.grid[,i]))
+    cl = class(x)
+    if (cl == "factor") {
+      if (all(levels(x) %in% c("TRUE", "FALSE"))) {
+        x = as.logical(as.character(x))
+        cl = "logical"
+      } else {
+        x = as.character(x)
+        cl = "character"
+      }
+    }
+    if (discretize)
+      cl = "character"
+    switch(cl,
+      character = makeDiscreteParam(id = i, values = x),
+      logical = makeLogicalParam(id = i),
+      numeric = makeNumericParam(id = i, lower = min(x), upper = max(x)),
+      integer = makeIntegerParam(id = i, lower = min(x), upper = max(x))
+    )
+  })
+  names(params) = colnames(caret.grid)
+
+  # are the parameters configurable or are the values unique?
+  is.tunable = vlapply(params, function(x) {
+    (!is.null(x$values) && length(x$values) > 1) |
+      (!is.null(x$lower) && !is.null(x$upper) && (x$upper > x$lower))
+  })
+
+  # define par.vals (if existing)
+  if (all(is.tunable)) {
+    par.vals = NULL
+  } else {
+    par.vals = lapply(caret.grid[!is.tunable], function(x) {
+      if (is.factor(x))
+        x = as.character(x)
+      return(x[1L])
+    })
+    # convert integerish variables into integer
+    par.vals[vlapply(par.vals, testIntegerish)] = 
+      lapply(par.vals[vlapply(par.vals, testIntegerish)], as.integer)
+  }
+
+  return(list(par.vals = par.vals,
+    par.set = do.call(makeParamSet, params[is.tunable])))
+}

--- a/tests/testthat/test_base_getCaretParamSet.R
+++ b/tests/testthat/test_base_getCaretParamSet.R
@@ -1,0 +1,39 @@
+context("getCaretParamSet")
+
+test_that("getCaretParamSet", {
+  requirePackages(c("caret", "rpart", "earth"))
+  caret.learners = c("gbm", "rf", "svmPoly", "svmLinear", "svmRadial",
+    "rpart", "J48", "stepLDA", "earth")
+  checkCaretParams = function(lrn, k, x, y) {
+    set.seed(123)
+    a = capture.output({cps1 = getCaretParamSet(lrn, length = k, x = x, y = y, discretize = TRUE)})
+    set.seed(123)
+    b = capture.output({cps2 = getCaretParamSet(lrn, length = k, x = x, y = y, discretize = FALSE)})
+    expect_identical(cps1$par.vals, cps2$par.vals)
+    expect_identical(names(cps1$par.set$pars), names(cps2$par.set$pars))
+    expect_identical(class(cps1$par.set), "ParamSet")
+    expect_identical(class(cps2$par.set), "ParamSet")
+    if (!is.null(cps1$par.vals))
+      expect_identical(class(cps1$par.vals), "list")
+  }
+
+  # binaryclass problems
+  x = subset(binaryclass.df, select = setdiff(colnames(binaryclass.df), binaryclass.target))
+  y = subset(binaryclass.df, select = binaryclass.target)[[1]]
+  r1 = lapply(caret.learners, checkCaretParams, k = 9, x = x, y = y)
+  r2 = lapply(caret.learners, checkCaretParams, k = 5, x = x, y = y)
+
+  # multiclass problems
+  x = subset(multiclass.df, select = setdiff(colnames(multiclass.df), multiclass.target))
+  y = subset(multiclass.df, select = multiclass.target)[[1]]
+  r1 = lapply(caret.learners, checkCaretParams, k = 9, x = x, y = y)
+  r2 = lapply(caret.learners, checkCaretParams, k = 5, x = x, y = y)
+
+  # regression problems
+  x = subset(regr.df, select = setdiff(colnames(regr.df), regr.target))
+  y = subset(regr.df, select = regr.target)[[1]]
+  caret.learners = c("gbm", "rf", "svmPoly", "svmLinear",
+    "rpart", "J48", "stepLDA", "earth")
+  r1 = lapply(caret.learners, checkCaretParams, k = 9, x = x, y = y)
+  r2 = lapply(caret.learners, checkCaretParams, k = 5, x = x, y = y)
+})


### PR DESCRIPTION
After having some problems with PR #403 and #404 this is a clean commit and PR. So this will again address issue #207 by providing a getter that converts caret's tuning grids into mlr/ParamHelpers style.