### PR TITLE
Add hill climbing algorithm to learn the weight to do average in StackedLearner.R

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,7 @@ mlr_2.5:
 - Learner Propoerties are now implemented object oriented as a state of a Learner.
   Only RLearners have the properties stored in a slot.
   For each class the getter can be overwritten.
+- The hill climbing algorithm for stacking (Caruana 04) is implemented as method 'hill.climb' in 'makeStackedLearner' to select models from base learners, which is equivalent to weighted average.
 
 - new functions
 -- getDefaultMeasure

--- a/man/makeStackedLearner.Rd
+++ b/man/makeStackedLearner.Rd
@@ -5,7 +5,8 @@
 \title{Create a stacked learner object.}
 \usage{
 makeStackedLearner(base.learners, super.learner = NULL, predict.type = NULL,
-  method = "stack.nocv", use.feat = FALSE, resampling = NULL)
+  method = "stack.nocv", use.feat = FALSE, resampling = NULL,
+  parset = list())
 }
 \arguments{
 \item{base.learners}{[(list of) \code{\link{Learner}}]\cr
@@ -46,6 +47,16 @@ Default is \code{FALSE}.}
 Resampling strategy for \code{method = 'stack.cv'}.
 Currently only CV is allowed for resampling.
 The default \code{NULL} uses 5-fold CV.}
+
+\item{parset}{the parameters for \code{hill.climb} method, including
+\describe{
+  \item{\code{replace}}{Whether a base learner can be selected more than once.}
+  \item{\code{init}}{Number of best models being included before the selection algorithm.}
+  \item{\code{bagprob}}{The proportion of models being considered in one round of selection.}
+  \item{\code{bagtime}}{The number of rounds of the bagging selection.}
+  \item{\code{metric}}{The result evaluation metric function taking two parameters \code{pred} and \code{true},
+  the smaller the score the better.}
+}}
 }
 \description{
 A stacked learner uses predictions of several base learners and fits
@@ -57,6 +68,29 @@ The following stacking methods are available:
   \item{\code{stack.nocv}}{Fits the super learner, where in-sample predictions of the base learners are used.}
   \item{\code{stack.cv}}{Fits the super learner, where the base learner predictions are computed
   by crossvalidated predictions (the resampling strategy can be set via the \code{resampling} argument).}
+  \item{\code{hill.climb}}{Select a subset of base learner predictions by hill climbing algorithm.}
  }
+}
+\examples{
+require(mlr)
+
+  # Classification
+  data(iris)
+  tsk = makeClassifTask(data = iris, target = "Species")
+  lrns = listLearners(tsk, properties = "prob", create = TRUE)
+  lrns = lapply(lrns, setPredictType, "prob")
+  m = makeStackedLearner(base.learners = lrns[1:5],
+    predict.type = "prob", method = "hill.climb")
+  tmp = train(m, tsk)
+  res = predict(tmp, tsk)
+
+  # Regression
+  data(BostonHousing, package = "mlbench")
+  tsk = makeRegrTask(data = BostonHousing, target = "medv")
+  lrns = listLearners(tsk, create = TRUE)
+  m = makeStackedLearner(base.learners = lrns[c(1, 14, 15, 19, 21, 27, 29, 31)],
+    predict.type = "response", method = "hill.climb")
+  tmp = train(m, tsk)
+  res = predict(tmp, tsk)
 }
 


### PR DESCRIPTION
This is a cleaner version of https://github.com/mlr-org/mlr/pull/418 . 

As stated in https://github.com/mlr-org/mlr/issues/288#issuecomment-124255728, The hill climbing algorithm can be used to learn the weights of the base models.

I have also fix one of the `FIXME` in `StackedLearner.R`: https://github.com/mlr-org/mlr/blob/master/R/StackedLearner.R#L201. Instead of calling `table` in each row, I count the table manually for each class. This speeds up the calculation dramatically as in the following example:

```{r}
oldfun = function(probs) t(apply(probs, 1L, function(x) (table(factor(x, 1:5) )/length(x))))
newfun = function(probs) {
  mat = matrix(0,nrow(probs),5)
  for (i in 1:5) 
    mat[,i] = rowSums(probs==i) 
  mat = mat/ncol(mat)
  return(mat)
}

probs = matrix(sample(1:5,100000,replace = TRUE), 20000,5)

system.time({res1 = oldfun(probs)})
system.time({res2 = newfun(probs)})
sum((res1-res2)^2)
```

The running time is 5 secs versus <0.01 sec, and the difference is zero.