### PR TITLE
Add compress model algorithm in Stackedlearner

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,7 @@ mlr_2.5:
   Only RLearners have the properties stored in a slot.
   For each class the getter can be overwritten.
 - The hill climbing algorithm for stacking (Caruana 04) is implemented as method 'hill.climb' in 'makeStackedLearner' to select models from base learners, which is equivalent to weighted average.
+- The model compression algorithm for stacking (Caruana 06) is implemented as method 'compress' in 'makeStackedLearner' to first select models from base learners and then mimic the behaviour with a super learner. The default super learner is neural network.
 
 - new functions
 -- getDefaultMeasure

--- a/man/makeStackedLearner.Rd
+++ b/man/makeStackedLearner.Rd
@@ -34,9 +34,13 @@ Not used for \code{method = 'average'}. Default is \code{NULL}.}
 
 \item{method}{[\code{character(1)}]\cr
 \dQuote{average} for averaging the predictions of the base learners,
-\dQuote{stack.nocv} for building a super learner using the predictions of the base learners and
+\dQuote{stack.nocv} for building a super learner using the predictions of the base learners,
 \dQuote{stack.cv} for building a super learner using crossvalidated predictions of the base learners.
-Default is \dQuote{stack.nocv}.}
+Default is \dQuote{stack.nocv},
+\dQuote{hill.climb} for averaging the predictions of the base learners, with the weights learned from
+hill climbing algorithm and
+\dQuote{compress} for compressing the model to mimic the predictive of a collection of base learners,
+while speed up the prediction and reduce the size of the model.}
 
 \item{use.feat}{[\code{logical(1)}]\cr
 Whether the original features should also be passed to the super learner.
@@ -56,6 +60,12 @@ The default \code{NULL} uses 5-fold CV.}
   \item{\code{bagtime}}{The number of rounds of the bagging selection.}
   \item{\code{metric}}{The result evaluation metric function taking two parameters \code{pred} and \code{true},
   the smaller the score the better.}
+}
+the parameters for \code{compress} method, including
+\describe{
+   \item{k}{the size multiplier of the generated data}
+   \item{prob}{the probability to exchange values}
+   \item{s}{the standard deviation of each numerical feature}
 }}
 }
 \description{
@@ -69,11 +79,11 @@ The following stacking methods are available:
   \item{\code{stack.cv}}{Fits the super learner, where the base learner predictions are computed
   by crossvalidated predictions (the resampling strategy can be set via the \code{resampling} argument).}
   \item{\code{hill.climb}}{Select a subset of base learner predictions by hill climbing algorithm.}
+  \item{\code{compress}}{Train a neural network to compress the model from a collection of base learners.}
  }
 }
 \examples{
-\dontrun{
-  require(mlr)
+require(mlr)
 
   # Classification
   data(iris)
@@ -91,11 +101,9 @@ The following stacking methods are available:
   tsk = makeRegrTask(data = BostonHousing, target = "medv")
   base = c("regr.rpart", "regr.svm")
   lrns = lapply(base, makeLearner)
-  lrns = listLearners(tsk, create = TRUE)
   m = makeStackedLearner(base.learners = lrns,
-    predict.type = "response", method = "hill.climb")
+    predict.type = "response", method = "compress")
   tmp = train(m, tsk)
   res = predict(tmp, tsk)
-}
 }
 

--- a/tests/testthat/test_stack.R
+++ b/tests/testthat/test_stack.R
@@ -80,3 +80,24 @@ test_that("Parameters for hill climb works", {
 
 })
 
+test_that("Parameters for compress model", {
+  tsk = binaryclass.task
+  base = c("classif.rpart", "classif.lda", "classif.svm")
+  lrns = lapply(base, makeLearner)
+  lrns = lapply(lrns, setPredictType, "prob")
+  m = makeStackedLearner(base.learners = lrns, predict.type = "prob", method = "compress",
+                         parset = list(k = 5, prob = 0.3))
+  tmp = train(m, tsk)
+  res = predict(tmp, tsk)
+  
+  
+  tsk = regr.task
+  base = c("regr.rpart", "regr.svm")
+  lrns = lapply(base, makeLearner)
+  lrns = lapply(lrns, setPredictType, "response")
+  m = makeStackedLearner(base.learners = lrns, predict.type = "response", method = "compress",
+                         parset = list(k = 5, prob = 0.3))
+  tmp = train(m, tsk)
+  res = predict(tmp, tsk)
+})
+


### PR DESCRIPTION
As stated in this thread:https://github.com/mlr-org/mlr/issues/288#issuecomment-125407467, I have  implemented the model compression algorithm as a succeeding algorithm:

1. Run the hill climbing algorithm on a relatively small size of data
2. Generate some psuedo training data and label the data by the ensemble model from the hill climbing algorithm
3. Train a super learner (neural network by default) to mimic the behaviour of the ensemble. The result is this model, thus the size and the prediction efficiency of the model is reduced.

Since it relies on the hill climbing algorithm, I have implemented this algorithm in the same file. To make examples work, I also removed the `listLearners` command. 