### PR TITLE
allow getCaretParamSet to use tasks

### DIFF
--- a/man/getCaretParamSet.Rd
+++ b/man/getCaretParamSet.Rd
@@ -4,7 +4,7 @@
 \alias{getCaretParamSet}
 \title{Get tuning parameters from a learner of the caret R-package.}
 \usage{
-getCaretParamSet(learner, length = 3, x, y, discretize = TRUE)
+getCaretParamSet(learner, length = 3L, task, discretize = TRUE)
 }
 \arguments{
 \item{learner}{[\code{character(1)}]\cr
@@ -18,11 +18,8 @@ generating the grid of tuning parameters. \code{caret} generates either as
 many values per tuning parameter / dimension as defined by \code{length}
 or only a single value (in case of non-tunable \code{par.vals}).}
 
-\item{x}{[\code{data.frame}]\cr
-A data frame with the input data.}
-
-\item{y}{[\code{factor} | \code{numeric}]\cr
-A response vector.}
+\item{task}{[\code{\link{Task}}]\cr
+Learning task, which might be requested for creating the tuning grid.}
 
 \item{discretize}{[\code{logical(1)}]\cr
 Should the numerical parameters be discretized? Alternatively, they will
@@ -47,14 +44,15 @@ discretized into specific values.
 }
 \examples{
 library(caret)
+classifTask = makeClassifTask(data = iris, target = "Species")
 
 # (1) classification (random forest) with discretized parameters
-getCaretParamSet("rf", length = 9L, x = iris[, -5], y = iris[, 5], discretize = TRUE)
+getCaretParamSet("rf", length = 9L, task = classifTask, discretize = TRUE)
 
 # (2) regression (gradient boosting machine) without discretized parameters
 library(mlbench)
 data(BostonHousing)
-getCaretParamSet("gbm", length = 9L, x = BostonHousing[, -14],
-  y = BostonHousing[, 14], discretize = FALSE)
+regrTask = makeRegrTask(data = BostonHousing, target = "medv")
+getCaretParamSet("gbm", length = 9L, task = regrTask, discretize = FALSE)
 }
 

--- a/tests/testthat/test_base_getCaretParamSet.R
+++ b/tests/testthat/test_base_getCaretParamSet.R
@@ -2,13 +2,11 @@ context("getCaretParamSet")
 
 test_that("getCaretParamSet", {
   requirePackages(c("caret", "rpart", "earth"))
-  caret.learners = c("gbm", "rf", "svmPoly", "svmLinear", "svmRadial",
-    "rpart", "J48", "stepLDA", "earth")
-  checkCaretParams = function(lrn, k, x, y) {
+  checkCaretParams = function(lrn, k, task) {
     set.seed(123)
-    a = capture.output({cps1 = getCaretParamSet(lrn, length = k, x = x, y = y, discretize = TRUE)})
+    a = capture.output({cps1 = getCaretParamSet(lrn, length = k, task = task, discretize = TRUE)})
     set.seed(123)
-    b = capture.output({cps2 = getCaretParamSet(lrn, length = k, x = x, y = y, discretize = FALSE)})
+    b = capture.output({cps2 = getCaretParamSet(lrn, length = k, task = task, discretize = FALSE)})
     expect_identical(cps1$par.vals, cps2$par.vals)
     expect_identical(names(cps1$par.set$pars), names(cps2$par.set$pars))
     expect_identical(class(cps1$par.set), "ParamSet")
@@ -17,23 +15,20 @@ test_that("getCaretParamSet", {
       expect_identical(class(cps1$par.vals), "list")
   }
 
+  caret.learners = c("gbm", "rf", "svmPoly", "svmLinear", "svmRadial",
+    "rpart", "J48", "stepLDA", "earth")
+
   # binaryclass problems
-  x = subset(binaryclass.df, select = setdiff(colnames(binaryclass.df), binaryclass.target))
-  y = subset(binaryclass.df, select = binaryclass.target)[[1]]
-  r1 = lapply(caret.learners, checkCaretParams, k = 9, x = x, y = y)
-  r2 = lapply(caret.learners, checkCaretParams, k = 5, x = x, y = y)
+  r1 = lapply(caret.learners, checkCaretParams, k = 9, task = binaryclass.task)
+  r2 = lapply(caret.learners, checkCaretParams, k = 5, task = binaryclass.task)
 
   # multiclass problems
-  x = subset(multiclass.df, select = setdiff(colnames(multiclass.df), multiclass.target))
-  y = subset(multiclass.df, select = multiclass.target)[[1]]
-  r1 = lapply(caret.learners, checkCaretParams, k = 9, x = x, y = y)
-  r2 = lapply(caret.learners, checkCaretParams, k = 5, x = x, y = y)
+  r1 = lapply(caret.learners, checkCaretParams, k = 9, task = multiclass.task)
+  r2 = lapply(caret.learners, checkCaretParams, k = 5, task = multiclass.task)
 
   # regression problems
-  x = subset(regr.df, select = setdiff(colnames(regr.df), regr.target))
-  y = subset(regr.df, select = regr.target)[[1]]
   caret.learners = c("gbm", "rf", "svmPoly", "svmLinear",
     "rpart", "J48", "stepLDA", "earth")
-  r1 = lapply(caret.learners, checkCaretParams, k = 9, x = x, y = y)
-  r2 = lapply(caret.learners, checkCaretParams, k = 5, x = x, y = y)
+  r1 = lapply(caret.learners, checkCaretParams, k = 9, task = regr.task)
+  r2 = lapply(caret.learners, checkCaretParams, k = 5, task = regr.task)
 })


### PR DESCRIPTION
This PR is just a minor fix of `getCaretParamSet`, allowing to use `task` instead of `x` and `y`.