### PR TITLE
make center, fmin, and fmax a named list in generatePartialPredictionData

### DIFF
--- a/man/generatePartialPredictionData.Rd
+++ b/man/generatePartialPredictionData.Rd
@@ -6,10 +6,11 @@
 \usage{
 generatePartialPredictionData(obj, data, features, interaction = FALSE,
   individual = FALSE, center = NULL, fun = mean, resample = "none",
-  fmin = sapply(features, function(x) ifelse(!is.factor(data[[x]]),
-  min(data[[x]], na.rm = TRUE), NA)), fmax = sapply(features, function(x)
-  ifelse(!is.factor(data[[x]]), max(data[[x]], na.rm = TRUE), NA)),
-  gridsize = 10L, ...)
+  fmin = lapply(features, function(x) ifelse(is.ordered(data[[x]]) |
+  is.numeric(data[[x]]), min(data[[x]], na.rm = TRUE), NA)),
+  fmax = lapply(features, function(x) ifelse(is.ordered(data[[x]]) |
+  is.numeric(data[[x]]), max(data[[x]], na.rm = TRUE), NA)), gridsize = 10L,
+  ...)
 }
 \arguments{
 \item{obj}{a \code{\link{WrappedModel}} returned from \code{\link{train}}.}
@@ -35,8 +36,9 @@ partial predictions of all observations in \code{data} across all values of the 
 The algorithm is developed in Goldstein, Kapelner, Bleich, and Pitkin (2015).
 Default is \code{FALSE}.}
 
-\item{center}{\code{numeric}\cr
-The fixed values of the \code{features} used to calculate an individual partial prediction which is then
+\item{center}{\code{list}\cr
+A named list containing the fixed values of the \code{features}
+used to calculate an individual partial prediction which is then
 subtracted from each individual partial prediction made across the prediction grid created for the
 \code{features}: centering the individual partial prediction lines to make them more interpretable.
 This argument is ignored if \code{individual != TRUE}.

--- a/man/makeModelMultiplexerParamSet.Rd
+++ b/man/makeModelMultiplexerParamSet.Rd
@@ -15,7 +15,7 @@ The muliplexer learner.}
 You only need to enter the parameters you want to tune without reference
 to the \code{selected.learner} field in any way.\cr
 (b) Second option. Just the params you would enter in the param sets.
-Even shorterto create. Only works when it can be uniquely identified to which
+Even shorter to create. Only works when it can be uniquely identified to which
 learner each of your passed parameters belongs.}
 
 \item{.check}{[\code{logical}]\cr

--- a/man/makeStackedLearner.Rd
+++ b/man/makeStackedLearner.Rd
@@ -36,11 +36,11 @@ Not used for \code{method = 'average'}. Default is \code{NULL}.}
 \dQuote{average} for averaging the predictions of the base learners,
 \dQuote{stack.nocv} for building a super learner using the predictions of the base learners,
 \dQuote{stack.cv} for building a super learner using crossvalidated predictions of the base learners.
-Default is \dQuote{stack.nocv},
 \dQuote{hill.climb} for averaging the predictions of the base learners, with the weights learned from
 hill climbing algorithm and
 \dQuote{compress} for compressing the model to mimic the predictions of a collection of base learners
-while speeding up the predictions and reducing the size of the model.}
+while speeding up the predictions and reducing the size of the model.
+Default is \dQuote{stack.nocv},}
 
 \item{use.feat}{[\code{logical(1)}]\cr
 Whether the original features should also be passed to the super learner.

--- a/tests/testthat/test_base_generatePartialPrediction.R
+++ b/tests/testthat/test_base_generatePartialPrediction.R
@@ -5,7 +5,8 @@ test_that("generatePartialPredictionData", {
 
   fr = train("regr.rpart", regr.task)
   dr = generatePartialPredictionData(fr, getTaskData(regr.task), c("lstat", "chas"), TRUE,
-                                     fmin = c(1, NA), fmax = c(40, NA), gridsize = gridsize)
+                                     fmin = list("lstat" = 1, "chas" = NA),
+                                     fmax = list("lstat" = 40, "chas" = NA), gridsize = gridsize)
   nfeat = length(dr$features)
   nfacet = length(unique(getTaskData(regr.task)[["chas"]]))
   n = getTaskSize(regr.task)
@@ -23,7 +24,8 @@ test_that("generatePartialPredictionData", {
   ## plotPartialPredictionGGVIS(dr, interact = "chas")
 
   dr = generatePartialPredictionData(fr, getTaskData(regr.task), c("lstat", "chas"), TRUE, TRUE,
-                                     fmin = c(1, NA), fmax = c(40, NA), gridsize = gridsize)
+                                     fmin = list("lstat" = 1, "chas" = NA),
+                                     fmax = list("lstat" = 40, "chas" = NA), gridsize = gridsize)
   expect_that(max(dr$data$lstat), equals(40.))
   expect_that(min(dr$data$lstat), equals(1.))
   expect_that(nrow(dr$data), equals(gridsize * nfeat * n))


### PR DESCRIPTION
use a named list instead of a vector to avoid errors due to features that are not numeric