### PR TITLE
parallelmap drops lists of length 1

### DIFF
--- a/R/generatePartialPrediction.R
+++ b/R/generatePartialPrediction.R
@@ -172,10 +172,9 @@ generatePartialPredictionData = function(obj, data, features, interaction = FALS
   } else {
     args = list(obj = obj, data = data, fun = fun, td = td, rng = rng, features = features, ...)
     out = parallelMap::parallelMap(doPartialPredictionIteration, seq_len(nrow(rng)), more.args = args)
-    if (!is.null(center) & individual) {
-      centerpred = doPartialPredictionIteration(obj, data, center, features, fun, td, 1)
-      centerpred = as.data.frame(do.call("rbind", centerpred))
-    } else
+    if (!is.null(center) & individual)
+      centerpred = as.data.frame(doPartialPredictionIteration(obj, data, center, features, fun, td, 1))
+    else
       centerpred = NULL
     if (!individual)
       out = doAggregatePartialPrediction(out, td, target, features, test, rng)

--- a/tests/testthat/test_base_generatePartialPrediction.R
+++ b/tests/testthat/test_base_generatePartialPrediction.R
@@ -23,6 +23,10 @@ test_that("generatePartialPredictionData", {
   expect_that(length(XML::getNodeSet(doc, black.xpath, "svg")), equals(nfacet * gridsize))
   ## plotPartialPredictionGGVIS(dr, interact = "chas")
 
+  ## parallelMap drops lists of length 1 to the type of the element
+  dr.1 = generatePartialPredictionData(fr, getTaskData(regr.task), "lstat", fmin = list("lstat" = 1),
+                                       fmax = list("lstat" = 40), gridsize = gridsize)
+
   dr = generatePartialPredictionData(fr, getTaskData(regr.task), c("lstat", "chas"), TRUE, TRUE,
                                      fmin = list("lstat" = 1, "chas" = NA),
                                      fmax = list("lstat" = 40, "chas" = NA), gridsize = gridsize)


### PR DESCRIPTION
 - don't call rbind on result of one call to
   doPartialPredictionIteration
 - adds tests for bug