### PR TITLE
remove filter from partial predictions

### DIFF
--- a/man/generatePartialPredictionData.Rd
+++ b/man/generatePartialPredictionData.Rd
@@ -4,37 +4,20 @@
 \alias{generatePartialPredictionData}
 \title{Generate partial predictions}
 \usage{
-generatePartialPredictionData(obj, task, data, features, n,
-  method = "rf.importance", interaction = FALSE, individual = FALSE,
-  center = NULL, fun = mean, resample = "none", fmin, fmax,
-  gridsize = 10L, ...)
+generatePartialPredictionData(obj, input, features, interaction = FALSE,
+  individual = FALSE, center = NULL, fun = mean, resample = "none",
+  fmin, fmax, gridsize = 10L, ...)
 }
 \arguments{
 \item{obj}{[\code{\link{WrappedModel}}]\cr
 Result of \code{\link{train}}.}
 
-\item{task}{[\code{\link{Task}}]\cr
-The task. If this is passed, data from this task is predicted.}
-
-\item{data}{[\code{data.frame}]\cr
-Data to be used to compute partial predictions.
-Pass this alternatively instead of \code{task}.}
+\item{input}{[\code{data.frame} | \code{\link{Task}}]\cr
+Input data.}
 
 \item{features}{[\code{character}]\cr
 A vector of feature names contained in the training data.
-If not specified the features will be extracted from the \code{task}.
-If \code{n} is unspecified, half of the available features will be used, with the
-most important features (according to \code{\link{generateFilterValuesData}}) being selected first.}
-
-\item{n}{[\code{integer(1)}]\cr
-The number of features to select if \code{features} is not specified. The features are selected in
-order of their importance as calculated by \code{\link{generateFilterValuesData}} using the filter
-specified by \code{method}.}
-
-\item{method}{[\code{character(1)}]\cr
-The filter method to use. Ignored if \code{features} specified.
-See \code{\link{listFilterMethods}}.
-Default is \dQuote{rf.importance}}
+If not specified all features in the \code{input} will be used.}
 
 \item{interaction}{[\code{logical(1)}]\cr
 Whether the \code{features} should be interacted or not. If \code{TRUE} then the Cartesian product of the
@@ -116,12 +99,12 @@ estimating E_(x_c)(f(x_s, x_c)). The conditional expectation of f at observation
 \examples{
 lrn = makeLearner("regr.rpart")
 fit = train(lrn, bh.task)
-pd = generatePartialPredictionData(fit, task = bh.task, features = "lstat")
+pd = generatePartialPredictionData(fit, bh.task, "lstat")
 plotPartialPrediction(pd)
 
 lrn = makeLearner("classif.rpart", predict.type = "prob")
 fit = train(lrn, iris.task)
-pd = generatePartialPredictionData(fit, task = iris.task, features = "Petal.Width")
+pd = generatePartialPredictionData(fit, iris.task, "Petal.Width")
 plotPartialPrediction(pd)
 }
 \references{

--- a/tests/testthat/test_base_generatePartialPrediction.R
+++ b/tests/testthat/test_base_generatePartialPrediction.R
@@ -4,7 +4,7 @@ test_that("generatePartialPredictionData", {
   gridsize = 3L
 
   fr = train("regr.rpart", regr.task)
-  dr = generatePartialPredictionData(fr, task = regr.task, features = c("lstat", "chas"),
+  dr = generatePartialPredictionData(fr, input = regr.task, features = c("lstat", "chas"),
                                      interaction = TRUE, fmin = list("lstat" = 1, "chas" = NA),
                                      fmax = list("lstat" = 40, "chas" = NA), gridsize = gridsize)
   nfeat = length(dr$features)
@@ -23,15 +23,11 @@ test_that("generatePartialPredictionData", {
   expect_that(length(XML::getNodeSet(doc, black.xpath, "svg")), equals(nfacet * gridsize))
   ## plotPartialPredictionGGVIS(dr, interact = "chas")
 
-  ## test that automatic feature selection works
-  dr.fs = generatePartialPredictionData(fr, task = regr.task, n = 2L, gridsize = gridsize)
-  expect_that(nrow(dr.fs$data), equals(gridsize * 2L))
-
-  dr.1 = generatePartialPredictionData(fr, task = regr.task, features = "lstat",
+  dr.1 = generatePartialPredictionData(fr, input = regr.task, features = "lstat",
                                        fmin = list("lstat" = 1),
                                        fmax = list("lstat" = 40), gridsize = gridsize)
 
-  dr = generatePartialPredictionData(fr, task = regr.task, features = c("lstat", "chas"),
+  dr = generatePartialPredictionData(fr, input = regr.task, features = c("lstat", "chas"),
                                      interaction = TRUE, individual = TRUE,
                                      fmin = list("lstat" = 1, "chas" = NA),
                                      fmax = list("lstat" = 40, "chas" = NA), gridsize = gridsize)
@@ -47,7 +43,7 @@ test_that("generatePartialPredictionData", {
   ## plotPartialPredictionGGVIS(dr, interact = "chas")
 
   fc = train("classif.rpart", multiclass.task)
-  dc = generatePartialPredictionData(fc, task = multiclass.task, features = c("Petal.Width", "Petal.Length"),
+  dc = generatePartialPredictionData(fc, input = multiclass.task, features = c("Petal.Width", "Petal.Length"),
                                      fun = function(x) table(x) / length(x), gridsize = gridsize)
   nfeat = length(dc$features)
   n = getTaskSize(multiclass.task)
@@ -62,9 +58,9 @@ test_that("generatePartialPredictionData", {
   ## plotPartialPredictionGGVIS(dc) ##FIXME
 
   fcp = train(makeLearner("classif.rpart", predict.type = "prob"), multiclass.task)
-  expect_error(generatePartialPrediction(fcp, task = multiclass.task, features = "Petal.Width",
+  expect_error(generatePartialPrediction(fcp, input = multiclass.task, features = "Petal.Width",
                                          fun = function(x) quantile(x, c(.025, .5, .975))), gridsize = gridsize)
-  dcp = generatePartialPredictionData(fcp, task = multiclass.task, features = c("Petal.Width", "Petal.Length"),
+  dcp = generatePartialPredictionData(fcp, input = multiclass.task, features = c("Petal.Width", "Petal.Length"),
                                       interaction = TRUE, gridsize = gridsize)
   nfacet = length(unique(dcp$data$Petal.Length))
   ntarget = length(dcp$target)
@@ -77,13 +73,13 @@ test_that("generatePartialPredictionData", {
   expect_that(length(XML::getNodeSet(doc, green.xpath, "svg")) - 1, equals(ntarget * nfacet))
   ## plotPartialPredictionGGVIS(dcp, interact = "Petal.Length")
 
-  dcp = generatePartialPredictionData(fcp, task = multiclass.task, features = c("Petal.Width", "Petal.Length"),
+  dcp = generatePartialPredictionData(fcp, input = multiclass.task, features = c("Petal.Width", "Petal.Length"),
                                       interaction = TRUE, individual = TRUE, gridsize = gridsize)
   plotPartialPrediction(dcp, facet = "Petal.Length")
   ## plotPartialPredictionGGVIS(dcp, interact = "Petal.Length")
 
   fs = train("surv.coxph", surv.task)
-  ds = generatePartialPredictionData(fs, task = surv.task, features = c("Petal.Width", "Petal.Length"),
+  ds = generatePartialPredictionData(fs, input = surv.task, features = c("Petal.Width", "Petal.Length"),
                                      gridsize = gridsize)
   nfeat = length(ds$features)
   n = getTaskSize(surv.task)
@@ -94,7 +90,7 @@ test_that("generatePartialPredictionData", {
   expect_that(length(XML::getNodeSet(doc, black.xpath, "svg")), equals(gridsize * nfeat))
   ## plotPartialPredictionGGVIS(ds)
 
-  db = generatePartialPredictionData(fr, task = regr.task, features = c("lstat", "chas"),
+  db = generatePartialPredictionData(fr, input = regr.task, features = c("lstat", "chas"),
                                      interaction = TRUE,
                                      fun = function(x) quantile(x, c(.25, .5, .75)), gridsize = gridsize)
   nfacet = length(unique(getTaskData(regr.task)[["chas"]]))
@@ -107,7 +103,7 @@ test_that("generatePartialPredictionData", {
   expect_that(length(XML::getNodeSet(doc, black.xpath, "svg")), equals(nfacet * gridsize))
   ## plotPartialPredictionGGVIS(db, interact = "chas")
 
-  db2 = generatePartialPredictionData(fr, task = regr.task, features = c("lstat", "crim"),
+  db2 = generatePartialPredictionData(fr, input = regr.task, features = c("lstat", "crim"),
                                       fun = function(x) quantile(x, c(.25, .5, .75)), gridsize = gridsize)
   nfeat = length(db2$features)
   n = getTaskSize(regr.task)
@@ -119,7 +115,7 @@ test_that("generatePartialPredictionData", {
   ## plotPartialPredictionGGVIS(db2)
 
   fcpb = train(makeLearner("classif.rpart", predict.type = "prob"), binaryclass.task)
-  bc = generatePartialPredictionData(fcpb, task = binaryclass.task, features = c("V11", "V12"),
+  bc = generatePartialPredictionData(fcpb, input = binaryclass.task, features = c("V11", "V12"),
                                      individual = TRUE, gridsize = gridsize)
   nfeat = length(bc$features)
   n = getTaskSize(binaryclass.task)


### PR DESCRIPTION
 - simply generatePartialPredictionData by combining task and data
   arguments and removing filter and filter arguments

results of talking to @berndbischl about this. should close #456. plotting the most important features only will be shown in the tutorial. 



