### PR TITLE
add functions to merge BenchmarkResult - need this for OpenML soon

### DIFF
--- a/R/benchmarkResult_mergers.R
+++ b/R/benchmarkResult_mergers.R
@@ -1,8 +1,8 @@
-#' @title Merge BenchmarkResult objects with respect to their learners
-#' @description Combines the BenchmarkResult objects that were performed with different learners
-#'   on the same set of Task(s). 
-#'   This can be helpful if you forgot to run one learner on the set of tasks you used.
-#' @param ... [\code{BenchmarkResult}] \cr 
+#' @title Merge different learners of BenchmarkResult objects
+#' @description Combines the \code{\link{BenchmarkResult}} objects that were performed 
+#'   with different learners on the same set of Task(s). 
+#'   This can be helpful if you, e.g. forgot to run one learner on the set of tasks you used.
+#' @param ... [\code{\link{BenchmarkResult}}] \cr 
 #'   \code{BenchmarkResult} objects that should be merged
 #' @export
 mergeBenchmarkResultLearner = function(...) {
@@ -25,11 +25,11 @@ mergeBenchmarkResultLearner = function(...) {
   Reduce(function(...) mergeLearner(...), list(...))
 }
 
-#' @title Merge BenchmarkResult objects with respect to their tasks
-#' @description Combines the BenchmarkResult objects that were performed on different tasks
-#'   with the same set of learner(s). 
-#'   This can be helpful if you forgot to run the set of learners on one (or more) other Tasks.
-#' @param ... [\code{BenchmarkResult}] \cr 
+#' @title Merge different tasks of BenchmarkResult objects
+#' @description Combines the \code{\link{BenchmarkResult}} objects that were performed
+#'   on different tasks with the same set of learner(s). 
+#'   This can be helpful if you, e.g. forgot to run the set of learners on a new task
+#' @param ... [\code{\link{BenchmarkResult}}] \cr 
 #'   \code{BenchmarkResult} objects that should be merged
 #' @export
 mergeBenchmarkResultTask = function(...) {


### PR DESCRIPTION
This two functions are the basis to merge two BenchmarkResult. Since a BenchmarkResult needs all learner-task combinations, there are two simple usecases:

1) In my experiments I forgot to train a learner on all my task -> use `mergeBenchmarkResultLearner`
2) In my experiments I forgot to train all my learners on a task -> use `mergeBenchmarkResultTask`

If you are really forgetful and forgot both, a learner and a task, then, well, then you have to write your own function that might be based on my two functions...
I would need this two functions for `OpenML` as soon as possible.