### PR TITLE
work on randomForest se estimators

### DIFF
--- a/R/RLearner_regr_randomForest.R
+++ b/R/RLearner_regr_randomForest.R
@@ -54,7 +54,7 @@ trainLearner.regr.randomForest = function(.learner, .task, .subset, .weights = N
 
       # fit models on the bootstrap samples
       models = apply(samplesIdx, 2, function(bootstrapIdx) {
-        randomForest::randomForest(f, data = train[bootstrapIdx,, drop = FALSE],...)
+        randomForest::randomForest(f, data = train[bootstrapIdx,, drop = FALSE], ntree = ntree, ...)
       })
 
       # save models in attrribute

--- a/R/RLearner_regr_randomForest.R
+++ b/R/RLearner_regr_randomForest.R
@@ -90,8 +90,8 @@ bootstrapStandardError = function(.learner, .model, .newdata, ...) {
 
     models = attr(.model$learner.model, "mlr.se.bootstrap.models")
     B = length(models)
-    R = par.vals$ntree
-    M = if(is.null(par.vals$ntree.for.se)) par.vals$ntree else par.vals$ntree.for.se
+    M = par.vals$ntree
+    R = if(is.null(par.vals$ntree.for.se)) M else par.vals$ntree.for.se
 
     # make predictions for newdata based on each "bootstrap model"
     preds = lapply(models, function(model) {


### PR DESCRIPTION
Maybe we can think of a more general way to handle ensemble learners in general than a special implementation for the randomForest.
However this code seems very unreviewed which is dangerous as it is a crucial part of mlrMBO.
I would like @mllg to join me on reviewing this code based on [Standard errors for bagged and random forest estimators, Sexton and Laake, 2009](http://dl.acm.org/citation.cfm?id=1465325).