### PR TITLE
default nodesize for regr.randomForest is 5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,7 @@ mlr_2.5:
   For the new ones, see below.
 - Added some commonly used ResampleDesc description objects, to save typing in resample experiments:
   hout, cv2, cv3, cv5, cv10.
+- regr.randomForest: changed default nodesize to 5 (according to randomForest defaults)
 
 - new functions
 -- getDefaultMeasure

--- a/R/RLearner_regr_randomForest.R
+++ b/R/RLearner_regr_randomForest.R
@@ -13,7 +13,7 @@ makeRLearner.regr.randomForest = function() {
       makeIntegerLearnerParam(id = "mtry", lower = 1L),
       makeLogicalLearnerParam(id = "replace", default = TRUE),
       makeIntegerLearnerParam(id = "sampsize", lower = 1L),
-      makeIntegerLearnerParam(id = "nodesize", default = 1L, lower = 1L),
+      makeIntegerLearnerParam(id = "nodesize", default = 5L, lower = 1L),
       makeIntegerLearnerParam(id = "maxnodes", lower = 1L),
       makeLogicalLearnerParam(id = "importance", default = FALSE),
       makeLogicalLearnerParam(id = "localImp", default = FALSE),


### PR DESCRIPTION
Quote from the RF Help
> Minimum size of terminal nodes. Setting this number larger causes smaller trees to be grown (and thus take less time). Note that the default values are different for classification (1) and regression (5).