### PR TITLE
allow to override all parameters for cforest (fixes #556)

### DIFF
--- a/R/RLearner_classif_cforest.R
+++ b/R/RLearner_classif_cforest.R
@@ -40,7 +40,13 @@ trainLearner.classif.cforest = function(.learner, .task, .subset,
   nresample, maxsurrogate, maxdepth, savesplitstats, ...) {
   f = getTaskFormula(.task)
   d = getTaskData(.task, .subset)
-  ctrl = learnerArgsToControl(party::cforest_unbiased, ntree, mtry, replace,
+  defaults = getDefaults(getParamSet(.learner))
+  if (missing(teststat)) teststat = defaults$teststat
+  if (missing(testtype)) testtype = defaults$testtype
+  if (missing(mincriterion)) mincriterion = defaults$mincriterion
+  if (missing(replace)) replace = defaults$replace
+  if (missing(fraction)) fraction = defaults$fraction
+  ctrl = learnerArgsToControl(party::cforest_control, ntree, mtry, replace,
     fraction, trace, pvalue, teststat, testtype, mincriterion, minprob,
     minsplit, minbucket, stump, randomsplits, nresample, maxsurrogate,
     maxdepth, savesplitstats)

--- a/R/RLearner_regr_cforest.R
+++ b/R/RLearner_regr_cforest.R
@@ -42,7 +42,13 @@ trainLearner.regr.cforest = function(.learner, .task, .subset, .weights = NULL,
                                      savesplitstats,...) {
   f = getTaskFormula(.task)
   d = getTaskData(.task, .subset)
-  ctrl = learnerArgsToControl(party::cforest_unbiased, ntree, mtry, replace, fraction,
+  defaults = getDefaults(getParamSet(.learner))
+  if (missing(teststat)) teststat = defaults$teststat
+  if (missing(testtype)) testtype = defaults$testtype
+  if (missing(mincriterion)) mincriterion = defaults$mincriterion
+  if (missing(replace)) replace = defaults$replace
+  if (missing(fraction)) fraction = defaults$fraction
+  ctrl = learnerArgsToControl(party::cforest_control, ntree, mtry, replace, fraction,
                               trace, pvalue, teststat, testtype, mincriterion,
                               minprob, minsplit, minbucket, stump, randomsplits,
                               nresample, maxsurrogate, maxdepth, savesplitstats)

--- a/R/RLearner_surv_cforest.R
+++ b/R/RLearner_surv_cforest.R
@@ -39,7 +39,13 @@ trainLearner.surv.cforest = function(.learner, .task, .subset,
   nresample, maxsurrogate, maxdepth, savesplitstats, ...) {
   f = getTaskFormula(.task)
   d = getTaskData(.task, .subset)
-  ctrl = learnerArgsToControl(party::cforest_unbiased, ntree, mtry, replace,
+  defaults = getDefaults(getParamSet(.learner))
+  if (missing(teststat)) teststat = defaults$teststat
+  if (missing(testtype)) testtype = defaults$testtype
+  if (missing(mincriterion)) mincriterion = defaults$mincriterion
+  if (missing(replace)) replace = defaults$replace
+  if (missing(fraction)) fraction = defaults$fraction
+  ctrl = learnerArgsToControl(party::cforest_control, ntree, mtry, replace,
     fraction, trace, pvalue, teststat, testtype, mincriterion, minprob,
     minsplit, minbucket, stump, randomsplits, nresample, maxsurrogate,
     maxdepth, savesplitstats)

--- a/tests/testthat/test_classif_cforest.R
+++ b/tests/testthat/test_classif_cforest.R
@@ -29,6 +29,13 @@ test_that("classif_cforest", {
 
   testSimpleParsets("classif.cforest", binaryclass.df, binaryclass.target, binaryclass.train.inds,
     old.predicts.list, parset.list2)
-  testProbParsets ("classif.cforest", binaryclass.df, binaryclass.target, binaryclass.train.inds,
+  testProbParsets("classif.cforest", binaryclass.df, binaryclass.target, binaryclass.train.inds,
     old.probs.list, parset.list2)
+
+  # issue 556
+  parset.list3 = list(
+    list(replace = FALSE)
+  )
+  testSimpleParsets("classif.cforest", binaryclass.df, binaryclass.target, binaryclass.train.inds,
+    old.predicts.list, parset.list3)
 })

--- a/tests/testthat/test_regr_cforest.R
+++ b/tests/testthat/test_regr_cforest.R
@@ -26,4 +26,10 @@ test_that("regr_cforest", {
   }
 
   testSimpleParsets("regr.cforest", regr.df, regr.target, regr.train.inds, old.predicts.list, parset.list2)
+
+  # issue 556
+  parset.list3 = list(
+    list(replace = FALSE)
+  )
+  testSimpleParsets("regr.cforest", regr.df, regr.target, regr.train.inds, old.predicts.list, parset.list3)
 })

--- a/tests/testthat/test_surv_cforest.R
+++ b/tests/testthat/test_surv_cforest.R
@@ -26,4 +26,11 @@ test_that("surv_cforest", {
 
   testSimpleParsets("surv.cforest", surv.df, surv.target, surv.train.inds,
     old.predicts.list, parset.list2)
+
+  # issue 556
+  parset.list3 = list(
+    list(replace = FALSE)
+  )
+  testSimpleParsets("surv.cforest", surv.df, surv.target, surv.train.inds,
+    old.predicts.list, parset.list3)
 })


### PR DESCRIPTION
The code to set defaults is a bit ugly -- I guess what we really need is a function that merges parameter sets, or replaces missing things in parameter sets. I didn't see anything that does it in ParamHelpers, but I could be mistaken.