### PR TITLE
fix: iter for CV must be at least 2 to prevent nonesense

### DIFF
--- a/R/ResampleDesc.R
+++ b/R/ResampleDesc.R
@@ -123,7 +123,7 @@ makeResampleDescHoldout = function(iters, split = 2/3) {
 }
 
 makeResampleDescCV = function(iters = 10L) {
-  iters = asCount(iters, positive = TRUE)
+  iters = asInt(iters, lower = 2L)
   makeResampleDescInternal("cross-validation", iters = iters)
 }
 


### PR DESCRIPTION
Because:
```r
> ri = makeResampleInstance(makeResampleDesc("CV", iter = 1), task = iris.task)
> ri$train.inds
[[1]]
integer(0)
```