### PR TITLE
fix memory leaks for benchmark()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+mlr_2.7:
+- New argument "models" for function benchmark
+- fixed a bug where 'keep.pred' was ignored in the benchmark function
+
 mlr_2.6:
 - cluster.kmeans: added support for fuzzy clustering (property "prob")
 - regr.lm: removed some erroneous param settings

--- a/man/benchmark.Rd
+++ b/man/benchmark.Rd
@@ -5,7 +5,7 @@
 \title{Benchmark experiment for multiple learners and tasks.}
 \usage{
 benchmark(learners, tasks, resamplings, measures, keep.pred = TRUE,
-  show.info = getMlrOption("show.info"))
+  models = TRUE, show.info = getMlrOption("show.info"))
 }
 \arguments{
 \item{learners}{[(list of) \code{\link{Learner}}]\cr
@@ -28,6 +28,10 @@ Keep the prediction data in the \code{pred} slot of the result object.
 If you do many experiments (on larger data sets) these objects might unnecessarily increase
 object size / mem usage, if you do not really need them.
 In this case you can this argument to \code{FALSE}.
+Default is \code{TRUE}.}
+
+\item{models}{[\code{logical(1)}]\cr
+Should all fitted models be returned?
 Default is \code{TRUE}.}
 
 \item{show.info}{[\code{logical(1)}]\cr


### PR DESCRIPTION
I ran into a problem where I could not perform a very basic benchmark study of different SVMs w/o mlr eating >30GB of memory. This should fix it:

* `keep.preds` is now correctly passed down to `resample()`
* Added argument `models` to `benchmark()`, also passed down to `resample()`
* Some minor cleanups and simplifications in `benchmark()`