### PR TITLE
fix bug in irace with unnamed discrete values, fixes #627

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Depends:
     R (>= 3.0.2),
     BBmisc (>= 1.9),
     ggplot2,
-    ParamHelpers (>= 1.6),
+    ParamHelpers (>= 1.7),
     stats
 Imports:
     checkmate (>= 1.6.2),

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ mlr_new:
 - Fixed a bug where the resampling objects hout, cv2, cv3, cv5, cv10 were not documented
   in the ResampleDesc help page
 - regr.xgboost, classif.xgboost: add feval param
+- fixed a bug in irace tuning interface with unamed discrete values
 
 - API changes
 -- listLearners now returns a data frame with properties of the learners if

--- a/R/convertX.R
+++ b/R/convertX.R
@@ -21,15 +21,6 @@ convertXMatrixCols = function(xs, par.set) {
   })
 }
 
-# convert logical param values from chars to true logicals, eg irace produces strings in tuning
-convertXLogicalsNotAsStrings = function(x, par.set) {
-  types = getParamTypes(par.set, use.names = TRUE)
-  j = types %in% c("logical", "logicalvector")
-  if (any(j))
-    x[j] = lapply(x[j], as.logical)
-  return(x)
-}
-
 roundIntegers = function(x, par.set) {
   Map(function(par, v) {
     if (par$type %in% c("integer", "integervector"))

--- a/R/tuneIrace.R
+++ b/R/tuneIrace.R
@@ -1,12 +1,21 @@
 tuneIrace = function(learner, task, resampling, measures, par.set, control, opt.path, show.info) {
   requirePackages("irace", why = "tuneIrace", default.method = "load")
-
-  cx = function(x) convertXLogicalsNotAsStrings(x, par.set)
   hookRun = function(experiment, config = list()) {
     rin = experiment$instance
-    tunerFitnFun(as.list(experiment$candidate), learner = learner, task = task, resampling = rin, measures = measures,
+    plen = getParamNr(par.set, devectorize = TRUE)
+    x = experiment$candidate
+    # FIXME: this is a bug in irace, where for 1 param only a scalar is returned
+    # BB reported this already, maybe we can remove this later
+    if (plen == 1L)
+      x = makeDataFrame(1L, 1L, init = x, col.names = getParamIds(par.set))
+
+    # now convert to list, we also need to convert col types, irace sometimes uses not what we need
+    # - logicals are stored as as strings
+    x = dfRowToList(x, par.set, 1L, enforce.col.types = TRUE)
+
+    tunerFitnFun(x, learner = learner, task = task, resampling = rin, measures = measures,
       par.set = par.set, ctrl = control, opt.path = opt.path, show.info = show.info,
-      convertx = cx, remove.nas = TRUE)
+      convertx = identity, remove.nas = TRUE)
   }
 
   n.instances = control$extra.args$n.instances

--- a/tests/testthat/test_tune_tuneIrace.R
+++ b/tests/testthat/test_tune_tuneIrace.R
@@ -91,7 +91,7 @@ test_that("tuneIrace uses digits", {
   lrn.tune = makeTuneWrapper("classif.gbm", resampling = rdesc, par.set = ps,
     control = ctrl, show.info = FALSE)
   res = resample(lrn.tune, task = multiclass.task, rdesc)
-  
+
   lrn = makeLearner("classif.rpart")
   ctrl = makeTuneControlIrace(maxExperiments = 30L, nbIterations = 1L,
     digits = 5L)
@@ -99,19 +99,19 @@ test_that("tuneIrace uses digits", {
   lrn.tune = makeTuneWrapper(lrn, resampling = rdesc, par.set = ps,
     control = ctrl, show.info = FALSE)
   res = resample(lrn.tune, task = multiclass.task, rdesc)
-  
+
   ctrl = makeTuneControlIrace(maxExperiments = 60L, digits = 4L)
   ps = makeParamSet(makeNumericParam("cp", lower = 1e-5, upper = 1e-4))
   lrn.tune = makeTuneWrapper(lrn, resampling = rdesc, par.set = ps,
     control = ctrl, show.info = FALSE)
   expect_error(suppressAll(resample(lrn.tune, task = multiclass.task, rdesc)))
-  
+
   ctrl = makeTuneControlIrace(maxExperiments = 60L, digits = "a")
   ps = makeParamSet(makeNumericParam("cp", lower = 1e-5, upper = 1e-4))
   lrn.tune = makeTuneWrapper(lrn, resampling = rdesc, par.set = ps,
     control = ctrl, show.info = FALSE)
   expect_error(suppressAll(resample(lrn.tune, task = multiclass.task, rdesc)))
-  
+
   ctrl = makeTuneControlIrace(maxExperiments = 60L, digits = c(6L, 7L))
   ps = makeParamSet(makeNumericParam("cp", lower = 1e-5, upper = 1e-4))
   lrn.tune = makeTuneWrapper(lrn, resampling = rdesc, par.set = ps,
@@ -142,3 +142,14 @@ test_that("Error in hyperparameter tuning with scientific notation for lower/upp
   set.seed(123)
   res = resample(lrn.tune, task = sonar.task, rdesc)
 })
+
+# we had a bug here, see issue #627
+test_that("irace works with unnamed discrete values", {
+  lrn = makeLearner("classif.rpart")
+  ctrl = makeTuneControlIrace(maxExperiments = 30L, nbIterations = 1L)
+  ps = makeParamSet(
+    makeDiscreteParam("minsplit", c(2L, 7L))
+  )
+  res = tuneParams(lrn, multiclass.task, hout, par.set = ps, control = ctrl)
+})
+


### PR DESCRIPTION
I did the following:

- I improved the conversion code for irace. 
- I added a new option in ParamHelpers so, we now rely on version 1.7 for this
- I removed a convertX function, which was only there for irace and is not needed now
