### PR TITLE
fix bug in ModelMultiplexer predict, where hyperpars were not passed on

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@ mlr_new:
 - fixed a bug in irace tuning interface with unamed discrete values
 - Fixed bugs in "jackknife" and "bootstrap" se estimators for regr.randomForest.
 - Added "sd" estimator for regr.randomForest.
+- Fixed a mini bug in ModelMultiplexer where hyperpars that are only need in
+  predict were not passed down correctly
 
 - API changes
 -- listLearners now returns a data frame with properties of the learners if

--- a/R/ModelMultiplexer.R
+++ b/R/ModelMultiplexer.R
@@ -99,7 +99,10 @@ predictLearner.ModelMultiplexer = function(.learner, .model, .newdata, ...) {
   # simply predict with the model
   sl = .learner$par.vals$selected.learner
   bl = .learner$base.learners[[sl]]
-  predictLearner(bl, .model$learner.model$next.model, .newdata)
+  # we need to pass the changed setting of the base learner for the predict function further down
+  args = list(.learner = bl, .model = .model$learner.model$next.model, .newdata = .newdata)
+  args = c(args, getHyperPars(bl, for.fun = "predict"))
+  do.call(predictLearner, args)
 }
 
 #' @export

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -115,3 +115,15 @@ test_that("ModelMultiplexer inherits predict.type from base learners", {
   ctrl = makeTuneControlGrid(tune.threshold = TRUE)
   res = tuneParams(learner, binaryclass.task, resampling = rdesc, par.set = ps, control = ctrl)
 })
+
+# we had bug here, see issue #647
+test_that("ModelMultiplexer passes on hyper pars in predict", {
+  base.learners = list(
+    makeLearner("regr.glmnet"),
+    makeLearner("regr.rpart")
+  )
+  learner = makeModelMultiplexer(base.learners)
+  expect_equal(learner$predict.type, "response")
+  r = holdout(learner, regr.task)
+})
+


### PR DESCRIPTION
Fixes issue #647 

Please review
