### PR TITLE
various doc fixes

### DIFF
--- a/R/Aggregation.R
+++ b/R/Aggregation.R
@@ -2,7 +2,7 @@
 #' @description
 #' An aggregation method reduces the performance values of the test
 #' (and possibly the training sets) to a single value.
-#' To see all possible, implemented aggregations look at \code{\link{aggregations}}.
+#' To see all possible implemented aggregations look at \code{\link{aggregations}}.
 #'
 #' The aggregation can access all relevant information of the result after resampling
 #' and combine them into a single value. Though usually something very simple
@@ -10,7 +10,8 @@
 #'
 #' Object members:
 #' \describe{
-#' \item{id [\code{character(1)}]}{Name of aggregation method.}
+#' \item{id [\code{character(1)}]}{Name of the aggregation method.}
+#' \item{name [\code{character(1)}]}{Long name of the aggregation method.}
 #' \item{fun [\code{function(task, perf.test, perf.train, measure, group, pred)}]}{Aggregation function.}
 #' }
 #' @name Aggregation
@@ -19,29 +20,35 @@
 NULL
 
 
-#' @title Specifiy your own aggregation of measures
+#' @title Specify your own aggregation of measures.
 #'
 #' @description
-#' This is an adavanced feature of mlr. It gives access to some
-#' inner workings so the result might not be compatible with everything! \cr
-#'
+#' This is an advanced feature of mlr. It gives access to some
+#' inner workings so the result might not be compatible with everything!
 #'
 #' @param id [\code{character(1)}]\cr
 #'   Name of the aggregation method (preferably the same name as the generated function).
 #' @param name [\code{character(1)}]\cr
 #'   Long name of the aggregation method. Default is \code{id}.
-#' @param fun [\code{function}]\cr
-#'   A function with following signature: \code{function(task, perf.test, perf.train, measure, group, pred)}
-#'   \itemize{
-#'    \item{\bold{task}}: task (\code{\link{Task}}) object
-#'    \item{\bold{perf.test}}: numerical vector of \link{performance} results on the test data set
-#'    \item{\bold{perf.train}}. numerical vector of \link{performance} results on the train data set
-#'    \item{\bold{measure}}: \code{\link{Measure}} object.
-#'    \item{\bold{group}}: grouping vector
-#'    \item{\bold{pred}}: \code{\link{Prediction}} object
+#' @param fun [\code{function(task, perf.test, perf.train, measure, group, pred)}]\cr
+#'   Calculates the aggregated performance. In most cases you will only need the performances
+#'   \code{perf.test} and optionally \code{perf.train} on the test and training data sets.
+#'   \describe{
+#'     \item{\code{task} [\code{\link{Task}}]}{The task.}
+#'     \item{\code{perf.test} [\code{numeric}]}{
+#'       \code{\link{performance}} results on the test data sets.}
+#'     \item{\code{perf.train} [\code{numeric}]}{
+#'       \code{\link{performance}} results on the training data sets.}
+#'     \item{\code{measure} [\code{\link{Measure}}]}{
+#'       Performance measure.}
+#'     \item{\code{group} [\code{factor}]}{
+#'       Grouping of resampling iterations. This encodes whether specific iterations
+#'       'belong together' (e.g. repeated CV).}
+#'     \item{\code{pred} [\code{\link{Prediction}}]}{
+#'       Prediction object.}
 #'   }
-#' @seealso \link{aggregations}, \code{\link{setAggregation}}
-#' @return \link{Aggregation} object
+#' @seealso \code{\link{aggregations}}, \code{\link{setAggregation}}
+#' @return [\code{\link{Aggregation}}].
 #' @examples
 #' # computes the interquartile range on all performance values
 #' test.iqr = makeAggregation(id = "test.iqr", name = "Test set interquartile range",

--- a/R/BenchmarkResult_operators.R
+++ b/R/BenchmarkResult_operators.R
@@ -141,7 +141,6 @@ getBMRPredictions = function(bmr, task.ids = NULL, learner.ids = NULL, as.df = F
 #' \code{\link{resample}}, or these objects are rbind-ed with extra columns
 #' \dQuote{task.id} and \dQuote{learner.id}.
 #'
-#' Note: Measure values will be \code{NA} for \code{\link{ResampleDesc}}s with \code{predict} is \dQuote{train}
 #'
 #' @template arg_bmr
 #' @template arg_bmr_taskids
@@ -163,7 +162,6 @@ getBMRPerformances = function(bmr, task.ids = NULL, learner.ids = NULL, as.df = 
 #' \code{\link{resample}}, or these objects are rbind-ed with extra columns
 #' \dQuote{task.id} and \dQuote{learner.id}.
 #'
-#' Note: Measure values will be \code{NA} for \code{\link{ResampleDesc}}s with \code{predict} is \dQuote{train}
 #'
 #' @template arg_bmr
 #' @template arg_bmr_taskids

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -1,6 +1,6 @@
 .FilterRegister = new.env()
 
-#' Create a feature filter
+#' Create a feature filter.
 #'
 #' Creates and registers custom feature filters. Implemented filters
 #' can be listed with \code{\link{listFilterMethods}}.
@@ -43,7 +43,7 @@ makeFilter = function(name, desc, pkg, supported.tasks, supported.features, fun)
   obj
 }
 
-#' List filter methods
+#' List filter methods.
 #'
 #' Returns a subset-able dataframe with filter information.
 #'
@@ -274,7 +274,7 @@ makeFilter(
 
 makeFilter(
   name = "oneR",
-  desc = "oneR assocation rule",
+  desc = "oneR association rule",
   pkg  = "FSelector",
   supported.tasks = c("classif", "regr"),
   supported.features = c("numerics", "factors"),
@@ -346,7 +346,7 @@ makeFilter(
 
 makeFilter(
   name = "kruskal.test",
-  desc = "Kurskal Test for binary and multiclass classification tasks",
+  desc = "Kruskal Test for binary and multiclass classification tasks",
   pkg = character(0L),
   supported.tasks = c("classif"),
   supported.features = c("numerics", "factors"),
@@ -376,7 +376,7 @@ makeFilter(
 
 makeFilter(
   name = "permutation.importance",
-  desc = "the aggregate difference between feature permuted and unpermuted predictions",
+  desc = "Aggregated difference between feature permuted and unpermuted predictions",
   pkg = character(0L),
   supported.tasks = c("classif", "regr", "surv"),
   supported.features = c("numerics", "factors"),

--- a/R/ImputeMethods.R
+++ b/R/ImputeMethods.R
@@ -41,7 +41,8 @@ simpleImpute = function(data, target, col, const) {
 }
 
 
-#' Built in imputation methods
+#' Built-in imputation methods.
+#'
 #' The built-ins are:
 #' \itemize{
 #'   \item \code{imputeConstant(const)} for imputation using a constant value,

--- a/R/Learner_properties.R
+++ b/R/Learner_properties.R
@@ -1,4 +1,4 @@
-#' @title Set, add, remove or query properties of learners
+#' @title Query properties of learners.
 #'
 #' @description
 #' Properties can be accessed with \code{getLearnerProperties(learner)}, which returns a
@@ -6,11 +6,12 @@
 #'
 #' @template arg_learner
 #' @param props [\code{character}]\cr
-#'   Vector of properties to set, add, remove or query.
+#'   Vector of properties to query.
 #' @return \code{getLearnerProperties} returns a character vector with learner properties.
 #'  \code{hasLearnerProperties} returns a logical vector of the same length as \code{props}.
 #' @name LearnerProperties
 #' @rdname LearnerProperties
+#' @aliases getLearnerProperties hasLearnerProperties
 #' @family learner
 NULL
 

--- a/R/Measure.R
+++ b/R/Measure.R
@@ -46,7 +46,20 @@
 #'   }
 #'   Default is \code{character(0)}.
 #' @param fun [\code{function(task, model, pred, feats, extra.args)}]\cr
-#'   Calculates performance value.
+#'   Calculates the performance value. Usually you will only need the prediction
+#'   object \code{pred}.
+#'   \describe{
+#'     \item{\code{task} [\code{\link{Task}}]}{
+#'       The task.}
+#'     \item{\code{model} [\code{\link{WrappedModel}}]}{
+#'       The fitted model.}
+#'     \item{\code{pred} [\code{\link{Prediction}}]}{
+#'       Prediction object.}
+#'     \item{\code{feats} [\code{data.frame}]}{
+#'       The features.}
+#'     \item{\code{extra.args} [\code{list}]}{
+#'       See below.}
+#'   }
 #' @param extra.args [\code{list}]\cr
 #'   List of extra arguments which will always be passed to \code{fun}.
 #'   Default is empty list.
@@ -144,7 +157,8 @@ getDefaultMeasure = function(x) {
 #' Set how this measure will be aggregated after resampling.
 #' To see possible aggregation functions: \code{\link{aggregations}}.
 #'
-#' @template arg_measure
+#' @param measure [\code{\link{Measure}}]\cr
+#'   Performance measure.
 #' @template arg_aggr
 #' @return [\code{\link{Measure}}] with changed aggregation behaviour.
 #' @export

--- a/R/Measure_custom_resampled.R
+++ b/R/Measure_custom_resampled.R
@@ -19,6 +19,17 @@
 #' @param fun [\code{function(task, group, pred, extra.args)}]\cr
 #'   Calculates performance value from \code{\link{ResamplePrediction}} object.
 #'   For rare cases you can also use the task, the grouping or the extra arguments \code{extra.args}.
+#'   \describe{
+#'     \item{\code{task} [\code{\link{Task}}]}{
+#'       The task.}
+#'     \item{\code{group} [\code{factor}]}{
+#'       Grouping of resampling iterations. This encodes whether specific iterations
+#'       'belong together' (e.g. repeated CV).}
+#'     \item{\code{pred} [\code{\link{Prediction}}]}{
+#'       Prediction object.}
+#'     \item{\code{extra.args} [\code{list}]}{
+#'       See below.}
+#'   }
 #' @param extra.args [\code{list}]\cr
 #'   List of extra arguments which will always be passed to \code{fun}.
 #'   Default is empty list.

--- a/R/PreprocWrapperCaret.R
+++ b/R/PreprocWrapperCaret.R
@@ -1,4 +1,4 @@
-#' @title Fuse learner with preprocessing
+#' @title Fuse learner with preprocessing.
 #'
 #' @description
 #' Fuses a learner with preprocessing methods provided by \code{\link[caret]{preProcess}}.

--- a/R/RLearner.R
+++ b/R/RLearner.R
@@ -2,50 +2,48 @@
 #'
 #' Wraps an already implemented learning method from R to make it accessible to mlr.
 #' Call this method in your constructor. You have to pass an id (name), the required
-#' package(s), a description object for all changeable parameters (you dont have to do this for the
+#' package(s), a description object for all changeable parameters (you do not have to do this for the
 #' learner to work, but it is strongly recommended), and use property tags to define features of the learner.
 #'
-#' @param cl [\code{character(1)}] \cr
-#'   Class name for learner to create.
-#'   By convention, all classification learners start with \dQuote{classif.},
-#'   all regression learners with \dQuote{regr.}, all cluster learners with \dQuote{cluster.}
-#'   and all survival learners start with \dQuote{surv.}.
+#' @template arg_lrncl
 #' @param package [\code{character}]\cr
 #'   Package(s) to load for the implementation of the learner.
-#' @param properties [\code{character(1)}]\cr
+#' @param properties [\code{character}]\cr
 #'   Set of learner properties. Some standard property names include:
 #'   \describe{
-#'     \item{numerics}{Can numeric features be handled?}
-#'     \item{factors}{Can factor features be handled?}
-#'     \item{missings}{Can missing features be handled?}
-#'     \item{oneclas,twoclass,multiclass}{Can one-class, two-class or multi-class classification problems be handled?}
+#'     \item{numerics, factors, ordered}{Can numeric, factor or ordered factor features be handled?}
+#'     \item{missings}{Can missing values in features be handled?}
+#'     \item{oneclas, twoclass, multiclass}{Can one-class, two-class or multi-class classification problems be handled?}
+#'     \item{class.weights}{Can class weights be handled?}
+#'     \item{rcens, lcens, icens}{Can right, left, or interval censored data be handled?}
 #'     \item{prob}{Can probabilites be predicted?}
 #'     \item{se}{Can standard errors be predicted?}
-#'     \item{class.weights}{Can class weights be handled?}
 #'   }
 #'   Default is \code{character(0)}.
-#' @param class.weights.param [\code{character(1)}] \cr
+#' @param class.weights.param [\code{character(1)}]\cr
 #'   Name of the parameter, which can be used for providing class weights.
-#' @param par.set [\code{\link[ParamHelpers]{ParamSet}}] \cr
+#' @param par.set [\code{\link[ParamHelpers]{ParamSet}}]\cr
 #'   Parameter set of (hyper)parameters and their constraints.
 #'   Dependent parameters with a \code{requires} field must use \code{quote} and not
 #'   \code{expression} to define it.
-#' @param par.vals [\code{list}] \cr
+#' @param par.vals [\code{list}]\cr
 #'   Always set hyperparameters to these values when the object is constructed.
 #'   Useful when default values are missing in the underlying function.
 #'   The values can later be overwritten when the user sets hyperparameters.
 #'   Default is empty list.
-#' @param name [\code{character(1)}]
+#' @param name [\code{character(1)}]\cr
 #'   Meaningful name for learner.
 #'   Default is \code{id}.
-#' @param short.name [\code{character(1)}]
+#' @param short.name [\code{character(1)}]\cr
 #'   Short name for learner.
 #'   Should only be a few characters so it can be used in plots and tables.
 #'   Default is \code{id}.
-#' @param note [\code{character(1)}]
+#' @param note [\code{character(1)}]\cr
 #'   Additional notes regarding the learner and its integration in mlr.
-#'   Default is \dQuote{}.
-#' @return [\code{\link{RLearnerClassif}}, \code{\link{RLearnerCluster}}, \code{\link{RLearnerMultilabel}} \code{\link{RLearnerRegr}} or \code{\link{RLearnerSurv}}].
+#'   Default is \code{\dQuote{}}.
+#' @return [\code{\link{RLearner}}]. The specific subclass is one of \code{\link{RLearnerClassif}},
+#'   \code{\link{RLearnerCluster}}, \code{\link{RLearnerMultilabel}},
+#'   \code{\link{RLearnerRegr}}, \code{\link{RLearnerSurv}}.
 #' @name RLearner
 #' @rdname RLearner
 #' @aliases RLearnerClassif RLearnerCluster RLearnerMultilabel RLearnerRegr RLearnerSurv

--- a/R/ResampleDesc.R
+++ b/R/ResampleDesc.R
@@ -40,12 +40,12 @@
 #'   Further parameters for strategies.\cr
 #'   \describe{
 #'   \item{iters [\code{integer(1)}]}{Number of iterations, for \dQuote{CV}, \dQuote{Subsample}
-#'     and \dQuote{Boostrap}}
+#'     and \dQuote{Boostrap}.}
 #'   \item{split [\code{numeric(1)}]}{Proportion of training cases for \dQuote{Holdout} and
 #'     \dQuote{Subsample} between 0 and 1. Default is 2/3.}
-#'   \item{reps [integer(1)]}{Repeats for \dQuote{RepCV}. Here \code{iters = folds * reps}.
+#'   \item{reps [\code{integer(1)}]}{Repeats for \dQuote{RepCV}. Here \code{iters = folds * reps}.
 #'     Default is 10.}
-#'   \item{folds [integer(1)]}{Folds in the repeated CV for \code{RepCV}.
+#'   \item{folds [\code{integer(1)]}}{Folds in the repeated CV for \code{RepCV}.
 #'     Here \code{iters = folds * reps}. Default is 10.}
 #'   }
 #' @param stratify [\code{logical(1)}]\cr
@@ -53,7 +53,7 @@
 #'   For classification tasks, this means that the resampling strategy is applied to all classes
 #'   individually and the resulting index sets are joined to make sure that the proportion of
 #'   observations in each training set is as in the original data set. Useful for imbalanced class sizes.
-#'   For survival tasks stratification is done on the events, resulting training sets with comparable
+#'   For survival tasks stratification is done on the events, resulting in training sets with comparable
 #'   censoring rates.
 #' @param stratify.cols [\code{character}]\cr
 #'   Stratify on specific columns referenced by name. All columns have to be factors.

--- a/R/Task.R
+++ b/R/Task.R
@@ -16,8 +16,8 @@
 #' \describe{
 #' \item{env [\code{environment}]}{Environment where data for the task are stored.
 #'   Use \code{\link{getTaskData}} in order to access it.}
-#' \item{weights [\code{numeric}]}{See argument above. \code{NULL} if not present.}
-#' \item{blocking [\code{factor}]}{See argument above. \code{NULL} if not present.}
+#' \item{weights [\code{numeric}]}{See argument. \code{NULL} if not present.}
+#' \item{blocking [\code{factor}]}{See argument. \code{NULL} if not present.}
 #' \item{task.desc [\code{\link{TaskDesc}}]}{Encapsulates further information about the task.}
 #' }
 #'
@@ -28,14 +28,15 @@
 #'
 #' @param id [\code{character(1)}]\cr
 #'   Id string for object.
-#'   Default is the name of R variable passed to \code{data}.
+#'   Default is the name of the R variable passed to \code{data}.
 #' @param data [\code{data.frame}]\cr
 #'   A data frame containing the features and target variable(s).
-#' @param target [\code{character(1)} | \code{character(2)}]\cr
-#'   Name of the target variable.
+#' @param target [\code{character(1)} | \code{character(2)} | \code{character(n.classes)}]\cr
+#'   Name(s) of the target variable(s).
 #'   For survival analysis these are the names of the survival time and event columns,
-#'   so it has length 2, for multilabel classification it must the names of the logical
-#'   columns that encode whether a label is present or not.
+#'   so it has length 2. For multilabel classification it contains the names of the logical
+#'   columns that encode whether a label is present or not and its length corresponds to the
+#'   number of classes.
 #' @param costs [\code{data.frame}]\cr
 #'   A numeric matrix or data frame containing the costs of misclassification.
 #'   We assume the general case of observation specific costs.
@@ -68,11 +69,11 @@
 #' @param check.data [\code{logical(1)}]\cr
 #'   Should sanity of data be checked initially at task creation?
 #'   You should have good reasons to turn this off (one might be speed).
-#'   Default is \code{TRUE}
+#'   Default is \code{TRUE}.
 #' @return [\code{\link{Task}}].
 #' @name Task
 #' @rdname Task
-#' @aliases ClassifTask RegrTask SurvTask CostSensTask ClusterTask
+#' @aliases ClassifTask RegrTask SurvTask CostSensTask ClusterTask MultilabelTask
 #' @examples
 #' library(mlbench)
 #' data(BostonHousing)

--- a/R/TaskDesc.R
+++ b/R/TaskDesc.R
@@ -7,12 +7,16 @@
 #' \describe{
 #' \item{id [\code{character(1)}]}{Id string of task.}
 #' \item{type [\code{character(1)}]}{Type of task, \dQuote{classif} for classification,
-#'   \dQuote{regr} for regression, \dQuote{surv} for survival, \dQuote{costsens} for
-#'   cost-sensitive classification.}
-#' \item{target [\code{character(0)} | \code{character(1)} | \code{character(2)}]}{
-#'  Name of target variable.
-#'  For \dQuote{surv} these are the names of the survival time and event columns, so it has length 2.
-#'  For \dQuote{costsens} ist has length 0, as there is no target column, but a cost matrix instead.}
+#'   \dQuote{regr} for regression, \dQuote{surv} for survival and \dQuote{cluster} for 
+#'   cluster analysis, \dQuote{costsens} for cost-sensitive classification, and
+#'   \dQuote{multilabel} for multilabel classification.}
+#' \item{target [\code{character(0)} | \code{character(1)} | \code{character(2)} | \code{character(n.classes)}]}{
+#'   Name(s) of the target variable(s).
+#'   For \dQuote{surv} these are the names of the survival time and event columns, so it has length 2.
+#'   For \dQuote{costsens} it has length 0, as there is no target column, but a cost matrix instead.
+#'   For \dQuote{multilabel} these are the names of logical columns that indicate whether a
+#'   class label is present and the number of target variables corresponds to the number of
+#'   classes.}
 #' \item{size [\code{integer(1)}]}{Number of cases in data set.}
 #' \item{n.feat [\code{integer(2)}]}{Number of features, named vector with entries:
 #'   \dQuote{numerics}, \dQuote{factors}, \dQuote{ordered}.}
@@ -20,11 +24,15 @@
 #' \item{has.weights [\code{logical(1)}]}{Are weights specified for each observation?}
 #' \item{has.blocking [\code{logical(1)}]}{Is a blocking factor for cases available in the task?}
 #' \item{class.levels [\code{character}]}{All possible classes.
-#'   Only present for \dQuote{classif} and \dQuote{costsens}.}
+#'   Only present for \dQuote{classif}, \dQuote{costsens}, and \dQuote{multilabel}.}
 #' \item{positive [\code{character(1)}]}{Positive class label for binary classification.
 #'   Only present for \dQuote{classif}, NA for multiclass.}
 #' \item{negative [\code{character(1)}]}{Negative class label for binary classification.
 #'   Only present for \dQuote{classif}, NA for multiclass.}
+#' \item{censoring [\code{character(1)}]}{Censoring type for survival analysis.
+#'   Only present for \dQuote{surv}, one of \dQuote{rcens} for right censored data,
+#'   \dQuote{lcens} for left censored data, and \dQuote{icens} for interval censored
+#'   data.}
 #' }
 #' @name TaskDesc
 #' @rdname TaskDesc

--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -17,7 +17,7 @@
 #'   \item{\bold{b632}}{\cr Aggregation for B632 bootstrap.}
 #'   \item{\bold{b632plus}}{\cr Aggregation for B632+ bootstrap.}
 #'   \item{\bold{testgroup.mean}}{\cr Performance values on test sets are grouped according
-#'     to resampling method. The mean for very group is calculated, then the mean of those means.
+#'     to resampling method. The mean for every group is calculated, then the mean of those means.
 #'     Mainly used for repeated CV.}
 #'   \item{\bold{test.join}}{\cr Performance measure on joined test sets.
 #'     This is especially useful for small sample sizes where unbalanced group sizes have a significant impact

--- a/R/benchmarkResult_mergers.R
+++ b/R/benchmarkResult_mergers.R
@@ -1,9 +1,9 @@
-#' @title Merge different learners of BenchmarkResult objects
+#' @title Merge different learners of BenchmarkResult objects.
 #' @description Combines the \code{\link{BenchmarkResult}} objects that were performed 
 #'   with different learners on the same set of Task(s). 
 #'   This can be helpful if you, e.g. forgot to run one learner on the set of tasks you used.
-#' @param ... [\code{\link{BenchmarkResult}}] \cr 
-#'   \code{BenchmarkResult} objects that should be merged
+#' @param ... [\code{\link{BenchmarkResult}}]\cr 
+#'   \code{BenchmarkResult} objects that should be merged.
 #' @export
 mergeBenchmarkResultLearner = function(...) {
   mergeLearner = function(x, y) {
@@ -25,12 +25,12 @@ mergeBenchmarkResultLearner = function(...) {
   Reduce(function(...) mergeLearner(...), list(...))
 }
 
-#' @title Merge different tasks of BenchmarkResult objects
+#' @title Merge different tasks of BenchmarkResult objects.
 #' @description Combines the \code{\link{BenchmarkResult}} objects that were performed
 #'   on different tasks with the same set of learner(s). 
 #'   This can be helpful if you, e.g. forgot to run the set of learners on a new task
-#' @param ... [\code{\link{BenchmarkResult}}] \cr 
-#'   \code{BenchmarkResult} objects that should be merged
+#' @param ... [\code{\link{BenchmarkResult}}]\cr 
+#'   \code{BenchmarkResult} objects that should be merged.
 #' @export
 mergeBenchmarkResultTask = function(...) {
   mergeTask = function(x, y) {

--- a/R/convertBMRToRankMatrix.R
+++ b/R/convertBMRToRankMatrix.R
@@ -1,7 +1,5 @@
 #' @title Convert BenchmarkResult to a rank-matrix.
 #'
-#' @description
-#' Computes a matrix of all the ranks of different algorithms over different datasets (tasks).
 #' @description Computes a matrix of all the ranks of different algorithms
 #' over different datasets (tasks). Ranks are computed from aggregated
 #' measures.
@@ -11,7 +9,7 @@
 #' @template arg_bmr
 #' @template arg_measure
 #' @param ties.method [\code{character(1)}]\cr
-#'   see \code{\link[base]{rank}} for details.
+#'   See \code{\link[base]{rank}} for details.
 #' @template arg_aggregation_method
 #' @return [\code{matrix}] with measure ranks as entries.
 #'   The matrix has one row for each \code{learner}, and one column for each \code{task}.

--- a/R/crossover.R
+++ b/R/crossover.R
@@ -1,4 +1,4 @@
-#' crossover
+#' Crossover.
 #'
 #' Takes two bit strings and creates a new one of the same size by selecting the items from the first string or
 #' the second, based on a given rate (the probability of choosing an element from the first string).

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -1,4 +1,4 @@
-#' Iris classification task
+#' Iris classification task.
 #'
 #' Contains the task (\code{iris.task}).
 #'
@@ -8,7 +8,7 @@
 #' @docType data
 NULL
 
-#' Sonar classification task
+#' Sonar classification task.
 #'
 #' Contains the task (\code{sonar.task}).
 #'
@@ -18,7 +18,7 @@ NULL
 #' @docType data
 NULL
 
-#' Wisconsin Breast Cancer classification task
+#' Wisconsin Breast Cancer classification task.
 #'
 #' Contains the task (\code{bc.task}).
 #'
@@ -29,7 +29,7 @@ NULL
 #' @docType data
 NULL
 
-#' PimaIndiansDiabetes classification task
+#' PimaIndiansDiabetes classification task.
 #'
 #' Contains the task (\code{pid.task}).
 #'
@@ -40,7 +40,7 @@ NULL
 #' @docType data
 NULL
 
-#' Boston Housing regression task
+#' Boston Housing regression task.
 #'
 #' Contains the task (\code{bh.task}).
 #'
@@ -51,7 +51,7 @@ NULL
 #' @docType data
 NULL
 
-#' Wisonsin Prognostic Breast Cancer (WPBC) survival task
+#' Wisonsin Prognostic Breast Cancer (WPBC) survival task.
 #'
 #' Contains the task (\code{wpbc.task}).
 #'
@@ -63,7 +63,7 @@ NULL
 #' @docType data
 NULL
 
-#' NCCTG Lung Cancer survival task
+#' NCCTG Lung Cancer survival task.
 #'
 #' Contains the task (\code{lung.task}).
 #'
@@ -75,7 +75,7 @@ NULL
 #' @docType data
 NULL
 
-#' Motor Trend Car Road Tests clustering task
+#' Motor Trend Car Road Tests clustering task.
 #'
 #' Contains the task (\code{mtcars.task}).
 #'
@@ -86,7 +86,7 @@ NULL
 #' @docType data
 NULL
 
-#' European Union Agricultural Workforces clustering task
+#' European Union Agricultural Workforces clustering task.
 #'
 #' Contains the task (\code{agri.task}).
 #'
@@ -97,7 +97,7 @@ NULL
 #' @docType data
 NULL
 
-#' Iris cost-sensitive classification task
+#' Iris cost-sensitive classification task.
 #'
 #' Contains the task (\code{costiris.task}).
 #'
@@ -112,7 +112,7 @@ NULL
 #' @docType data
 NULL
 
-#' Yeast multilabel classification task
+#' Yeast multilabel classification task.
 #'
 #' Contains the task (\code{yeast.task}).
 #'

--- a/R/estimateResidualVariance.R
+++ b/R/estimateResidualVariance.R
@@ -1,4 +1,4 @@
-#' Estimate the residual variance
+#' Estimate the residual variance.
 #'
 #' Estimate the residual variance of a regression model on a given task.
 #' If a regression learner is provided instead of a model, the model is

--- a/R/generateCalibration.R
+++ b/R/generateCalibration.R
@@ -10,9 +10,10 @@
 #'
 #' @family generate_plot_data
 #' @family calibration
+#' @aliases CalibrationData
 #'
 #' @template arg_plotroc_obj
-#' @param breaks [\code{character(1)}] or [\code{numeric}]\cr
+#' @param breaks [\code{character(1)} | \code{numeric}]\cr
 #'   If \code{character(1)}, the algorithm to use in generating probability bins.
 #'   See \code{\link{hist}} for details.
 #'   If \code{numeric}, the cut points for the bins.
@@ -24,6 +25,27 @@
 #' @param task.id [\code{character(1)}]\cr
 #'   Selected task in \code{\link{BenchmarkResult}} to do plots for, ignored otherwise.
 #'   Default is first task.
+#'
+#' @return [CalibrationData]. A \code{list} containing:
+#'   \item{proportion}{[\code{data.frame}] with columns:
+#'     \itemize{
+#'       \item \code{Learner} Name of learner.
+#'       \item \code{bin} Bins calculated according to the \code{breaks} or \code{groups} argument.
+#'       \item \code{Class} Class labels (for binary classification only the positive class).
+#'       \item \code{Proportion} Proportion of observations from class \code{Class} among all
+#'         observations with posterior probabilities of class \code{Class} within the
+#'         interval given in \code{bin}.
+#'     }}
+#'   \item{data}{[\code{data.frame}] with columns:
+#'     \itemize{
+#'       \item \code{Learner} Name of learner.
+#'       \item \code{truth} True class label.
+#'       \item \code{Class} Class labels (for binary classification only the positive class).
+#'       \item \code{Probability} Predicted posterior probability of \code{Class}.
+#'       \item \code{bin} Bin corresponding to \code{Probability}.
+#'     }}
+#'   \item{task}{[\code{\link{TaskDesc}}]\cr
+#'     Task description.}
 #'
 #' @references Vuk, Miha, and Curk, Tomaz. \dQuote{ROC Curve, Lift Chart, and Calibration Plot.} Metodoloski zvezki. Vol. 3. No. 1 (2006): 89-108.
 #' @export
@@ -111,7 +133,7 @@ generateCalibrationData.list = function(obj, breaks = "Sturges", groups = NULL, 
 #' @family calibration
 #'
 #' @param obj [\code{CalibrationData}]\cr
-#'   Result of \code{\link{generateCalibrationData}}
+#'   Result of \code{\link{generateCalibrationData}}.
 #' @param smooth [\code{logical(1)}]\cr
 #'   Whether to use a loess smoother.
 #'   Default is \code{FALSE}.

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -6,6 +6,7 @@
 #'
 #' @family generate_plot_data
 #' @family filter
+#' @aliases FilterValues
 #'
 #' @template arg_task
 #' @param method [\code{character}]\cr
@@ -15,8 +16,16 @@
 #'   Number of scores to request. Scores are getting calculated for all features per default.
 #' @param ... [any]\cr
 #'   Passed down to selected method.
-#' @return [\code{\link{FilterValues}}].
-#' @family filter
+#' @return [\code{FilterValues}]. A \code{list} containing:
+#'   \item{task.desc}{[\code{\link{TaskDesc}}]\cr
+#'	   Task description.}
+#'   \item{data}{[\code{data.frame}] with columns:
+#'     \itemize{
+#'       \item \code{name} Name of feature.
+#'       \item \code{type} Feature column type.
+#'       \item A column for each \code{method} with
+#'                   the feature importance values.
+#'     }}
 #' @export
 generateFilterValuesData = function(task, method = "rf.importance", nselect = getTaskNFeats(task), ...) {
   assert(checkClass(task, "ClassifTask"), checkClass(task, "RegrTask"), checkClass(task, "SurvTask"))
@@ -60,20 +69,6 @@ generateFilterValuesData = function(task, method = "rf.importance", nselect = ge
             task.desc = td,
             data = out)
 }
-#' Result of \code{\link{generateFilterValuesData}}.
-#'
-#' @family filter
-#'
-#' \itemize{
-#'   \item{task.desc [\code{\link{TaskDesc}}]}{Task description.}
-#'   \item{data [\code{data.frame}]}{Has columns: \code{name} = Names of features;
-#'     \code{type} = Feature column type; and a column for each \code{method} with
-#'                   the feature values.}
-#' }
-#' @name FilterValues
-#' @rdname FilterValues
-#' @family filter
-NULL
 #' @export
 print.FilterValues = function(x, ...) {
   catf("FilterValues:")

--- a/R/generateLearningCurve.R
+++ b/R/generateLearningCurve.R
@@ -1,10 +1,11 @@
-#' @title Generates a learning curve
+#' @title Generates a learning curve.
 #'
 #' @description
 #' Observe how the performance changes with an increasing number of observations.
 #'
 #' @family generate_plot_data
 #' @family learning_curve
+#' @aliases LearningCurveData
 #'
 #' @param learners [(list of) \code{\link{Learner}}]\cr
 #'   Learning algorithms which should be compared.
@@ -23,7 +24,18 @@
 #'   Only for classification:
 #'   Should the downsampled data be stratified according to the target classes?
 #' @template arg_showinfo
-#' @return An object of class \code{\link{LearningCurveData}}.
+#' @return [\code{LearningCurveData}]. A \code{list} containing:
+#'   \item{task}{[\code{\link{Task}}]\cr
+#'     The task.}
+#'   \item{measures}{[(list of) \code{\link{Measure}}]\cr
+#'     Performance measures.}
+#'   \item{data}{[\code{data.frame}] with columns:
+#'     \itemize{	
+#'       \item \code{learner} Names of learners.
+#'       \item \code{percentage} Percentages drawn from the training split.
+#'       \item One column for each
+#'     \code{\link{Measure}} passed to \code{\link{generateLearningCurveData}}.
+#'    }}
 #' @examples
 #' r = generateLearningCurveData(list("classif.rpart", "classif.knn"),
 #' task = sonar.task, percs = seq(0.2, 1, by = 0.2),
@@ -80,20 +92,6 @@ generateLearningCurveData = function(learners, task, resampling = NULL,
             measures = measures,
             data = out)
 }
-#' Result of \code{\link{generateLearningCurveData}}.
-#'
-#' @family learning_curve
-#'
-#' \itemize{
-#'   \item{task [\code{\link{TaskDesc}}]}{Task description.}
-#'   \item{measures} [\code{\link{Measure}}]{Measures.}
-#'   \item{data [\code{data.frame}]}{Has columns: \code{learner} = Name of learner;
-#'     \code{perc} = Percentages drawn from the training split.; and a column for each \code{\link{Measure}}
-#'                   passed to \code{\link{generateLearningCurveData}}.}
-#' }
-#' @name LearningCurveData
-#' @rdname LearningCurveData
-NULL
 #' @export
 print.LearningCurveData = function(x, ...) {
   catf("LearningCurveData:")

--- a/R/generatePartialPrediction.R
+++ b/R/generatePartialPrediction.R
@@ -1,4 +1,4 @@
-#' @title Generate partial predictions
+#' @title Generate partial predictions.
 #'
 #' @description
 #' Estimate how the learned prediction function is affected by one or more features.
@@ -9,6 +9,7 @@
 #'
 #' @family partial_prediction
 #' @family generate_plot_data
+#' @aliases PartialPredictionData
 #'
 #' @param obj [\code{\link{WrappedModel}}]\cr
 #'   Result of \code{\link{train}}.
@@ -88,11 +89,35 @@
 #'   the number of (possibly non-unique) values resampled. If \code{resample = NULL} it defines the
 #'   length of the evenly spaced grid created.
 #' @param ... additional arguments to be passed to \code{\link{predict}}.
-#' @return [\code{PartialPredictionData}], A named list, which contains the partial predictions,
+#' @return [\code{PartialPredictionData}]. A named list, which contains the partial predictions,
 #'   input data, target, features, task description, and other arguments controlling the type of
 #'   partial predictions made.
+#'
+#' Object members:
+#'   \item{data}{[\code{data.frame}]\cr
+#'     Has columns for the prediction: one column for regression and
+#'     survival analysis, and a column for class and the predicted probability for classification as well
+#'     as a a column for each element of \code{features}. If \code{individual = TRUE} then there is an
+#'     additional column \code{idx} which gives the index of the \code{data} that each prediction corresponds to.}
+#'   \item{task.desc}{[\code{\link{TaskDesc}}]\cr
+#'     Task description.}
+#'   \item{target}{Target feature for regression, target feature levels for classification,
+#'         survival and event indicator for survival.}
+#'   \item{features}{[\code{character}]\cr
+#'     Features argument input.}
+#'   \item{interaction}{[\code{logical(1)}]\cr
+#'     Whether or not the features were interacted (i.e. conditioning).}
+#'   \item{derivative}{[\code{logical(1)}]\cr
+#'     Whether or not the partial derivative was estimated.}
+#'   \item{individual}{[\code{logical(1)}]\cr
+#'     Whether the partial predictions were aggregated or the individual curves are retained.}
+#'   \item{center}{[\code{logical(1)}]\cr
+#'     If \code{individual == TRUE} whether the partial prediction at the values of the
+#'                 features specified was subtracted from the individual partial predictions. Only displayed if
+#'                 \code{individual == TRUE}.}
 #' @references
 #' Goldstein, Alex, Adam Kapelner, Justin Bleich, and Emil Pitkin. \dQuote{Peeking inside the black box: Visualizing statistical learning with plots of individual conditional expectation.} Journal of Computational and Graphical Statistics. Vol. 24, No. 1 (2015): 44-65.
+#'
 #' Friedman, Jerome. \dQuote{Greedy Function Approximation: A Gradient Boosting Machine.} The Annals of Statistics. Vol. 29. No. 5 (2001): 1189-1232.
 #' @examples
 #' lrn = makeLearner("regr.rpart")
@@ -382,29 +407,6 @@ doIndividualPartialPrediction = function(out, td, n = nrow(data), rng, target, f
   }
   out
 }
-#' Result of \code{\link{generatePartialPredictionData}}.
-#'
-#' @family partial_prediction
-#'
-#' \itemize{
-#'   \item{data \code{data.frame}}{Has columns for the prediction: one column for regression and
-#'   survival analysis, and a column for class and the predicted probability for classification as well
-#'   as a a column for each element of \code{features}. If \code{individual = TRUE} then there is an
-#'   additional column \code{idx} which gives the index of the \code{data} that each prediction corresponds to.}
-#'   \item{task.desc \code{\link{TaskDesc}}}{Task description}.
-#'   \item{features}{Features argument input}.
-#'   \item{target}{Target feature for regression, target feature levels for classification,
-#'         survival and event indicator for survival.}
-#'   \item{derivative}{Whether or not the partial derivative was estimated.}
-#'   \item{interaction}{Whether or not the features were interacted (i.e. conditioning)}
-#'   \item{individual}{Whether the parial predictions were aggregated or the individual curves are retained.}
-#'   \item{center}{If \code{individual == TRUE} whether the partial prediction at the values of the
-#'                 features specified was subtracted from the individual partial predictions. Only displayed if
-#'                 \code{individual == TRUE}.}
-#' }
-#' @name PartialPredictionData
-#' @rdname PartialPredictionData
-NULL
 #' @export
 print.PartialPredictionData = function(x, ...) {
   catf("PartialPredictionData")
@@ -418,7 +420,7 @@ print.PartialPredictionData = function(x, ...) {
     catf("Predictions centered: %s", x$center)
   print(head(x$data))
 }
-#' @title Plot a partial prediction with ggplot2
+#' @title Plot a partial prediction with ggplot2.
 #' @description
 #' Plot a partial prediction from \code{\link{generatePartialPredictionData}} using ggplot2.
 #'
@@ -428,7 +430,7 @@ print.PartialPredictionData = function(x, ...) {
 #' @param obj [\code{PartialPredictionData}]\cr
 #'   Generated by \code{\link{generatePartialPredictionData}}.
 #' @param geom [\code{charater(1)}]\cr
-#'   The type of geom to use to disply the data. Can be \dQuote{line} or \dQuote{tile}.
+#'   The type of geom to use to display the data. Can be \dQuote{line} or \dQuote{tile}.
 #'   For tiling at least two features must be used with \code{interaction = TRUE} in the call to
 #'   \code{\link{generatePartialPredictionData}}. This may be used in conjuction with the
 #'   \code{facet} argument if three features are specified in the call to
@@ -561,7 +563,7 @@ plotPartialPrediction = function(obj, geom = "line", facet = NULL, p = 1) {
 
   plt
 }
-#' @title Plot a partial prediction using ggvis
+#' @title Plot a partial prediction using ggvis.
 #' @description
 #' Plot a partial prediction from \code{\link{generatePartialPredictionData}} using ggvis.
 #'

--- a/R/generateROCRCurves.R
+++ b/R/generateROCRCurves.R
@@ -9,6 +9,7 @@
 #' @family roc
 #' @family predict
 #' @family generate_plot_data
+#' @aliases ROCRCurvesData
 #'
 #' @template arg_plotroc_obj
 #' @param meas1 [\code{character(1)}]\cr
@@ -31,8 +32,8 @@
 #'   Selected task in \code{\link{BenchmarkResult}} to do plots for, ignored otherwise.
 #'   Default is first task.
 #'
-#' @return A \code{ROCRCurvesData} object, a \code{list} with elements giving the data output from
-#'   \code{\link[ROCR]{performance}} and the input arguments.
+#' @return [\code{ROCRCurvesData}]. A \code{list} with elements giving the data output from
+#'   ROCR's \code{\link[ROCR]{performance}} and the input arguments.
 #' @export
 generateROCRCurvesData = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
                               perf.args = list(), task.id = NULL) {
@@ -202,7 +203,7 @@ print.ROCRCurvesData = function(x, ...) {
 #'   Result of \code{\link{generateROCRCurvesData}}.
 #' @param diagonal [\code{logical(1)}]\cr
 #'   Whether to plot a dashed diagonal line.
-#'   Default is false.
+#'   Default is \code{FALSE}.
 #' @param xlab [\code{character(1)}]\cr
 #'   Label for x-axis.
 #'   Default is \code{meas1}.

--- a/R/generateThreshVsPerf.R
+++ b/R/generateThreshVsPerf.R
@@ -5,6 +5,7 @@
 #'
 #' @family generate_plot_data
 #' @family thresh_vs_perf
+#' @aliases ThreshVsPerfData
 #'
 #' @template arg_plotroc_obj
 #' @template arg_measures
@@ -270,7 +271,7 @@ plotThreshVsPerfGGVIS = function(obj, interaction = "measure", mark.th = NA_real
   }
 }
 
-#' @title Plots a ROC curve using ggplot2
+#' @title Plots a ROC curve using ggplot2.
 #'
 #' @description
 #' Plots a ROC curve from predictions.

--- a/R/makeLearner.R
+++ b/R/makeLearner.R
@@ -14,7 +14,8 @@
 #'   Classification: \dQuote{response} (= labels) or \dQuote{prob} (= probabilities and labels by selecting the ones with maximal probability).
 #'   Regression: \dQuote{response} (= mean response) or \dQuote{se} (= standard errors and mean response).
 #'   Survival: \dQuote{response} (= some sort of orderable risk) or \dQuote{prob} (= time dependent probabilities).
-#'   Clustering: \dQuote{response} (= cluster IDS) or \dQuote{prob} (= fuzzy cluster membership probabilities).
+#'   Clustering: \dQuote{response} (= cluster IDS) or \dQuote{prob} (= fuzzy cluster membership probabilities),
+#'   Multilabel: \dQuote{response} (= logical matrix indicating the predicted class labels) or \dQuote{prob} (= probabilities and corresponding logical matrix indicating class labels).
 #'   Default is \dQuote{response}.
 #' @template arg_predictthreshold
 #' @param fix.factors.prediction [\code{logical(1)}]\cr

--- a/R/normalizeFeatures.R
+++ b/R/normalizeFeatures.R
@@ -1,4 +1,4 @@
-#' @title Normalize features
+#' @title Normalize features.
 #'
 #' @description
 #' Normalize features by different methods. 

--- a/R/options.R
+++ b/R/options.R
@@ -1,4 +1,4 @@
-#' @title Returns a list of mlr's options
+#' @title Returns a list of mlr's options.
 #'
 #' @description
 #' Gets the options for mlr.

--- a/R/plotBMRBoxplots.R
+++ b/R/plotBMRBoxplots.R
@@ -1,8 +1,8 @@
-#' @title Create a box- or violin plots for a BenchmarkResult
+#' @title Create box or violin plots for a BenchmarkResult.
 #'
 #' @description
-#' Plots boxplots or violin plots for a selected \code{measure} across all iterations
-#' of the resampling strategy, faceted by the \code{task.id}
+#' Plots box or violin plots for a selected \code{measure} across all iterations
+#' of the resampling strategy, faceted by the \code{task.id}.
 #'
 #' @template arg_bmr
 #' @template arg_measure
@@ -10,8 +10,8 @@
 #'   Type of plot, can be \dQuote{box} for a boxplot or \dQuote{violin} for a violin plot.
 #'   Default is \dQuote{box}.
 #' @param pretty.names [\code{logical(1)}]\cr
-#'  Whether to use the \code{\link{Measure}} name instead of the id in the plot.
-#'  Default is \code{TRUE}.
+#'   Whether to use the \code{\link{Measure}} name instead of the id in the plot.
+#'   Default is \code{TRUE}.
 #' @template arg_order_lrns
 #' @template arg_order_tsks
 #' @template ret_gg2

--- a/R/plotBMRRanksAsBarChart.R
+++ b/R/plotBMRRanksAsBarChart.R
@@ -1,24 +1,24 @@
-#' @title Create a bar-chart for ranks in a BenchmarkResult.
+#' @title Create a bar chart for ranks in a BenchmarkResult.
 #'
 #' @description
-#' Plots a barchart from the ranks of algorithms. Alternatively
+#' Plots a bar chart from the ranks of algorithms. Alternatively,
 #' tiles can be plotted for every rank-task combination, see \code{pos}
-#' for details. The x-axis accross all plots is the ranks of a learner.id.
-#' Areas are always coloured corresponding to the learner.
+#' for details. In all plot variants the ranks of the learning algorithms are displayed on
+#' the x-axis. Areas are always colored according to the \code{learner.id}.
 #'
 #' @template arg_bmr
 #' @template arg_measure
 #' @param ties.method [\code{character(1)}]\cr
 #'   See \code{\link{rank}} for details.
 #' @template arg_aggregation_method
-#' @param pos [\code{character(1)}]
+#' @param pos [\code{character(1)}]\cr
 #'   Optionally set how the bars are positioned in ggplot2.
 #'   Ranks are plotted on the x-axis.
-#'   \dQuote{tile} plots a heatmap with \code{task} as the y-axis.
+#'   \dQuote{tile} plots a heat map with \code{task} as the y-axis.
 #'   Allows identification of the performance in a special task.
-#'   \dQuote{stack} plots a stacked barplot. r
-#'   Allows for comparison of learners within and and accross ranks.
-#'   \dQuote{dodge} plots a barplot with bars next to each other instead
+#'   \dQuote{stack} plots a stacked bar plot.
+#'   Allows for comparison of learners within and and across ranks.
+#'   \dQuote{dodge} plots a bar plot with bars next to each other instead
 #'   of stacked bars.
 #' @template arg_order_lrns
 #' @template arg_order_tsks

--- a/R/plotBMRSummary.R
+++ b/R/plotBMRSummary.R
@@ -1,16 +1,17 @@
 #' @title Plot a benchmark summary.
 #'
 #' @description
-#' Creates a scatter plots, where each line refers to a task.
+#' Creates a scatter plot, where each line refers to a task.
 #' On that line the aggregated scores for all learners are plotted, for that task.
-#' You can use a rank transformation or just use ggplot2's \code{}
+#' Optionally, you can apply a rank transformation or just use one of ggplot2's transformations
+#' like \code{\link[ggplot2]{scale_x_log10}}.
 #'
 #' @template arg_bmr
 #' @template arg_measure
 #' @param trafo [\code{character(1)}]\cr
 #'   Currently either \dQuote{none} or \dQuote{rank}, the latter performing a rank transformation
 #'   (with average handling of ties) of the scores per task.
-#'   NB: You can add always addd \code{\link{scale_x_log10}} to the result to put scores on a log scale.
+#'   NB: You can add always add \code{\link[ggplot2]{scale_x_log10}} to the result to put scores on a log scale.
 #'   Default is \dQuote{none}.
 #' @template arg_order_tsks
 #' @param pointsize [\code{numeric(1)}]\cr

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -3,9 +3,10 @@
 #' Mainly for internal use. Predict new data with a fitted model.
 #' You have to implement this method if you want to add another learner to this package.
 #'
-#' You implementation must adhere to the following:
-#' The model must be fitted on the subset of \code{.task} given by \code{.subset}. All parameters
-#' in \code{...} must be passed to the underlying training function.
+#' Your implementation must adhere to the following:
+#' Predictions for the observations in \code{.newdata} must be made based on the fitted
+#' model (\code{.model$learner.model}).
+#' All parameters in \code{...} must be passed to the underlying predict function.
 #'
 #' @param .learner [\code{\link{RLearner}}]\cr
 #'   Wrapped learner.
@@ -15,11 +16,25 @@
 #'   New data to predict. Does not include target column.
 #' @param ... [any]\cr
 #'   Additional parameters, which need to be passed to the underlying predict function.
-#' @return For classification: Either a factor for type \dQuote{response} or a matrix for
-#'   type \dQuote{prob}. In the latter case the columns must be named with the class labels.
-#'   For regressions: Either a numeric for type \dQuote{response} or a matrix with two columns
-#'   for type \dQuote{se}. In the latter case first column is the estimated response (mean value)
-#'   and the second column the estimated standard errors.
+#' @return
+#' \itemize{
+#'   \item For classification: Either a factor with class labels for type
+#'     \dQuote{response} or, if the learner supports this, a matrix of class probabilities
+#'     for type \dQuote{prob}. In the latter case the columns must be named with the class
+#'     labels.
+#'   \item For regression: Either a numeric vector for type \dQuote{response} or,
+#'     if the learner supports this, a matrix with two columns for type \dQuote{se}.
+#'     In the latter case the first column contains the estimated response (mean value)
+#'     and the second column the estimated standard errors.
+#'   \item For survival: Either a numeric vector with some sort of orderable risk
+#'     for type \dQuote{response} or, if supported, a numeric vector with time dependent
+#'     probabilities for type \dQuote{prob}.
+#'   \item For clustering: Either an integer with cluster IDs for type \dQuote{response}
+#'     or, if supported, a matrix of membership probabilities for type \dQuote{prob}.
+#'   \item For multilabel: A logical matrix that indicates predicted class labels for type
+#'     \dQuote{response} or, if supported, a matrix of class probabilities for type
+#'     \dQuote{prob}. The columns must be named with the class labels.
+#'  }
 #' @export
 predictLearner = function(.learner, .model, .newdata, ...) {
   lmod = getLearnerModel(.model)

--- a/R/relativeOverfitting.R
+++ b/R/relativeOverfitting.R
@@ -5,7 +5,7 @@
 #'
 #' Currently only support for classification and regression tasks is implemented.
 #'
-#' @param rdesc [\code{\link{ResampleDesc}}\cr
+#' @param rdesc [\code{\link{ResampleDesc}}]\cr
 #'   Resampling strategy.
 #' @template arg_measures
 #' @template arg_task

--- a/R/resample.R
+++ b/R/resample.R
@@ -47,7 +47,7 @@
 #' @param ... [any]\cr
 #'   Further hyperparameters passed to \code{learner}.
 #' @template arg_showinfo
-#' @return [\code{\link{ResampleResult}}]. List of:
+#' @return [\code{\link{ResampleResult}}].
 #' @family resample
 #' @export
 #' @examples

--- a/R/train.R
+++ b/R/train.R
@@ -5,14 +5,14 @@
 #'
 #' @template arg_learner
 #' @template arg_task
-#' @param subset [\code{integer} | \code{integer}]\cr
+#' @param subset [\code{integer} | \code{logical}]\cr
 #'   An index vector specifying the training cases to be used for fitting.
 #'   By default the complete data set is used.
 #'   Logical vectors will be transformed to integer with \code{\link[base]{which}}.
 #' @param weights [\code{numeric}]\cr
 #'   Optional, non-negative case weight vector to be used during fitting.
 #'   If given, must be of same length as \code{subset} and in corresponding order.
-#'   By default \code{NULL} which means no weights are used unless specified in the task ([\code{\link{Task}}]).
+#'   By default \code{NULL} which means no weights are used unless specified in the task (\code{\link{Task}}).
 #'   Weights from the task will be overwritten.
 #' @return [\code{\link{WrappedModel}}].
 #' @export

--- a/man-roxygen/arg_bmr_asdf.R
+++ b/man-roxygen/arg_bmr_asdf.R
@@ -1,4 +1,4 @@
 #' @param as.df [\code{character(1)}]\cr
 #'   Return one data.frame as result - or a list of lists of objects?.
-#'   Default is \code{FALSE}
+#'   Default is \code{FALSE}.
 

--- a/man-roxygen/arg_imputey.R
+++ b/man-roxygen/arg_imputey.R
@@ -1,5 +1,5 @@
 #' @param impute.val [\code{numeric}]\cr
-#'   If something goes wrong during optimization (e.g, the learner crashes),
+#'   If something goes wrong during optimization (e.g. the learner crashes),
 #'   this value is fed back to the tuner, so the tuning algorithm does not abort.
 #'   It is not stored in the optimization path, an NA and a corresponding error message are
 #'   logged instead.

--- a/man-roxygen/arg_keep_pred.R
+++ b/man-roxygen/arg_keep_pred.R
@@ -2,6 +2,6 @@
 #'   Keep the prediction data in the \code{pred} slot of the result object.
 #'   If you do many experiments (on larger data sets) these objects might unnecessarily increase
 #'   object size / mem usage, if you do not really need them.
-#'   In this case you can this argument to \code{FALSE}.
+#'   In this case you can set this argument to \code{FALSE}.
 #'   Default is \code{TRUE}.
 

--- a/man-roxygen/arg_lrncl.R
+++ b/man-roxygen/arg_lrncl.R
@@ -1,8 +1,9 @@
 #' @param cl [\code{character(1)}]\cr
 #'   Class of learner. By convention, all classification learners
 #'   start with \dQuote{classif.}, all regression learners with
-#'   \dQuote{regr.}, all survival learners start with \dQuote{surv.}
-#'   and all clustering learners with \dQuote{cluster.}.
-#'   A list of all learners is available on the
+#'   \dQuote{regr.}, all survival learners start with \dQuote{surv.},
+#'   all clustering learners with \dQuote{cluster.}, and all multilabel
+#'   classification learners start with \dQuote{multilabel.}.
+#'   A list of all integrated learners is available on the
 #'   \code{\link{learners}} help page.
 

--- a/man-roxygen/arg_measure.R
+++ b/man-roxygen/arg_measure.R
@@ -1,4 +1,3 @@
 #' @param measure [\code{\link{Measure}}]\cr
 #'   Performance measure.
-#'   Default is the default measure for the task, see here \code{\link{getDefaultMeasure}}.
-
+#'   Default is the first measure used in the benchmark experiment.

--- a/man-roxygen/arg_taskdf_target.R
+++ b/man-roxygen/arg_taskdf_target.R
@@ -1,6 +1,8 @@
-#' @param target [\code{character(1)} | \code{character(2)}]\cr
-#'   Name of the target variable(s).
+#' @param target [\code{character(1)} | \code{character(2)} | \code{character(n.classes)}]\cr
+#'   Name(s) of the target variable(s).
 #'   Only used when \code{obj} is a data.frame, otherwise ignored.
 #'   If survival analysis is applicable, these are the names of the survival time and event columns,
 #'   so it has length 2.
-
+#'   For multilabel classification these are the names of logical columns that indicate whether
+#'   a class label is present and the number of target variables corresponds to the number of
+#'   classes.


### PR DESCRIPTION
I know this PR is quite large, but most changes are pretty straightforward.

I fixed some typos, formatting and roxygen, ..., added some missing info with regard to multilabel and survival and doc'ed the `CalibrationData` object.

Here is a list of files where you might want to check that I didn't miss anything. 

Aggregation:
* extended and reformatted the docs of arg `fun` of `makeAggregation`

BenchmarkResult_operators:
In the docs of `getBMRPerformances`, `getBMRAggrPerformances` there was a
note saying that "Measure values will be NA for ResampleDescs with predict is “train”"
I find this more confusing than helpful. Of course, when you are doing things
wrong (i.e. don't set a suitable aggregation) you will get meaningless results.
Therefore I removed the notes, but can add a reminder about measure aggregation
to the benchmark page in the tutorial.

generateCalibration: added missing return field and doc'ed the CalibrationData object.
@zmjones: Would you mind having a look?

Measure:
* extended docs of arg `fun` of `makeMeasure`
* in the docs for `setAggregation` the arg_measure template is not used anymore because the info about the default does not apply here (see below)

Measure_custom_resampled:
* extended docs of arg `fun` of `makeCustomResampledMeasure`

RLearner:
* added multilabel to the learner class template (arg_lrncl) and use this template in RLearner
* added missing learner properties

Task:
* added info about length of the `target` arg with regard to multilabel.

TaskDesc:
* extended docs with regard to multilabel and survival

generateFilterValues, generateLearningCurveData, generatePartialPrediction:
* Because of a small error in roxygen the info about the generated `*Data` objects was not
shown on the *Data help pages. I moved the `*Data` docs to the
`generate*Data` help page (which is just my personal taste) and made some small changes.
* @family filter was twice in the docs, therefore removed one
* also removed the alias FilterValues from the docs of deprecated function `getFilterValues`

makeLearner:
* add multilabel info

plotBMRSummary:
* The last sentence in the description field was incomplete.
  @berndbischl: I guess your intention was to point to the transformations available in ggplot2?

predictLearner:
* The @details were copied from `trainLearner`, I added some info for predict instead.
* @return: added survival, cluster, and multilabel. Please check if everything is correct.
I wasn't totally sure whether to doc the case `pred.type = "prob"` for survival.
This case is also doc'ed everywhere else (e.g. ?makeLearner) but `predictLearner` says that "prob"
for survival is not yet supported.

arg_measure:
* This template is currently used in benchmarkTest, convertBMRToRankMatrix,
  generateCritDifferences, plotBMR*.
* The info about the default of the `measure` arg was wrong: Per default the first measure
  in `benchmark` is used, i.e., `getBMRMeasures(bmr)[[1]]` and not the default measure
  of the task.
* It was also used in the docs of `setAggregation` for which the `measure` arg does not have a default, so I removed the template there.





