### PR TITLE
Fix #708: omitted parameter in {classif,regr}.glmboost

### DIFF
--- a/R/RLearner_classif_glmboost.R
+++ b/R/RLearner_classif_glmboost.R
@@ -25,8 +25,8 @@ makeRLearner.classif.glmboost = function() {
 }
 
 #' @export
-trainLearner.classif.glmboost = function(.learner, .task, .subset, .weights = NULL, mstop, nu, m, risk, ...) {
-  ctrl = learnerArgsToControl(mboost::boost_control, mstop, nu, risk)
+trainLearner.classif.glmboost = function(.learner, .task, .subset, .weights = NULL, mstop, nu, m, risk, stopintern, trace, ...) {
+  ctrl = learnerArgsToControl(mboost::boost_control, mstop, nu, risk, stopintern, trace)
   d = getTaskData(.task, .subset)
   if (.learner$predict.type == "prob") {
     td = getTaskDescription(.task)

--- a/R/RLearner_regr_glmboost.R
+++ b/R/RLearner_regr_glmboost.R
@@ -21,8 +21,8 @@ makeRLearner.regr.glmboost = function() {
   )
 }
 #' @export
-trainLearner.regr.glmboost = function(.learner, .task, .subset, .weights = NULL, mstop, nu, m, risk, ...) {
-  ctrl = learnerArgsToControl(mboost::boost_control, mstop, nu, risk)
+trainLearner.regr.glmboost = function(.learner, .task, .subset, .weights = NULL, mstop, nu, m, risk, trace, stopintern, ...) {
+  ctrl = learnerArgsToControl(mboost::boost_control, mstop, nu, risk, trace, stopintern)
   d = getTaskData(.task, .subset)
   f = getTaskFormula(.task)
   if (is.null(.weights)) {


### PR DESCRIPTION
I didn't write a test because it is my impression that arbitrary / mostly unimportant hyperparameters don't get tested anyways. Please tell me if there is an infrastructure that sets all hyperparameters to their default value and compares to the result of no given hyperparameter.