### PR TITLE
Fixed bug in gmean measure

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -670,8 +670,12 @@ gmean = makeMeasure(id = "gmean", minimize = FALSE, best = 1, worst = 0,
 #' @export measureGMEAN
 #' @rdname measures
 #' @format none
+#' @references
+#' He, H. & Garcia, E. A. (2009)
+#' \emph{Learning from Imbalanced Data.}
+#' IEEE Transactions on Knowledge and Data Engineering, vol. 21, no. 9. pp. 1263-1284.
 measureGMEAN = function(truth, response, negative, positive) {
-  sqrt(measureTP(truth, response, positive) * measureTN(truth, response, negative))
+  sqrt(measureTPR(truth, response, positive) * measureTNR(truth, response, negative))
 }
 
 #' @export gpr

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -360,7 +360,7 @@ test_that("check measure calculations", {
   expect_equal(f1.test, f1$fun(pred = pred.bin))
   expect_equal(f1.test, as.numeric(f1.perf))
   #gmean
-  gmean.test = sqrt(tp.test * tn.test)
+  gmean.test = sqrt((tp.test/(tp.test + fn.test)) * tn.test/(tn.test + fp.test))
   gmean.perf = performance(pred.bin, measures = gmean, model = mod.bin)
   expect_equal(gmean.test, gmean$fun(pred = pred.bin))
   expect_equal(gmean.test, as.numeric(gmean.perf))


### PR DESCRIPTION
gmean measure is defined as sqrt(TPR * TNR) for binary classification problems. This will also ensure that the measure is between the set limit of 0 and 1. 
NEWS: Updated gmean measure and unit test. Added reference to formula of gmean.