### PR TITLE
clean up randomForestSRC learners (this is related to #602)

### DIFF
--- a/R/RLearner_classif_randomForestSRC.R
+++ b/R/RLearner_classif_randomForestSRC.R
@@ -9,35 +9,48 @@ makeRLearner.classif.randomForestSRC = function() {
         values = c("by.root", "by.node", "none")),
       makeIntegerLearnerParam(id = "mtry", lower = 1L),
       makeIntegerLearnerParam(id = "nodesize", lower = 1L, default = 1L),
-      makeIntegerLearnerParam(id = "nsplit", default = 0L),
+      makeIntegerLearnerParam(id = "nodedepth", default = -1L),
+      makeDiscreteLearnerParam(id = "splitrule", default = "gini",
+        values = c("gini", "gini.unwt", "gini.hvwt", "random")),
+      makeIntegerLearnerParam(id = "nsplit", lower = 0L, default = 0L,
+        requires = quote(splitrule != "random")), # nsplit is ignored and internally set to 1L for splitrule = "random"
+      makeLogicalLearnerParam(id = "split.null", default = FALSE),
+      makeDiscreteLearnerParam(id = "importance", default = "permute", tunable = FALSE,
+        values = c("permute", "random", "anti", "permute.ensemble", "random.ensemble", "anti.ensemble", "none")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
-        values = c("na.omit", "na.impute"), when = "both"),
+        values = c("na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
-      makeNumericVectorLearnerParam(id = "xwar.wt", lower = 0),
-      makeLogicalLearnerParam(id = "forest", default = TRUE, tunable = FALSE),
-      makeIntegerLearnerParam(id = "seed", tunable = FALSE),
-      makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE),
+      makeDiscreteLearnerParam(id = "proximity", default = FALSE, tunable = FALSE,
+        values = list("inbag", "oob", "all", `TRUE` = TRUE, `FALSE` = FALSE)),
+      makeNumericVectorLearnerParam(id = "xvar.wt", lower = 0),
+      makeDiscreteLearnerParam(id = "var.used", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
+      makeDiscreteLearnerParam(id = "split.depth", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
+      makeIntegerLearnerParam(id = "seed", upper = 0L, tunable = FALSE),
+      makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE, when = "both"), # is currently ignored
       makeLogicalLearnerParam(id = "membership", default = TRUE, tunable = FALSE),
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam(id = "fast.restore", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(na.action = "na.impute"),
-    properties = c("missings", "numerics", "factors", "prob", "twoclass", "multiclass"),
+    par.vals = list(na.action = "na.impute", importance = "none"),
+    properties = c("missings", "numerics", "factors", "ordered", "prob", "twoclass", "multiclass"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = "`na.action` has been set to `na.impute` by default to allow missing data support."
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
+      `importance` has been set to `"none"` by default for speed.'
   )
 }
 
 #' @export
 trainLearner.classif.randomForestSRC = function(.learner, .task, .subset, .weights = NULL,  ...) {
   f = getTaskFormula(.task)
-  randomForestSRC::rfsrc(f, data = getTaskData(.task, .subset, recode.target = "drop.levels"), importance = "none", proximity = FALSE, forest = TRUE, ...)
+  randomForestSRC::rfsrc(f, data = getTaskData(.task, .subset, recode.target = "drop.levels"), forest = TRUE, ...)
 }
 
 #' @export
 predictLearner.classif.randomForestSRC = function(.learner, .model, .newdata, ...) {
-  p = predict(.model$learner.model, newdata = .newdata, importance = "none", ...)
+  p = predict(.model$learner.model, newdata = .newdata, membership = FALSE, ...)
   if (.learner$predict.type == "prob") {
     return(p$predicted)
   } else {

--- a/R/RLearner_regr_randomForestSRC.R
+++ b/R/RLearner_regr_randomForestSRC.R
@@ -9,35 +9,48 @@ makeRLearner.regr.randomForestSRC = function() {
         values = c("by.root", "by.node", "none")),
       makeIntegerLearnerParam(id = "mtry", lower = 1L),
       makeIntegerLearnerParam(id = "nodesize", lower = 1L, default = 5L),
-      makeIntegerLearnerParam(id = "nsplit", default = 0L),
+      makeIntegerLearnerParam(id = "nodedepth", default = -1L),
+      makeDiscreteLearnerParam(id = "splitrule", default = "mse",
+        values = c("mse", "mse.unwt", "mse.hvwt", "random")),
+      makeIntegerLearnerParam(id = "nsplit", lower = 0L, default = 0L,
+        requires = quote(splitrule != "random")), # nsplit is ignored and internally set to 1L for splitrule = "random"
+      makeLogicalLearnerParam(id = "split.null", default = FALSE),
+      makeDiscreteLearnerParam(id = "importance", default = "permute", tunable = FALSE,
+        values = c("permute", "random", "anti", "permute.ensemble", "random.ensemble", "anti.ensemble", "none")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
-        values = c("na.omit", "na.impute"), when = "both"),
+        values = c("na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
-      makeNumericVectorLearnerParam(id = "xwar.wt", lower = 0),
-      makeLogicalLearnerParam(id = "forest", default = TRUE, tunable = FALSE),
-      makeIntegerLearnerParam(id = "seed", tunable = FALSE),
-      makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE),
+      makeDiscreteLearnerParam(id = "proximity", default = FALSE, tunable = FALSE,
+        values = list("inbag", "oob", "all", `TRUE` = TRUE, `FALSE` = FALSE)),
+      makeNumericVectorLearnerParam(id = "xvar.wt", lower = 0),
+      makeDiscreteLearnerParam(id = "var.used", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
+      makeDiscreteLearnerParam(id = "split.depth", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
+      makeIntegerLearnerParam(id = "seed", upper = 0L, tunable = FALSE),
+      makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE, when = "both"), # is currently ignored
       makeLogicalLearnerParam(id = "membership", default = TRUE, tunable = FALSE),
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam(id = "fast.restore", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(na.action = "na.impute"),
-    properties = c("missings", "numerics", "factors"),
+    par.vals = list(na.action = "na.impute", importance = "none"),
+    properties = c("missings", "numerics", "factors", "ordered"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = "`na.action` has been set to `na.impute` by default to allow missing data support."
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
+      `importance` has been set to `"none"` by default for speed.'
   )
 }
 
 #' @export
 trainLearner.regr.randomForestSRC = function(.learner, .task, .subset, .weights = NULL,  ...) {
   f = getTaskFormula(.task)
-  randomForestSRC::rfsrc(f, data = getTaskData(.task, .subset), importance = "none", proximity = FALSE, forest = TRUE, ...)
+  randomForestSRC::rfsrc(f, data = getTaskData(.task, .subset), forest = TRUE, ...)
 }
 
 #' @export
 predictLearner.regr.randomForestSRC = function(.learner, .model, .newdata, ...) {
-  p = predict(.model$learner.model, newdata = .newdata, importance = "none", ...)
+  p = predict(.model$learner.model, newdata = .newdata, membership = FALSE, ...)
   # versison 2.0 of randomForestSRC returns an array here :(
   as.numeric(p$predicted)
 }

--- a/R/RLearner_surv_randomForestSRC.R
+++ b/R/RLearner_surv_randomForestSRC.R
@@ -10,23 +10,36 @@ makeRLearner.surv.randomForestSRC = function() {
       makeIntegerLearnerParam(id = "mtry", lower = 1L),
       makeNumericLearnerParam(id = "mtry.ratio", lower = 0L, upper = 1L),
       makeIntegerLearnerParam(id = "nodesize", lower = 1L, default = 3L),
+      makeIntegerLearnerParam(id = "nodedepth", default = -1L),
       makeDiscreteLearnerParam(id = "splitrule", default = "logrank",
-        values = c("logrank", "logrankscore")),
+        values = c("logrank", "logrankscore", "random")),
+      makeIntegerLearnerParam(id = "nsplit", lower = 0L, default = 0L,
+        requires = quote(splitrule != "random")), # nsplit is ignored and internally set to 1 for splitrule = "random"
+      makeLogicalLearnerParam(id = "split.null", default = FALSE),
+      makeDiscreteLearnerParam(id = "importance", default = "permute", tunable = FALSE,
+        values = c("permute", "random", "anti", "permute.ensemble", "random.ensemble", "anti.ensemble", "none")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
-        values = c("na.omit", "na.impute"), when = "both"),
-      makeNumericVectorLearnerParam(id = "xwar.wt", lower = 0),
-      makeLogicalLearnerParam(id = "forest", default = TRUE, tunable = FALSE),
-      makeIntegerLearnerParam(id = "seed", tunable = FALSE),
-      makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE),
+        values = c("na.impute", "na.random"), when = "both"),
+      makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
+      makeDiscreteLearnerParam(id = "proximity", default = FALSE, tunable = FALSE,
+        values = list("inbag", "oob", "all", `TRUE` = TRUE, `FALSE` = FALSE)),
+      makeNumericVectorLearnerParam(id = "xvar.wt", lower = 0),
+      makeDiscreteLearnerParam(id = "var.used", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
+      makeDiscreteLearnerParam(id = "split.depth", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
+      makeIntegerLearnerParam(id = "seed", upper = 0L, tunable = FALSE),
+      makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE, when = "both"), # is currently ignored
       makeLogicalLearnerParam(id = "membership", default = TRUE, tunable = FALSE),
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam(id = "fast.restore", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(na.action = "na.impute"),
+    par.vals = list(na.action = "na.impute", importance = "none"),
     properties = c("missings", "numerics", "factors", "ordered", "rcens"),
-    name = "Random Forests for Survival",
+    name = "Random Forest",
     short.name = "rfsrc",
-    note = "'na.action' has been set to 'na.impute' by default to allow missing data support"
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
+      `importance` has been set to `"none"` by default for speed.'
   )
 }
 
@@ -35,19 +48,18 @@ trainLearner.surv.randomForestSRC = function(.learner, .task, .subset, .weights 
   data = getTaskData(.task, subset = .subset)
   if (!is.null(mtry.ratio)) {
     if (!is.null(mtry))
-      stop("You cannot set both 'mtry' and 'mtry.ratio")
+      stop("You cannot set both 'mtry' and 'mtry.ratio'")
     mtry = mtry.ratio * nrow(data)
   }
 
   f = getTaskFormula(.task)
-  randomForestSRC::rfsrc(f, data = data, importance = "none", proximity = FALSE, forest = TRUE,
-    mtry = mtry, ...)
+  randomForestSRC::rfsrc(f, data = data, forest = TRUE, mtry = mtry, ...)
 }
 
 #' @export
 predictLearner.surv.randomForestSRC = function(.learner, .model, .newdata, ...) {
   if (.learner$predict.type == "response") {
-    predict(.model$learner.model, newdata = .newdata, importance = "none", ...)$predicted
+    predict(.model$learner.model, newdata = .newdata, membership = FALSE, ...)$predicted
   } else {
     stop("Unknown predict type")
   }

--- a/tests/testthat/test_classif_randomForestSRC.R
+++ b/tests/testthat/test_classif_randomForestSRC.R
@@ -7,17 +7,17 @@ test_that("classif_randomForestSRC", {
     list(),
     list(ntree = 100),
     list(ntree = 250, mtry = 4),
-    list(ntree = 250, nodesize = 2, na.action = "na.impute")
+    list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "none", proximity = FALSE)
   )
   old.predicts.list = list()
   old.probs.list = list()
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    parset = c(parset, list(data = binaryclass.train, formula = binaryclass.formula, importance = "none", proximity = FALSE, forest = TRUE))
+    parset = c(parset, list(data = binaryclass.train, formula = binaryclass.formula, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(randomForestSRC::rfsrc, parset)
-    p  = predict(m, newdata = binaryclass.test, importance = "none", na.action = "na.impute")
+    p = predict(m, newdata = binaryclass.test, membership = FALSE, na.action = "na.impute")
     old.predicts.list[[i]] = p$class
     old.probs.list[[i]] = p$predicted[,1]
   }

--- a/tests/testthat/test_regr_randomForestSRC.R
+++ b/tests/testthat/test_regr_randomForestSRC.R
@@ -7,17 +7,17 @@ test_that("regr_randomForestSRC", {
     list(),
     list(ntree = 100),
     list(ntree = 50, mtry = 4),
-    list(ntree = 50, nodesize = 2, na.action = "na.impute")
+    list(ntree = 50, nodesize = 2, na.action = "na.impute", importance = "none", proximity = FALSE)
   )
   old.predicts.list = list()
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    parset = c(parset, list(data = regr.train, formula = regr.formula, importance = "none", proximity = FALSE, forest = TRUE))
+    parset = c(parset, list(data = regr.train, formula = regr.formula, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(randomForestSRC::rfsrc, parset)
     # versison 2.0 of randomForestSRC returns an array here :(
-    p  = as.numeric(predict(m, newdata = regr.test, importance = "none", na.action = "na.impute")$predicted)
+    p = as.numeric(predict(m, newdata = regr.test, membership = FALSE, na.action = "na.impute")$predicted)
     old.predicts.list[[i]] = p
   }
 

--- a/tests/testthat/test_surv_randomForestSRC.R
+++ b/tests/testthat/test_surv_randomForestSRC.R
@@ -7,18 +7,18 @@ test_that("surv_randomForestSRC", {
     list(),
     list(ntree = 100),
     list(ntree = 50, mtry = 4),
-    list(ntree = 50, nodesize = 2, na.action = "na.impute", splitrule = "logrank")
+    list(ntree = 50, nodesize = 2, na.action = "na.impute", splitrule = "logrank", importance = "none", proximity = FALSE)
   )
   old.predicts.list = list()
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    parset = c(parset, list(data = surv.train, formula = surv.formula, importance = "none", proximity = FALSE, forest = TRUE))
+    parset = c(parset, list(data = surv.train, formula = surv.formula, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     # There are some crazy checks in RFSRC, we have to overwrite the formula here
     parset$formula = Surv(time, status) ~ .
     m = do.call(randomForestSRC::rfsrc, parset)
-    p  = predict(m, newdata = surv.test, importance = "none", na.action = "na.impute")$predicted
+    p = predict(m, newdata = surv.test, membership = FALSE, na.action = "na.impute")$predicted
     old.predicts.list[[i]] = drop(p)
   }
 


### PR DESCRIPTION
I basically did the stuff I listed [here](https://github.com/mlr-org/mlr/issues/602#issuecomment-171127957), i.e. added some missing parameters (most of minor importance), added dependencies, changed what parameters are hardcoded.

Questions regarding the `par.set`:
* Is this construction ok to cope with mixed logical and character options?

```
makeDiscreteLearnerParam(id = "var.used", default = FALSE, tunable = FALSE,
  values = list(`FALSE` = FALSE, "all.trees", "by.tree"))
```

* I'm not sure how to set the limits for `nodedepth`:
  Negative values of `nodedepth` mean that this parameter is ignored.
  0 corresponds to no splits, 1 results in a stump etc.
  So with regard to param checks allowing all negative integer values is ok.
  For tuning setting `lower = -1L` would be a better idea.
* Does anyone know what `split.null` does? I included it in the `par.set` for completeness sake, but I have no idea what it does, though I tried to find out.

train:
* `importance = "none"` was hardcoded.
  That doesn't hurt much because the importance can also later be extracted from the fitted
  tree by function `vimp`.
  But in case that someone wants to calculate the importance directly, I added it to the `par.set`,
  changed the default from `"permute"` to `"none"` in `par.vals` to save time and added a `note`.
* `proximity = FALSE` was hardcoded. In constrast to the importances this cannot be easily
  retrieved later on.
  I added it to the `par.set` and it defaults to `FALSE` anyway.
* I left `forest = TRUE` hardcoded and removed it from the `par.set`.
  (If `forest = FALSE` no fitted forest is returned and one can't make predictions.)

predict:
* `importance` was hardcoded, but this is not really necessary. It is ignored anyway
  because `.newdata` does not contain the target variable.
* I hardcoded `membership = FALSE` because it defaults to `TRUE`, but we ignore the calculated
  membership values anyway.
