### PR TITLE
SMOTEWrapper: nn param is not being passed to `smote` function

### DIFF
--- a/R/SMOTEWrapper.R
+++ b/R/SMOTEWrapper.R
@@ -64,10 +64,10 @@ makeSMOTEWrapper = function(learner, sw.rate = 1, sw.nn = 5L,
 
 #' @export
 trainLearner.SMOTEWrapper = function(.learner, .task, .subset, .weights = NULL, sw.rate = 1,
-  sw.standardize = TRUE, sw.alt.logic = FALSE, ...) {
+  sw.nn = 5, sw.standardize = TRUE, sw.alt.logic = FALSE, ...) {
 
   .task = subsetTask(.task, .subset)
-  .task = smote(.task, rate = sw.rate, standardize = sw.standardize, alt.logic = sw.alt.logic)
+  .task = smote(.task, rate = sw.rate, nn = sw.nn, standardize = sw.standardize, alt.logic = sw.alt.logic)
   m = train(.learner$next.learner, .task, weights = .weights)
   makeChainModel(next.model = m, cl = "SMOTEModel")
 }


### PR DESCRIPTION
The number of nearest neighbors to be considered `nn` is now passed from `SMOTEWrapper` to `smote`.
I have an additional concern, shouldn't the `...` dots in the wrapper be passed to the `train` function? For additional learner parameters? However, this causes some unit test to fail.