### PR TITLE
Fix #760: Params w/ when="both" in modelmultiplexer predict

### DIFF
--- a/R/ModelMultiplexer.R
+++ b/R/ModelMultiplexer.R
@@ -101,7 +101,7 @@ predictLearner.ModelMultiplexer = function(.learner, .model, .newdata, ...) {
   bl = .learner$base.learners[[sl]]
   # we need to pass the changed setting of the base learner for the predict function further down
   args = list(.learner = bl, .model = .model$learner.model$next.model, .newdata = .newdata)
-  args = c(args, getHyperPars(bl, for.fun = "predict"))
+  args = c(args, getHyperPars(bl, for.fun = c("predict", "both")))
   do.call(predictLearner, args)
 }
 


### PR DESCRIPTION
I guess there is an easier way to demonstrate bug #760 than how I did it. I don't know how the mlr test environment _usually_ tests that parameters reach their destination and I don't have time right now to familiarize myself with it. If someone wants they can write a test for this.