### PR TITLE
Fix #781: tuneControlRandom with only budget infers maxit from that.

### DIFF
--- a/R/TuneControlRandom.R
+++ b/R/TuneControlRandom.R
@@ -3,15 +3,19 @@
 #'   Default is 100.
 #' @export
 #' @rdname TuneControl
-makeTuneControlRandom = function(same.resampling.instance = TRUE, maxit = 100L, tune.threshold = FALSE,
+makeTuneControlRandom = function(same.resampling.instance = TRUE, maxit = NULL, tune.threshold = FALSE,
   tune.threshold.args = list(), log.fun = NULL, final.dw.perc = NULL, budget = NULL) {
 
-  if (is.null(budget))
+  if (is.null(budget)) {
+    if (is.null(maxit))
+      maxit = 100L
     budget = maxit
-  else if (is.null(maxit))
-    maxit = budget
-  else if (budget != maxit)
-    stopf("The parameters budget (%i) and maxit (%i) differ.", budget, maxit)
+  } else {
+    if (is.null(maxit))
+      maxit = budget
+    else if (budget != maxit)
+      stopf("The parameters budget (%i) and maxit (%i) differ.", budget, maxit)
+  }
   maxit = asCount(maxit)
 
   makeTuneControl(same.resampling.instance = same.resampling.instance,

--- a/tests/testthat/test_tune_tuneRandom.R
+++ b/tests/testthat/test_tune_tuneRandom.R
@@ -12,6 +12,11 @@ test_that("tuneRandom", {
   tr = tuneParams(lrn, multiclass.task, rdesc, par.set = ps, control = ctrl)
   expect_equal(getOptPathLength(tr$opt.path), 5)
   expect_true(!is.na(tr$y))
+
+  ctrl = makeTuneControlRandom(budget = 4)
+  tr = tuneParams(lrn, multiclass.task, rdesc, par.set = ps, control = ctrl)
+  expect_equal(getOptPathLength(tr$opt.path), 4)
+  expect_true(!is.na(tr$y))
 })
 
 test_that("tuneRandom works with dependent params", {


### PR DESCRIPTION
Take it or leave it, but I like this more; it is also consitent with the behaviour of `makeTuneControlIrace` and `makeTuneControlGenSA`, which also assign the budget value to the corresponding other variable.