### PR TITLE
new learner glinternet for classification and regression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Suggests:
     gbm,
     GenSA,
     glmnet,
+    glinternet,
     Hmisc,
     irace (>= 1.0.7),
     kernlab,

--- a/R/RLearner_classif_cvglinternet.R
+++ b/R/RLearner_classif_cvglinternet.R
@@ -1,0 +1,49 @@
+#' @export
+makeRLearner.classif.cvglinternet = function() {
+  makeRLearnerClassif(
+    cl = "classif.cvglinternet",
+    package = "glinternet",
+    par.set = makeParamSet(
+      makeIntegerLearnerParam(id = "nFolds", default = 10L, lower = 1L, tunable = FALSE),    
+      makeNumericVectorLearnerParam(id = "lambda", lower = 0),
+      makeIntegerLearnerParam(id = "nLambda", default = 50L, lower = 1L),
+      makeNumericLearnerParam(id = "lambdaMinRatio", lower = 0, upper = 1, default = 0.01),
+      makeIntegerLearnerParam(id = "screenLimit", lower = 1L),
+      makeNumericLearnerParam(id = "tol", default = 1.0e-5, lower = 0),
+      makeIntegerLearnerParam(id = "maxIter", default = 5000L, lower = 1L),
+      makeLogicalLearnerParam(id = "verbose", default = FALSE, tunable = FALSE),
+      makeDiscreteLearnerParam(id = "lambdaType", default = "lambdaHat", values = c("lambdaHat", "lambdaHat1Std"), when = "predict")
+    ),
+    properties = c("numerics", "factors", "ordered", "prob", "twoclass"),
+    name = "Linear Interaction Model with Group-Lasso Regularization (Cross Validated Lambda)",
+    short.name = "cvglinternet",
+    note = "(Ordered) factor features are automatically converted to integers."
+  )
+}
+
+#' @export
+trainLearner.classif.cvglinternet = function(.learner, .task, .subset, .weights = NULL, ...) {
+  ## class labels must be 0, 1
+  d = getTaskData(.task, .subset, target.extra = TRUE, recode.target = "01")
+  ## categorical variables must be coded as integers starting with 0
+  info = getFixDataInfo(d$data, factors.to.int = TRUE, ordered.to.int = TRUE, min.int.zero = TRUE)
+  ## numLevels contains the number of levels for categorical features, continuous features get a 1
+  numLevels = sapply(d$data, nlevels)
+  numLevels[numLevels == 0] = 1
+  attachTrainingInfo(glinternet::glinternet.cv(X = as.matrix(fixDataForLearner(d$data, info)), Y = d$target,
+    numLevels = numLevels, family = "binomial", ...), info)
+}
+
+#' @export
+predictLearner.classif.cvglinternet = function(.learner, .model, .newdata, ...) {
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
+  levs = c(.model$task.desc$negative, .model$task.desc$positive)
+  p = predict(.model$learner.model, X = .newdata, type = "response", ...)
+  if (.learner$predict.type == "response") {
+    p = as.factor(ifelse(p > 0.5, levs[2L], levs[1L]))
+  } else {
+    p = propVectorToMatrix(p, levs)
+  }
+  p
+}

--- a/R/RLearner_classif_glinternet.R
+++ b/R/RLearner_classif_glinternet.R
@@ -1,0 +1,56 @@
+#' @export
+makeRLearner.classif.glinternet = function() {
+  makeRLearnerClassif(
+    cl = "classif.glinternet",
+    package = "glinternet",
+    par.set = makeParamSet(
+      makeNumericVectorLearnerParam(id = "lambda", lower = 0),
+      makeIntegerLearnerParam(id = "nLambda", default = 50L, lower = 1L),
+      makeNumericLearnerParam(id = "lambdaMinRatio", lower = 0, upper = 1, default = 0.01),
+      makeIntegerLearnerParam(id = "screenLimit", lower = 1L),
+      makeIntegerLearnerParam(id = "numToFind", lower = 1L),
+      makeNumericLearnerParam(id = "tol", default = 1.0e-5, lower = 0),
+      makeIntegerLearnerParam(id = "maxIter", default = 5000L, lower = 1L),
+      makeLogicalLearnerParam(id = "verbose", default = FALSE, tunable = FALSE),
+      makeNumericVectorLearnerParam(id = "predictLambda", when = "predict")
+    ),
+    properties = c("numerics", "factors", "ordered", "prob", "twoclass"),
+    par.vals = list(predictLambda = 0.01),
+    name = "Linear Interaction Model with Group-Lasso Regularization",
+    short.name = "glinternet",
+    note = 'Learner param `predictLambda` can only be a single number, maps to `lambda` in `predict.glinternet` and
+      has been set to `0.01` per default.
+      If `predictLambda` is not a member of the `lambda` sequence used in training it is rounded to the next possible value.
+      (Ordered) factor features are automatically converted to integers.'
+  )
+}
+
+#' @export
+trainLearner.classif.glinternet = function(.learner, .task, .subset, .weights = NULL, ...) {
+  ## class labels must be 0, 1
+  d = getTaskData(.task, .subset, target.extra = TRUE, recode.target = "01")
+  ## categorical variables must be coded as integers starting with 0
+  info = getFixDataInfo(d$data, factors.to.int = TRUE, ordered.to.int = TRUE, min.int.zero = TRUE)
+  ## numLevels contains the number of levels for categorical features, continuous features get a 1
+  numLevels = sapply(d$data, nlevels)
+  numLevels[numLevels == 0] = 1
+  attachTrainingInfo(glinternet::glinternet(X = as.matrix(fixDataForLearner(d$data, info)), Y = d$target,
+    numLevels = numLevels, family = "binomial", ...), info)
+}
+
+#' @export
+predictLearner.classif.glinternet = function(.learner, .model, .newdata, predictLambda, ...) {
+  ## map predictLambda to nearest value in the lambda sequence (FIXME there might be a better solution ...)
+  lambda = .model$learner.model$lambda
+  lambda = lambda[which.min(abs(lambda - predictLambda))]
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
+  levs = c(.model$task.desc$negative, .model$task.desc$positive)
+  p = predict(.model$learner.model, X = .newdata, type = "response", lambda = lambda, ...)
+  if (.learner$predict.type == "response") {
+    p = as.factor(ifelse(p > 0.5, levs[2L], levs[1L]))
+  } else {
+    p = propVectorToMatrix(p, levs)
+  }
+  p
+}

--- a/R/RLearner_regr_cvglinternet.R
+++ b/R/RLearner_regr_cvglinternet.R
@@ -1,0 +1,41 @@
+#' @export
+makeRLearner.regr.cvglinternet = function() {
+  makeRLearnerRegr(
+    cl = "regr.cvglinternet",
+    package = "glinternet",
+    par.set = makeParamSet(
+      makeIntegerLearnerParam(id = "nFolds", default = 10L, lower = 1L, tunable = FALSE),    
+      makeNumericVectorLearnerParam(id = "lambda", lower = 0),
+      makeIntegerLearnerParam(id = "nLambda", default = 50L, lower = 1L),
+      makeNumericLearnerParam(id = "lambdaMinRatio", lower = 0, upper = 1, default = 0.01),
+      makeIntegerLearnerParam(id = "screenLimit", lower = 1L),
+      makeNumericLearnerParam(id = "tol", default = 1.0e-5, lower = 0),
+      makeIntegerLearnerParam(id = "maxIter", default = 5000L, lower = 1L),
+      makeLogicalLearnerParam(id = "verbose", default = FALSE, tunable = FALSE),
+      makeDiscreteLearnerParam(id = "lambdaType", default = "lambdaHat", values = c("lambdaHat", "lambdaHat1Std"), when = "predict")
+    ),
+    properties = c("numerics", "factors", "ordered"),
+    name = "Linear Interaction Model with Group-Lasso Regularization (Cross Validated Lambda)",
+    short.name = "cvglinternet",
+    note = "(Ordered) factor features are automatically converted to integers."
+  )
+}
+
+#' @export
+trainLearner.regr.cvglinternet = function(.learner, .task, .subset, .weights = NULL, ...) {
+  d = getTaskData(.task, .subset, target.extra = TRUE)
+  ## categorical variables must be coded as integers starting with 0
+  info = getFixDataInfo(d$data, factors.to.int = TRUE, ordered.to.int = TRUE, min.int.zero = TRUE)
+  ## numLevels contains the number of levels for categorical features, continuous features get a 1
+  numLevels = sapply(d$data, nlevels)
+  numLevels[numLevels == 0] = 1
+  attachTrainingInfo(glinternet::glinternet.cv(X = as.matrix(fixDataForLearner(d$data, info)), Y = d$target,
+    numLevels = numLevels, family = "gaussian", ...), info)
+}
+
+#' @export
+predictLearner.regr.cvglinternet = function(.learner, .model, .newdata, ...) {
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
+  drop(predict(.model$learner.model, X = .newdata, type = "response", ...))
+}

--- a/R/RLearner_regr_glinternet.R
+++ b/R/RLearner_regr_glinternet.R
@@ -1,0 +1,48 @@
+#' @export
+makeRLearner.regr.glinternet = function() {
+  makeRLearnerRegr(
+    cl = "regr.glinternet",
+    package = "glinternet",
+    par.set = makeParamSet(
+      makeNumericVectorLearnerParam(id = "lambda", lower = 0),
+      makeIntegerLearnerParam(id = "nLambda", default = 50L, lower = 1L),
+      makeNumericLearnerParam(id = "lambdaMinRatio", lower = 0, upper = 1, default = 0.01),
+      makeIntegerLearnerParam(id = "screenLimit", lower = 1L),
+      makeIntegerLearnerParam(id = "numToFind", lower = 1L),
+      makeNumericLearnerParam(id = "tol", default = 1.0e-5, lower = 0),
+      makeIntegerLearnerParam(id = "maxIter", default = 5000L, lower = 1L),
+      makeLogicalLearnerParam(id = "verbose", default = FALSE, tunable = FALSE),
+      makeNumericVectorLearnerParam(id = "predictLambda", when = "predict")
+    ),
+    properties = c("numerics", "factors", "ordered"),
+    par.vals = list(predictLambda = 0.01),
+    name = "Linear Interaction Model with Group-Lasso Regularization",
+    short.name = "glinternet",
+    note = 'Learner param `predictLambda` can only be a single number, maps to `lambda` in `predict.glinternet` and
+      has been set to `0.01` per default.
+      If `predictLambda` is not a member of the `lambda` sequence used in training it is rounded to the next possible value.
+      (Ordered) factor features are automatically converted to integers.'
+  )
+}
+
+#' @export
+trainLearner.regr.glinternet = function(.learner, .task, .subset, .weights = NULL, ...) {
+  d = getTaskData(.task, .subset, target.extra = TRUE)
+  ## categorical variables must be coded as integers starting with 0
+  info = getFixDataInfo(d$data, factors.to.int = TRUE, ordered.to.int = TRUE, min.int.zero = TRUE)
+  ## numLevels contains the number of levels for categorical features, continuous features get a 1
+  numLevels = sapply(d$data, nlevels)
+  numLevels[numLevels == 0] = 1
+  attachTrainingInfo(glinternet::glinternet(X = as.matrix(fixDataForLearner(d$data, info)), Y = d$target,
+    numLevels = numLevels, family = "gaussian", ...), info)
+}
+
+#' @export
+predictLearner.regr.glinternet = function(.learner, .model, .newdata, predictLambda, ...) {
+  ## map predictLambda to nearest value in the lambda sequence (FIXME there might be a better solution ...)
+  lambda = .model$learner.model$lambda
+  lambda = lambda[which.min(abs(lambda - predictLambda))]
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
+  p = drop(predict(.model$learner.model, X = .newdata, type = "response", lambda = lambda, ...))
+}

--- a/tests/testthat/test_classif_cvglinternet.R
+++ b/tests/testthat/test_classif_cvglinternet.R
@@ -1,0 +1,45 @@
+context("classif_cvglinternet")
+
+test_that("classif_cvglinternet", {
+  requirePackages("glinternet", default.method = "load")
+  parset.list = list(
+    list(),
+    list(nFolds = 3, screenLimit = 5, lambda = 2^(-(8:11)), lambdaType = "lambdaHat1Std")
+  )
+
+  old.predicts.list = list()
+  old.probs.list = list()
+
+  for (i in 1:length(parset.list)) {
+    parset = parset.list[[i]]
+    lambdaType = parset[["lambdaType"]]
+    if (is.null(lambdaType))
+      lambdaType = "lambdaHat"
+    parset[["lambdaType"]] = NULL
+
+    x = binaryclass.train
+    y = x[, binaryclass.class.col]
+    Y = ifelse(y == "M", 1, 0)	# first factor level M is positive class by default
+    x[, binaryclass.class.col] = NULL
+    numLevels = rep(1, ncol(x))
+    pars = list(X = as.matrix(x), Y = Y, family = "binomial", numLevels = numLevels)
+    pars = c(pars, parset)
+    set.seed(getOption("mlr.debug.seed"))
+    m = do.call(glinternet::glinternet.cv, pars)
+
+    newx = binaryclass.test
+    newx[, binaryclass.class.col] = NULL
+
+    p = drop(predict(m, as.matrix(newx), type = "response", lambdaType = lambdaType))
+    p2 = as.factor(binaryclass.class.levs[1 + (p <= 0.5)])
+    
+    old.probs.list[[i]] = p
+    old.predicts.list[[i]] = p2
+  }
+
+  testSimpleParsets("classif.cvglinternet", binaryclass.df, binaryclass.target,
+    binaryclass.train.inds, old.predicts.list, parset.list)
+  testProbParsets ("classif.cvglinternet", binaryclass.df, binaryclass.target,
+    binaryclass.train.inds, old.probs.list, parset.list)
+
+})

--- a/tests/testthat/test_classif_glinternet.R
+++ b/tests/testthat/test_classif_glinternet.R
@@ -1,0 +1,49 @@
+context("classif_glinternet")
+
+test_that("classif_glinternet", {
+  requirePackages("glinternet", default.method = "load")
+  parset.list = list(
+    list(),
+    list(nLambda = 10, lambdaMinRatio = 0.05, predictLambda = 0.02, numToFind = 10),
+    list(lambda = 2^(-(6:10)), predictLambda = 0.02, screenLimit = 5)
+  )
+
+  old.predicts.list = list()
+  old.probs.list = list()
+
+  for (i in 1:length(parset.list)) {
+    parset = parset.list[[i]]
+    predictLambda = parset[["predictLambda"]]
+    if (is.null(predictLambda))
+      predictLambda = 0.01
+    parset[["predictLambda"]] = NULL
+
+    x = binaryclass.train
+    y = x[, binaryclass.class.col]
+    Y = ifelse(y == "M", 1, 0)	# first factor level M is positive class by default
+    x[, binaryclass.class.col] = NULL
+    numLevels = sapply(x, nlevels)
+    numLevels[numLevels == 0] = 1
+    pars = list(X = as.matrix(x), Y = Y, family = "binomial", numLevels = numLevels)
+    pars = c(pars, parset)
+    set.seed(getOption("mlr.debug.seed"))
+    m = do.call(glinternet::glinternet, pars)
+
+    newx = binaryclass.test
+    newx[, binaryclass.class.col] = NULL
+    lambda = m$lambda
+    lambda = lambda[which.min(abs(lambda - predictLambda))]
+
+    p = drop(predict(m, as.matrix(newx), type = "response", lambda = lambda))
+    p2 = as.factor(binaryclass.class.levs[1 + (p <= 0.5)])
+   
+    old.probs.list[[i]] = p
+    old.predicts.list[[i]] = p2
+  }
+
+  testSimpleParsets("classif.glinternet", binaryclass.df, binaryclass.target,
+    binaryclass.train.inds, old.predicts.list, parset.list)
+  testProbParsets ("classif.glinternet", binaryclass.df, binaryclass.target,
+    binaryclass.train.inds, old.probs.list, parset.list)
+
+})

--- a/tests/testthat/test_learners_all_classif.R
+++ b/tests/testthat/test_learners_all_classif.R
@@ -11,6 +11,7 @@ test_that("learners work: classif ", {
       replace_missing_data_with_x_j_bar = TRUE,
       num_iterations_after_burn_in = 10L),
     classif.bdk = list(ydim = 2L),
+    classif.cvglinternet = list(nFolds = 2, nLambda = 10),
     classif.gbm = list(bag.fraction = 1, n.minobsinnode = 1),
     classif.lssvm = list(kernel = "rbfdot", reduced = FALSE),
     classif.nodeHarvest = list(nodes = 100L, nodesize = 5L),

--- a/tests/testthat/test_regr_cvglinternet.R
+++ b/tests/testthat/test_regr_cvglinternet.R
@@ -1,0 +1,38 @@
+context("regr_cvglinternet")
+
+test_that("regr_cvglinternet", {
+  requirePackages("glinternet", default.method = "load")
+  parset.list = list(
+    list(),
+    list(nFolds = 3, screenLimit = 5, lambda = 2^(-(10:11)), lambdaType = "lambdaHat1Std")
+  )
+
+  old.predicts.list = list()
+  old.probs.list = list()
+
+  for (i in 1:length(parset.list)) {
+    parset = parset.list[[i]]
+    lambdaType = parset[["lambdaType"]]
+    if (is.null(lambdaType))
+      lambdaType = "lambdaHat"
+    parset[["lambdaType"]] = NULL
+
+    ind = match(regr.target, names(regr.train))
+    x = regr.train[, -ind]
+    numLevels = sapply(x, nlevels)
+    numLevels[numLevels == 0] = 1
+    x$chas = as.integer(x$chas) - 1L
+    y = regr.train[, ind]
+    pars = list(X = as.matrix(x), Y = y, family = "gaussian", numLevels = numLevels)
+    pars = c(pars, parset)
+    set.seed(getOption("mlr.debug.seed"))
+    m = do.call(glinternet::glinternet.cv, pars)
+
+    newx = regr.test[,-ind]
+    newx$chas = as.integer(newx$chas) - 1L
+
+    old.predicts.list[[i]] = drop(predict(m, as.matrix(newx), lambdaType = lambdaType))
+  }
+  test.dat = regr.df
+  testSimpleParsets("regr.cvglinternet", test.dat, regr.target, regr.train.inds, old.predicts.list, parset.list)
+})

--- a/tests/testthat/test_regr_glinternet.R
+++ b/tests/testthat/test_regr_glinternet.R
@@ -1,0 +1,42 @@
+context("regr_glinternet")
+
+test_that("regr_glinternet", {
+  requirePackages("glinternet", default.method = "load")
+  parset.list = list(
+    list(),
+    list(nLambda = 10, lambdaMinRatio = 0.05, predictLambda = 0.02, numToFind = 10),
+    list(lambda = 2^(-(6:10)), predictLambda = 0.02, screenLimit = 5)
+  )
+
+  old.predicts.list = list()
+  old.probs.list = list()
+
+  for (i in 1:length(parset.list)) {
+    parset = parset.list[[i]]
+    predictLambda = parset[["predictLambda"]]
+    if (is.null(predictLambda))
+      predictLambda = 0.01
+    parset[["predictLambda"]] = NULL
+
+    ind = match(regr.target, names(regr.train))
+    x = regr.train[, -ind]
+    numLevels = sapply(x, nlevels)
+    numLevels[numLevels == 0] = 1
+    x$chas = as.integer(x$chas) - 1L
+    y = regr.train[, ind]
+    pars = list(X = as.matrix(x), Y = y, family = "gaussian", numLevels = numLevels)
+    pars = c(pars, parset)
+    set.seed(getOption("mlr.debug.seed"))
+    m = do.call(glinternet::glinternet, pars)
+
+    newx = regr.test[,-ind]
+    newx$chas = as.integer(newx$chas) - 1L
+
+    lambda = m$lambda
+    lambda = lambda[which.min(abs(lambda - predictLambda))]
+
+    old.predicts.list[[i]] = drop(predict(m, as.matrix(newx), lambda = lambda))
+  }
+  test.dat = regr.df
+  testSimpleParsets("regr.glinternet", test.dat, regr.target, regr.train.inds, old.predicts.list, parset.list)
+})


### PR DESCRIPTION
`glinternet` is a penalized regression learner and can detect 2-way interactions.
The interface is very similar to `glmnet`.

* In contrast to `glmnet`, `glinternet` cannot interpolate when making predictions for
`lambda`s that were not used for training.
That's why I introduced a new parameter `predictLambda` which is mapped to the closest
value in the `lambda`-sequence from training and then passed to `predict.glinternet`.
Maybe long-term we cold do the interpolation ourselves.

* `glinternet` wants categorical variables as integers starting with 0.
I therefore extended `fixDataInfo` and `fixDataforLearner`.
There is now an additional option `factors.to.int` and a logical parameter `min.int.zero` indicating
if the integer values start at 0 or 1.
