### PR TITLE
adapt randomForestSRC learners to new randomForestSRC version

### DIFF
--- a/R/RLearner_classif_randomForestSRC.R
+++ b/R/RLearner_classif_randomForestSRC.R
@@ -15,8 +15,9 @@ makeRLearner.classif.randomForestSRC = function() {
       makeIntegerLearnerParam(id = "nsplit", lower = 0L, default = 0L,
         requires = quote(splitrule != "random")), # nsplit is ignored and internally set to 1L for splitrule = "random"
       makeLogicalLearnerParam(id = "split.null", default = FALSE),
-      makeDiscreteLearnerParam(id = "importance", default = "permute", tunable = FALSE,
-        values = c("permute", "random", "anti", "permute.ensemble", "random.ensemble", "anti.ensemble", "none")),
+      makeDiscreteLearnerParam(id = "importance", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, `TRUE` = TRUE, "none", "permute", "random", "anti",
+          "permute.ensemble", "random.ensemble", "anti.ensemble")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
         values = c("na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
@@ -33,12 +34,11 @@ makeRLearner.classif.randomForestSRC = function() {
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam(id = "fast.restore", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(na.action = "na.impute", importance = "none"),
+    par.vals = list(na.action = "na.impute"),
     properties = c("missings", "numerics", "factors", "ordered", "prob", "twoclass", "multiclass"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
-      `importance` has been set to `"none"` by default for speed.'
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.'
   )
 }
 

--- a/R/RLearner_regr_randomForestSRC.R
+++ b/R/RLearner_regr_randomForestSRC.R
@@ -15,8 +15,9 @@ makeRLearner.regr.randomForestSRC = function() {
       makeIntegerLearnerParam(id = "nsplit", lower = 0L, default = 0L,
         requires = quote(splitrule != "random")), # nsplit is ignored and internally set to 1L for splitrule = "random"
       makeLogicalLearnerParam(id = "split.null", default = FALSE),
-      makeDiscreteLearnerParam(id = "importance", default = "permute", tunable = FALSE,
-        values = c("permute", "random", "anti", "permute.ensemble", "random.ensemble", "anti.ensemble", "none")),
+      makeDiscreteLearnerParam(id = "importance", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, `TRUE` = TRUE, "none", "permute", "random", "anti",
+          "permute.ensemble", "random.ensemble", "anti.ensemble")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
         values = c("na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
@@ -33,12 +34,11 @@ makeRLearner.regr.randomForestSRC = function() {
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam(id = "fast.restore", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(na.action = "na.impute", importance = "none"),
+    par.vals = list(na.action = "na.impute"),
     properties = c("missings", "numerics", "factors", "ordered"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
-      `importance` has been set to `"none"` by default for speed.'
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.'
   )
 }
 

--- a/R/RLearner_surv_randomForestSRC.R
+++ b/R/RLearner_surv_randomForestSRC.R
@@ -16,11 +16,14 @@ makeRLearner.surv.randomForestSRC = function() {
       makeIntegerLearnerParam(id = "nsplit", lower = 0L, default = 0L,
         requires = quote(splitrule != "random")), # nsplit is ignored and internally set to 1 for splitrule = "random"
       makeLogicalLearnerParam(id = "split.null", default = FALSE),
-      makeDiscreteLearnerParam(id = "importance", default = "permute", tunable = FALSE,
-        values = c("permute", "random", "anti", "permute.ensemble", "random.ensemble", "anti.ensemble", "none")),
+      makeDiscreteLearnerParam(id = "importance", default = FALSE, tunable = FALSE,
+        values = list(`FALSE` = FALSE, `TRUE` = TRUE, "none", "permute", "random", "anti",
+          "permute.ensemble", "random.ensemble", "anti.ensemble")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
         values = c("na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
+      ## FIXME
+      # makeIntegerLearnerParam(id = "ntime", lower = 1L), # can be a single integer or a vector of numeric (?) values
       makeDiscreteLearnerParam(id = "proximity", default = FALSE, tunable = FALSE,
         values = list("inbag", "oob", "all", `TRUE` = TRUE, `FALSE` = FALSE)),
       makeNumericVectorLearnerParam(id = "xvar.wt", lower = 0),
@@ -34,12 +37,11 @@ makeRLearner.surv.randomForestSRC = function() {
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam(id = "fast.restore", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(na.action = "na.impute", importance = "none"),
+    par.vals = list(na.action = "na.impute"),
     properties = c("missings", "numerics", "factors", "ordered", "rcens"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
-      `importance` has been set to `"none"` by default for speed.'
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.'
   )
 }
 

--- a/tests/testthat/test_classif_randomForestSRC.R
+++ b/tests/testthat/test_classif_randomForestSRC.R
@@ -7,7 +7,7 @@ test_that("classif_randomForestSRC", {
     list(),
     list(ntree = 100),
     list(ntree = 250, mtry = 4),
-    list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "none", proximity = FALSE)
+    list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
   old.probs.list = list()

--- a/tests/testthat/test_regr_randomForestSRC.R
+++ b/tests/testthat/test_regr_randomForestSRC.R
@@ -7,7 +7,7 @@ test_that("regr_randomForestSRC", {
     list(),
     list(ntree = 100),
     list(ntree = 50, mtry = 4),
-    list(ntree = 50, nodesize = 2, na.action = "na.impute", importance = "none", proximity = FALSE)
+    list(ntree = 50, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
 

--- a/tests/testthat/test_surv_randomForestSRC.R
+++ b/tests/testthat/test_surv_randomForestSRC.R
@@ -7,7 +7,7 @@ test_that("surv_randomForestSRC", {
     list(),
     list(ntree = 100),
     list(ntree = 50, mtry = 4),
-    list(ntree = 50, nodesize = 2, na.action = "na.impute", splitrule = "logrank", importance = "none", proximity = FALSE)
+    list(ntree = 50, nodesize = 2, na.action = "na.impute", splitrule = "logrank", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
 


### PR DESCRIPTION
With randomForestSRC 2.1.0 the default of the `importance` param has changed.
(See also [this commit](https://github.com/mlr-org/mlr/commit/6ed8a4c4c49f4a8d13a56a0bdc09e39595cfb0c9)).