### PR TITLE
some small corrections for randomForestSRC learners

### DIFF
--- a/R/RLearner_regr_randomForestSRC.R
+++ b/R/RLearner_regr_randomForestSRC.R
@@ -8,6 +8,7 @@ makeRLearner.regr.randomForestSRC = function() {
       makeDiscreteLearnerParam(id = "bootstrap", default = "by.root",
         values = c("by.root", "by.node", "none")),
       makeIntegerLearnerParam(id = "mtry", lower = 1L),
+      makeNumericLearnerParam(id = "mtry.ratio", lower = 0L, upper = 1L),
       makeIntegerLearnerParam(id = "nodesize", lower = 1L, default = 5L),
       makeIntegerLearnerParam(id = "nodedepth", default = -1L),
       makeDiscreteLearnerParam(id = "splitrule", default = "mse",
@@ -19,7 +20,7 @@ makeRLearner.regr.randomForestSRC = function() {
         values = list(`FALSE` = FALSE, `TRUE` = TRUE, "none", "permute", "random", "anti",
           "permute.ensemble", "random.ensemble", "anti.ensemble")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
-        values = c("na.impute", "na.random"), when = "both"),
+        values = c("na.omit", "na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
       makeDiscreteLearnerParam(id = "proximity", default = FALSE, tunable = FALSE,
         values = list("inbag", "oob", "all", `TRUE` = TRUE, `FALSE` = FALSE)),
@@ -38,14 +39,20 @@ makeRLearner.regr.randomForestSRC = function() {
     properties = c("missings", "numerics", "factors", "ordered"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.'
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
+      `mtry.ratio` indicates the proportion of variables randomly selected as candidates for a split.'
   )
 }
 
 #' @export
-trainLearner.regr.randomForestSRC = function(.learner, .task, .subset, .weights = NULL,  ...) {
+trainLearner.regr.randomForestSRC = function(.learner, .task, .subset, .weights = NULL, mtry = NULL, mtry.ratio = NULL, ...) {
+  if (!is.null(mtry.ratio)) {
+    if (!is.null(mtry))
+      stop("You cannot set both 'mtry' and 'mtry.ratio'")
+    mtry = mtry.ratio * getTaskNFeats(.task)
+  }
   f = getTaskFormula(.task)
-  randomForestSRC::rfsrc(f, data = getTaskData(.task, .subset), forest = TRUE, ...)
+  randomForestSRC::rfsrc(f, data = getTaskData(.task, .subset), forest = TRUE, mtry = mtry, ...)
 }
 
 #' @export

--- a/R/RLearner_surv_randomForestSRC.R
+++ b/R/RLearner_surv_randomForestSRC.R
@@ -20,10 +20,9 @@ makeRLearner.surv.randomForestSRC = function() {
         values = list(`FALSE` = FALSE, `TRUE` = TRUE, "none", "permute", "random", "anti",
           "permute.ensemble", "random.ensemble", "anti.ensemble")),
       makeDiscreteLearnerParam(id = "na.action", default = "na.impute",
-        values = c("na.impute", "na.random"), when = "both"),
+        values = c("na.omit", "na.impute", "na.random"), when = "both"),
       makeIntegerLearnerParam(id = "nimpute", default = 1L, lower = 1L),
-      ## FIXME
-      # makeIntegerLearnerParam(id = "ntime", lower = 1L), # can be a single integer or a vector of numeric (?) values
+      makeUntypedLearnerParam(id = "ntime"), # can be a single integer with number of time points or a numeric vector of time values
       makeDiscreteLearnerParam(id = "proximity", default = FALSE, tunable = FALSE,
         values = list("inbag", "oob", "all", `TRUE` = TRUE, `FALSE` = FALSE)),
       makeNumericVectorLearnerParam(id = "xvar.wt", lower = 0),
@@ -41,21 +40,20 @@ makeRLearner.surv.randomForestSRC = function() {
     properties = c("missings", "numerics", "factors", "ordered", "rcens"),
     name = "Random Forest",
     short.name = "rfsrc",
-    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.'
+    note = '`na.action` has been set to `"na.impute"` by default to allow missing data support.
+      `mtry.ratio` indicates the proportion of variables randomly selected as candidates for a split.'
   )
 }
 
 #' @export
 trainLearner.surv.randomForestSRC = function(.learner, .task, .subset, .weights = NULL, mtry = NULL, mtry.ratio = NULL, ...) {
-  data = getTaskData(.task, subset = .subset)
   if (!is.null(mtry.ratio)) {
     if (!is.null(mtry))
       stop("You cannot set both 'mtry' and 'mtry.ratio'")
-    mtry = mtry.ratio * nrow(data)
+    mtry = mtry.ratio * getTaskNFeats(.task)
   }
-
   f = getTaskFormula(.task)
-  randomForestSRC::rfsrc(f, data = data, forest = TRUE, mtry = mtry, ...)
+  randomForestSRC::rfsrc(f, data = getTaskData(.task, subset = .subset), forest = TRUE, mtry = mtry, ...)
 }
 
 #' @export

--- a/tests/testthat/test_classif_randomForestSRC.R
+++ b/tests/testthat/test_classif_randomForestSRC.R
@@ -6,7 +6,7 @@ test_that("classif_randomForestSRC", {
   parset.list = list(
     list(),
     list(ntree = 100),
-    list(ntree = 250, mtry = 4),
+    list(ntree = 250, mtry.ratio = 0.9),
     list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
@@ -14,6 +14,10 @@ test_that("classif_randomForestSRC", {
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
+    if (!is.null(parset$mtry.ratio)) {
+      parset$mtry = parset$mtry.ratio * (ncol(binaryclass.df) - 1)
+      parset$mtry.ratio = NULL
+    } 
     parset = c(parset, list(data = binaryclass.train, formula = binaryclass.formula, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(randomForestSRC::rfsrc, parset)

--- a/tests/testthat/test_regr_randomForestSRC.R
+++ b/tests/testthat/test_regr_randomForestSRC.R
@@ -6,13 +6,17 @@ test_that("regr_randomForestSRC", {
   parset.list = list(
     list(),
     list(ntree = 100),
-    list(ntree = 50, mtry = 4),
+    list(ntree = 50, mtry.ratio = 0.9),
     list(ntree = 50, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
+    if (!is.null(parset$mtry.ratio)) {
+      parset$mtry = parset$mtry.ratio * (ncol(regr.df) - 1)
+      parset$mtry.ratio = NULL
+    } 
     parset = c(parset, list(data = regr.train, formula = regr.formula, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(randomForestSRC::rfsrc, parset)

--- a/tests/testthat/test_surv_randomForestSRC.R
+++ b/tests/testthat/test_surv_randomForestSRC.R
@@ -6,13 +6,17 @@ test_that("surv_randomForestSRC", {
   parset.list = list(
     list(),
     list(ntree = 100),
-    list(ntree = 50, mtry = 4),
+    list(ntree = 50, mtry.ratio = 0.9),
     list(ntree = 50, nodesize = 2, na.action = "na.impute", splitrule = "logrank", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
+    if (!is.null(parset$mtry.ratio)) {
+      parset$mtry = parset$mtry.ratio * (ncol(surv.df) - 2)
+      parset$mtry.ratio = NULL
+    } 
     parset = c(parset, list(data = surv.train, formula = surv.formula, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     # There are some crazy checks in RFSRC, we have to overwrite the formula here


### PR DESCRIPTION
* Added option `"na.omit"` for `na.action`
* Added parameter `ntime` for survival
* For survival from mlr's side there is an additional learner parameter `mtry.ratio` which indicates the *proportion*  (while `mtry` gives the *absolute number*) of variables considered for a split. Oddly, `mtry.ratio` is multiplied by `nrow(data)` (the number of *observations*) instead of the number of *features*. 
I changed that and for completeness sake added the `mtry.ratio` option also for regression and classification.