### PR TITLE
#572: remove task from makeCostMeasure

### DIFF
--- a/R/Measure_make_cost.R
+++ b/R/Measure_make_cost.R
@@ -13,8 +13,6 @@
 #' @param costs [\code{matrix}]\cr
 #'   Matrix of misclassification costs. Rows and columns have to be named with class labels, order does not matter.
 #'   Rows indicate true classes, columns predicted classes.
-#' @param task [\code{\link{ClassifTask}}]\cr
-#'   Classification task. Has to be passed, so validity of matrix names can be checked.
 #' @param combine [\code{function}]\cr
 #'   How to combine costs over all cases for a SINGLE test set?
 #'   Note this is not the same as the \code{aggregate} argument in \code{\link{makeMeasure}}
@@ -24,44 +22,44 @@
 #' @template ret_measure
 #' @export
 #' @family performance
-makeCostMeasure = function(id = "costs", minimize = TRUE, costs, task, combine = mean, best = NULL, worst = NULL,
+makeCostMeasure = function(id = "costs", minimize = TRUE, costs, combine = mean, best = NULL, worst = NULL,
                            name = id, note = "") {
   assertString(id)
   assertFlag(minimize)
   assertMatrix(costs)
-  assertClass(task, classes = "ClassifTask")
   assertFunction(combine)
   assertString(name)
   assertString(note)
-
-  #check costs
-  td = getTaskDescription(task)
-  levs = td$class.levels
-  if (any(dim(costs))) {
-    if (any(dim(costs) != length(levs)))
-      stop("Dimensions of costs have to be the same as number of class levels!")
-    rns = rownames(costs)
-    cns = colnames(costs)
-    if (!setequal(rns, levs) || !setequal(cns, levs))
-      stop("Row and column names of cost matrix have to equal class levels!")
-  }
-
+  
+  
+  
   makeMeasure(id = id, minimize = minimize, extra.args = list(costs, combine),
-    properties = c("classif", "classif.multi", "req.pred", "req.truth", "predtype.response", "predtype.prob"),
-    best = best, worst = worst,
-    fun = function(task, model, pred, feats, extra.args) {
-      costs = extra.args[[1L]]
-      # cannot index with NA
-      r = pred$data$response
-      if (anyMissing(r))
-        return(NA_real_)
-      cc = function(truth, pred) {
-        costs[truth, pred]
-      }
-      y = mapply(cc, as.character(pred$data$truth), as.character(r))
-      combine(y)
-    },
-    name = name,
-    note = note
+              properties = c("classif", "classif.multi", "req.pred", "req.truth", "predtype.response", "predtype.prob"),
+              best = best, worst = worst,
+              fun = function(task, model, pred, feats, extra.args) {
+                #check costs    
+                td = pred$task.desc
+                levs = td$class.levels
+                if (any(dim(costs))) {
+                  if (any(dim(costs) != length(levs)))
+                    stop("Dimensions of costs have to be the same as number of class levels!")
+                  rns = rownames(costs)
+                  cns = colnames(costs)
+                  if (!setequal(rns, levs) || !setequal(cns, levs))
+                    stop("Row and column names of cost matrix have to equal class levels!")
+                }
+                costs = extra.args[[1L]]
+                # cannot index with NA
+                r = pred$data$response
+                if (anyMissing(r))
+                  return(NA_real_)
+                cc = function(truth, pred) {
+                  costs[truth, pred]
+                }
+                y = mapply(cc, as.character(pred$data$truth), as.character(r))
+                combine(y)
+              },
+              name = name,
+              note = note
   )
 }

--- a/R/Measure_make_cost.R
+++ b/R/Measure_make_cost.R
@@ -31,35 +31,34 @@ makeCostMeasure = function(id = "costs", minimize = TRUE, costs, combine = mean,
   assertString(name)
   assertString(note)
   
-  
-  
+
   makeMeasure(id = id, minimize = minimize, extra.args = list(costs, combine),
-              properties = c("classif", "classif.multi", "req.pred", "req.truth", "predtype.response", "predtype.prob"),
-              best = best, worst = worst,
-              fun = function(task, model, pred, feats, extra.args) {
-                #check costs    
-                td = pred$task.desc
-                levs = td$class.levels
-                if (any(dim(costs))) {
-                  if (any(dim(costs) != length(levs)))
-                    stop("Dimensions of costs have to be the same as number of class levels!")
-                  rns = rownames(costs)
-                  cns = colnames(costs)
-                  if (!setequal(rns, levs) || !setequal(cns, levs))
-                    stop("Row and column names of cost matrix have to equal class levels!")
-                }
-                costs = extra.args[[1L]]
-                # cannot index with NA
-                r = pred$data$response
-                if (anyMissing(r))
-                  return(NA_real_)
-                cc = function(truth, pred) {
-                  costs[truth, pred]
-                }
-                y = mapply(cc, as.character(pred$data$truth), as.character(r))
-                combine(y)
-              },
-              name = name,
-              note = note
+    properties = c("classif", "classif.multi", "req.pred", "req.truth", "predtype.response", "predtype.prob"),
+    best = best, worst = worst,
+    fun = function(task, model, pred, feats, extra.args) {
+      #check costs    
+      td = pred$task.desc
+      levs = td$class.levels
+      if (any(dim(costs))) {
+        if (any(dim(costs) != length(levs)))
+          stop("Dimensions of costs have to be the same as number of class levels!")
+        rns = rownames(costs)
+        cns = colnames(costs)
+        if (!setequal(rns, levs) || !setequal(cns, levs))
+          stop("Row and column names of cost matrix have to equal class levels!")
+      }
+      costs = extra.args[[1L]]
+      # cannot index with NA
+      r = pred$data$response
+      if (anyMissing(r))
+        return(NA_real_)
+      cc = function(truth, pred) {
+        costs[truth, pred]
+      }
+      y = mapply(cc, as.character(pred$data$truth), as.character(r))
+      combine(y)
+    },
+    name = name,
+    note = note
   )
 }

--- a/man/makeCostMeasure.Rd
+++ b/man/makeCostMeasure.Rd
@@ -4,8 +4,8 @@
 \alias{makeCostMeasure}
 \title{Creates a measure for non-standard misclassification costs.}
 \usage{
-makeCostMeasure(id = "costs", minimize = TRUE, costs, task,
-  combine = mean, best = NULL, worst = NULL, name = id, note = "")
+makeCostMeasure(id = "costs", minimize = TRUE, costs, combine = mean,
+  best = NULL, worst = NULL, name = id, note = "")
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr
@@ -20,9 +20,6 @@ Default is \code{TRUE}.}
 \item{costs}{[\code{matrix}]\cr
 Matrix of misclassification costs. Rows and columns have to be named with class labels, order does not matter.
 Rows indicate true classes, columns predicted classes.}
-
-\item{task}{[\code{\link{ClassifTask}}]\cr
-Classification task. Has to be passed, so validity of matrix names can be checked.}
 
 \item{combine}{[\code{function}]\cr
 How to combine costs over all cases for a SINGLE test set?

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -56,7 +56,7 @@ test_that("TuneWrapper uses tune.threshold", {
   rdesc = makeResampleDesc("Holdout")
   costs = matrix(c(0, 5, 1, 0), 2)
   colnames(costs) = rownames(costs) = getTaskDescription(binaryclass.task)$class.levels
-  mm = makeCostMeasure(id = "costs", costs = costs, task = binaryclass.task, best = 0, worst = 5)
+  mm = makeCostMeasure(id = "costs", costs = costs, best = 0, worst = 5)
   ps = makeParamSet(makeDiscreteParam("method", "moment"))
   ctrl = makeTuneControlGrid(tune.threshold = TRUE)
   lrn = makeTuneWrapper(lrn, resampling = rdesc, measures = mm, par.set = ps, control = ctrl)

--- a/tests/testthat/test_base_costs.R
+++ b/tests/testthat/test_base_costs.R
@@ -5,17 +5,17 @@ test_that("costs", {
   rdesc = makeResampleDesc("Holdout")
   task = binaryclass.task
   task$task.desc$positive = "M"
-
+  
   cc = 1 - diag(1, 2)
   rownames(cc) = colnames(cc) = getTaskClassLevels(task)
-  ms = makeCostMeasure(costs = cc, task = task)
+  ms = makeCostMeasure(costs = cc)
   r = resample(lrn, rdesc, task = task, measures = list(mmce, ms))
   expect_equal(r$aggr[[1]], r$aggr[[2]])
-
+  
   cc = matrix(0, 2, 2)
   rownames(cc) = colnames(cc) = getTaskClassLevels(task)
   cc["R","M"] = 1
-  ms = makeCostMeasure(id = "foo", costs = cc, task = task, combine = sum)
+  ms = makeCostMeasure(id = "foo", costs = cc, combine = sum)
   expect_equal(ms$id, "foo")
   r = resample(lrn, rdesc, task = task, measures = list(fp, ms))
   expect_equal(r$aggr[[1]], r$aggr[[2]])

--- a/tests/testthat/test_base_costs.R
+++ b/tests/testthat/test_base_costs.R
@@ -5,13 +5,13 @@ test_that("costs", {
   rdesc = makeResampleDesc("Holdout")
   task = binaryclass.task
   task$task.desc$positive = "M"
-  
+
   cc = 1 - diag(1, 2)
   rownames(cc) = colnames(cc) = getTaskClassLevels(task)
   ms = makeCostMeasure(costs = cc)
   r = resample(lrn, rdesc, task = task, measures = list(mmce, ms))
   expect_equal(r$aggr[[1]], r$aggr[[2]])
-  
+
   cc = matrix(0, 2, 2)
   rownames(cc) = colnames(cc) = getTaskClassLevels(task)
   cc["R","M"] = 1

--- a/tests/testthat/test_base_generateThreshVsPerf.R
+++ b/tests/testthat/test_base_generateThreshVsPerf.R
@@ -105,7 +105,7 @@ test_that("generateThreshVsPerfData", {
   mcm = matrix(sample(0:3, size = (length(classes))^2, TRUE), ncol = length(classes))
   rownames(mcm) = colnames(mcm) = classes
   costs = makeCostMeasure(id = "asym.costs", name = "Asymmetric costs",
-                          minimize = TRUE, costs = mcm, binaryclass.task, combine = mean)
+                          minimize = TRUE, costs = mcm, combine = mean)
   pvs.custom = generateThreshVsPerfData(pred, costs)
   plotThreshVsPerf(pvs.custom)
   ggsave(path)


### PR DESCRIPTION
I removed the parameter "task" from the function makeCostMeasure and modified the function in the way that it now gets the same information by pred$task.desc for varifying the matrix names.