### PR TITLE
improve regression randomForestSRCSyn

### DIFF
--- a/tests/testthat/test_regr_randomForestSRCSyn.R
+++ b/tests/testthat/test_regr_randomForestSRCSyn.R
@@ -7,17 +7,17 @@ test_that("regr_randomForestSRCSyn", {
     list(),
     list(ntree = 10L),
     list(ntree = 5L, mtry = 4L),
-    list(ntree = 5L, nodesize = 2L, na.action = "na.impute")
+    list(ntree = 5L, nodesize = 2L, nsplit = 5, splitrule = "random")
   )
   old.predicts.list = list()
 
   for (i in 1L:length(parset.list)) {
     parset = parset.list[[i]]
-    parset = c(parset, list(data = regr.train, formula = regr.formula, newdata = regr.test,
-     importance = "none", proximity = FALSE, forest = TRUE, verbose = FALSE))
+    parset = c(parset, list(data = regr.train, formula = regr.formula, forest = TRUE, na.action = "na.impute", verbose = FALSE))
     set.seed(getOption("mlr.debug.seed"))
-    p = do.call(randomForestSRC::rfsrcSyn, parset)$rfSynPred$predicted
-    # versison 2.0 of randomForestSRC returns an array here :(
+    m = do.call(randomForestSRC::rfsrcSyn, parset)
+    p = randomForestSRC::rfsrcSyn(object = m, newdata = regr.test, na.action = "na.impute", verbose = FALSE, membership = FALSE)$rfSynPred$predicted    
+    # version > 2.0 of randomForestSRC returns an array here :(
     old.predicts.list[[i]] = as.numeric(p)
   }
 


### PR DESCRIPTION
See #602. 
* extended and corrected parameter set
* changed `trainLearner` and `predictLearner` methods such that the synthetic forest is actually trained when calling `trainLearner`. (Before it was trained in `predictLearner`.)