### PR TITLE
#812 fixes bug in convertBMRToRankMatrix

### DIFF
--- a/R/convertBMRToRankMatrix.R
+++ b/R/convertBMRToRankMatrix.R
@@ -47,8 +47,9 @@ convertBMRToRankMatrix = function(bmr, measure = NULL, ties.method = "average", 
   # convert into matrix, rows = leaner, cols = tasks
   df = reshape2::melt(df, c("task.id", "learner.id"), "alg.rank")
   df = reshape2::dcast(df, learner.id ~ task.id )
-  rownames(df) = df$learner.id
-  mat = as.matrix(df[,colnames(df) != "learner.id"])
-
+  task.id.names = setdiff(colnames(df), "learner.id")
+  mat = as.matrix(df[, task.id.names])
+  rownames(mat) = df$learner.id
+  colnames(mat) = task.id.names
   return(mat)
 }

--- a/tests/testthat/test_base_convertBMRToRankMatrix.R
+++ b/tests/testthat/test_base_convertBMRToRankMatrix.R
@@ -32,4 +32,10 @@ test_that("convertBMRToRankMatrix", {
   r = convertBMRToRankMatrix(res, featperc, ties.method = "average")
   expect_equal(as.numeric(r[,1]), c(1.5, 1.5))
   expect_equal(as.numeric(r[,2]), c(1.5, 1.5))
+
+  # check that col and row names are right if only one task is given
+  res = benchmark(lrns, binaryclass.task, rdesc, meas)
+  r = convertBMRToRankMatrix(res)
+  expect_equivalent(rownames(r), getBMRLearnerIds(res))
+  expect_equivalent(colnames(r), getBMRTaskIds(res))
 })


### PR DESCRIPTION
Fixes a bug we had where the dim names were not passed correctly, if the bmr had only one task