### PR TITLE
Add OS files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ src/*.dll
 tests/testthat/Rplots.pdf
 testinfo.RData
 inst/doc/
+.directory
+.gdb_history
+.DS_Store
+ehthumbs.db
+Icon?
+Thumbs.db


### PR DESCRIPTION
- [x] base tests passed

Not really an "issue", but this makes git ignore some OS cruft files - especially DS_Store for those developing on OSX