### PR TITLE
#815 fix rank.correlation to only accept continuous features

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -211,8 +211,8 @@ makeFilter(
   name = "rank.correlation",
   desc = "Spearman's correlation between feature and target",
   pkg  = "FSelector",
-  supported.tasks = c("regr"),
-  supported.features = c("numerics", "factors"),
+  supported.tasks = "regr",
+  supported.features = "numerics",
   fun = function(task, nselect, ...) {
     y = FSelector::rank.correlation(getTaskFormula(task), data = getTaskData(task))
     setNames(y[["attr_importance"]], getTaskFeatureNames(task))


### PR DESCRIPTION
Fixes #815 so rank.correlation correctly only accepts continuous features. This will also need to be fixed on the tutorial at https://mlr-org.github.io/mlr-tutorial/release/html/filter_methods/index.html but I'm not sure how to update that?