### PR TITLE
Adds a check for learner properties...

### DIFF
--- a/R/CostSensWeightedPairsWrapper.R
+++ b/R/CostSensWeightedPairsWrapper.R
@@ -20,7 +20,7 @@
 #' @family costsens
 #' @aliases CostSensWeightedPairsWrapper CostSensWeightedPairsModel
 makeCostSensWeightedPairsWrapper = function(learner) {
-  learner = checkLearnerClassif(learner, weights = TRUE)
+  learner = checkLearnerClassif(learner, props = "weights")
   learner = setPredictType(learner, "response")
   id = paste("costsens", learner$id, sep = ".")
   makeHomogeneousEnsemble(id, "costsens", learner, package = learner$package,

--- a/R/checkLearner.R
+++ b/R/checkLearner.R
@@ -7,14 +7,15 @@ checkLearner = function(learner, type = NULL, props = NULL, ...) {
   else
     assertClass(learner, classes = "Learner")
   if (!is.null(props)){
+    assertSubset(props, getSupportedLearnerProperties())
     learner.props = getLearnerProperties(learner)
     missing.props = setdiff(props, learner.props)
     if (length(missing.props) != 0){
-      stopf("Learner '%s' must support '%s', but does not!", learner$id, collapse(missing.props))
+      stopf("Learner '%s' must support all properties '%s', but does not support '%s'.", learner$id, collapse(props), collapse(missing.props))
     }
   }
   if (!is.null(type) && learner$type %nin% type)
-    stopf("Learner '%s' must be of type '%s', not: '%s'", learner$id, collapse(type, ','), learner$type)
+    stopf("Learner '%s' must be of type '%s', not: '%s'", learner$id, collapse(type), learner$type)
   setHyperPars(learner, ...)
 }
 
@@ -25,3 +26,4 @@ checkLearnerClassif = function(learner, props = NULL) {
 checkLearnerRegr = function(learner, props = NULL) {
   checkLearner(learner, "regr", props)
 }
+

--- a/R/checkLearner.R
+++ b/R/checkLearner.R
@@ -1,19 +1,27 @@
-checkLearner = function(learner, type = NULL, weights = FALSE, ...) {
+# props checks if Learner has one or more properties specified in props as a 
+# character vector.
+
+checkLearner = function(learner, type = NULL, props = NULL, ...) {
   if (is.character(learner))
     learner = makeLearner(learner)
   else
     assertClass(learner, classes = "Learner")
+  if (!is.null(props)){
+    learner.props = getLearnerProperties(learner)
+    missing.props = setdiff(props, learner.props)
+    if (length(missing.props) != 0){
+      stopf("Learner '%s' must support '%s', but does not!", learner$id, collapse(missing.props))
+    }
+  }
   if (!is.null(type) && learner$type %nin% type)
     stopf("Learner '%s' must be of type '%s', not: '%s'", learner$id, collapse(type, ','), learner$type)
-  if (weights && !hasLearnerProperties(learner, "weights"))
-    stopf("Learner '%s' must support weights, but does not!", learner$id)
   setHyperPars(learner, ...)
 }
 
-checkLearnerClassif = function(learner, weights = FALSE) {
-  checkLearner(learner, "classif", weights)
+checkLearnerClassif = function(learner, props = NULL) {
+  checkLearner(learner, "classif", props)
 }
 
-checkLearnerRegr = function(learner, weights = FALSE) {
-  checkLearner(learner, "regr", weights)
+checkLearnerRegr = function(learner, props = NULL) {
+  checkLearner(learner, "regr", props)
 }


### PR DESCRIPTION
... and removes check for weights.
checkLearnerBeforeTrain.R could be adapted based upon this PR. This would make it possible to check multiple properties at once, but the error message would be a bit less concise.