### PR TITLE
remove upper limit for glmnet's parameter s

### DIFF
--- a/R/RLearner_classif_glmnet.R
+++ b/R/RLearner_classif_glmnet.R
@@ -5,7 +5,7 @@ makeRLearner.classif.glmnet = function() {
     package = "glmnet",
     par.set = makeParamSet(
       makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1),
-      makeNumericLearnerParam(id = "s", default = 0.01, lower = 0, upper = 1, when = "predict"),
+      makeNumericLearnerParam(id = "s", default = 0.01, lower = 0, when = "predict"),
       makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),
       makeNumericLearnerParam(id = "lambda.min.ratio", lower = 0, upper = 1),

--- a/R/RLearner_regr_glmnet.R
+++ b/R/RLearner_regr_glmnet.R
@@ -6,7 +6,7 @@ makeRLearner.regr.glmnet = function() {
     par.set = makeParamSet(
       makeDiscreteLearnerParam(id = "family", values = c("gaussian", "poisson"), default = "gaussian"),
       makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1),
-      makeNumericLearnerParam(id = "s", default = 0.01, lower = 0, upper = 1, when = "predict"),
+      makeNumericLearnerParam(id = "s", default = 0.01, lower = 0, when = "predict"),
       makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),
       makeNumericLearnerParam(id = "lambda.min.ratio", lower = 0, upper = 1),

--- a/R/RLearner_surv_glmnet.R
+++ b/R/RLearner_surv_glmnet.R
@@ -5,7 +5,7 @@ makeRLearner.surv.glmnet = function() {
     package = "glmnet",
     par.set = makeParamSet(
       makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1),
-      makeNumericLearnerParam(id = "s", default = 0.01, lower = 0, upper = 1, when = "predict"),
+      makeNumericLearnerParam(id = "s", default = 0.01, lower = 0, when = "predict"),
       makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),
       makeNumericLearnerParam(id = "lambda.min.ratio", lower = 0, upper = 1),


### PR DESCRIPTION
As far as I can tell parameter `s` of glmnet may have values `> 1`. Don't know why there is an upper limit in the param set.