### PR TITLE
set respect.unordered.factors for ranger learners

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,7 @@ mlr_2.9:
 - subsetTask, getTaskData: arg "features" now also accepts logical and integer
 - normalizeFeatures, createDummyFeatures: arg 'exclude' was replaced by 'cols'
 - normalizeFeatures is now S3 and can be called also on data.frames
+- classif.ranger, regr.ranger and surv.ranger: now respect unordered factors by default
 
 - new learners
 -- classif.C50

--- a/R/RLearner_classif_ranger.R
+++ b/R/RLearner_classif_ranger.R
@@ -22,11 +22,11 @@ makeRLearner.classif.ranger = function() {
       makeLogicalLearnerParam(id = "verbose", default = TRUE, when = "both", tunable = FALSE),
       makeIntegerLearnerParam(id = "seed", when = "both", tunable = FALSE)
     ),
-    par.vals = list(num.threads = 1L, verbose = FALSE),
+    par.vals = list(num.threads = 1L, verbose = FALSE, respect.unordered.factors = TRUE),
     properties = c("twoclass", "multiclass", "prob", "numerics", "factors", "ordered"),
     name = "Random Forests",
     short.name = "ranger",
-    note = "By default, internal parallelization is switched off (`num.threads = 1`) and `verbose` output is disabled. Both settings are changeable."
+    note = "By default, internal parallelization is switched off (`num.threads = 1`), `verbose` output is disabled and `respect.unordered.factors` is set to `TRUE`. All settings are changeable."
   )
 }
 

--- a/R/RLearner_regr_ranger.R
+++ b/R/RLearner_regr_ranger.R
@@ -21,11 +21,11 @@ makeRLearner.regr.ranger = function() {
       makeLogicalLearnerParam(id = "verbose", default = TRUE, when = "both", tunable = FALSE),
       makeIntegerLearnerParam(id = "seed", when = "both", tunable = FALSE)
     ),
-    par.vals = list(num.threads = 1L, verbose = FALSE),
+    par.vals = list(num.threads = 1L, verbose = FALSE, respect.unordered.factors = TRUE),
     properties = c("numerics", "factors", "ordered"),
     name = "Random Forests",
     short.name = "ranger",
-    note = "By default, internal parallelization is switched off (`num.threads = 1`) and `verbose` output is disabled. Both settings are changeable."
+    note = "By default, internal parallelization is switched off (`num.threads = 1`), `verbose` output is disabled and `respect.unordered.factors` is set to `TRUE`. All settings are changeable."
   )
 }
 

--- a/R/RLearner_surv_ranger.R
+++ b/R/RLearner_surv_ranger.R
@@ -22,11 +22,11 @@ makeRLearner.surv.ranger = function() {
       makeIntegerLearnerParam(id = "seed", when = "both", tunable = FALSE),
       makeDiscreteLearnerParam(id = "splitrule", values = c("logrank", "C"), default = "logrank")
     ),
-    par.vals = list(num.threads = 1L, verbose = FALSE),
-    properties = c("numerics", "factors", "ordered", "rcens"),
+    par.vals = list(num.threads = 1L, verbose = FALSE, respect.unordered.factors = TRUE),
+    properties = c("numerics", "factors", "ordered", "rcens", "prob"),
     name = "Random Forests",
     short.name = "ranger",
-    note = "By default, internal parallelization is switched off (`num.threads = 1`) and `verbose` output is disabled. Both settings are changeable."
+    note = "By default, internal parallelization is switched off (`num.threads = 1`), `verbose` output is disabled and `respect.unordered.factors` is set to `TRUE`. All settings are changeable."
   )
 }
 

--- a/tests/testthat/test_classif_ranger.R
+++ b/tests/testthat/test_classif_ranger.R
@@ -14,7 +14,7 @@ test_that("classif_ranger", {
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    parset = c(parset, list(data = binaryclass.train, formula = binaryclass.formula, write.forest = TRUE, probability = TRUE))
+    parset = c(parset, list(data = binaryclass.train, formula = binaryclass.formula, write.forest = TRUE, probability = TRUE, respect.unordered.factors = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(ranger::ranger, parset)
     p  = predict(m, data = binaryclass.test)

--- a/tests/testthat/test_regr_ranger.R
+++ b/tests/testthat/test_regr_ranger.R
@@ -13,7 +13,7 @@ test_that("regr_ranger", {
 
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    parset = c(parset, list(data = regr.train, formula = regr.formula, write.forest = TRUE))
+    parset = c(parset, list(data = regr.train, formula = regr.formula, write.forest = TRUE, respect.unordered.factors = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(ranger::ranger, parset)
     p  = predict(m, data = regr.test)

--- a/tests/testthat/test_surv_ranger.R
+++ b/tests/testthat/test_surv_ranger.R
@@ -20,7 +20,7 @@ test_that("surv_ranger", {
   old.predicts.list = list()
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    pars = list(formula = surv.formula, data = surv.train, write.forest = TRUE)
+    pars = list(formula = surv.formula, data = surv.train, write.forest = TRUE, respect.unordered.factors = TRUE)
     pars = c(pars, parset)
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(ranger::ranger, pars)


### PR DESCRIPTION
According to http://www.r-bloggers.com/on-ranger-respect-unordered-factors/, `respect.unordered.factors` set to `TRUE` seems to be a better default.

Or is the blog post wrong, @mnwright?