### PR TITLE
Fixes survival learners from penalized package (somewhat related to #840)

### DIFF
--- a/R/RLearner_surv_penalized_fusedlasso.R
+++ b/R/RLearner_surv_penalized_fusedlasso.R
@@ -17,7 +17,7 @@ makeRLearner.surv.penalized.fusedlasso = function() {
       makeLogicalLearnerParam(id = "standardize", default = FALSE),
       makeLogicalLearnerParam(id = "trace", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(lambda1 = 1, lambda2 = 1),
+    par.vals = list(lambda1 = 1, lambda2 = 1, trace = FALSE),
     properties = c("numerics", "factors", "ordered", "rcens"),
     name = "Fused Lasso Regression",
     short.name = "fusedlasso",
@@ -27,15 +27,24 @@ makeRLearner.surv.penalized.fusedlasso = function() {
 
 #' @export
 trainLearner.surv.penalized.fusedlasso = function(.learner, .task, .subset, .weights = NULL,  ...) {
-  f = getTaskFormula(.task)
-  penalized::penalized(f, data = getTaskData(.task, subset = .subset), model = "cox", fusedl = TRUE, ...)
+  data = getTaskData(.task, subset = .subset, target.extra = TRUE, recode.target = "rcens")
+  info = getFixDataInfo(data$data, factors.to.dummies = TRUE, ordered.to.int = TRUE)
+  data$data = as.matrix(fixDataForLearner(data$data, info))
+  attachTrainingInfo(
+    penalized::penalized(response = data$target, penalized = data$data, model = "cox",
+      fusedl = TRUE, ...),
+    info
+  )
 }
 
 #' @export
 predictLearner.surv.penalized.fusedlasso = function(.learner, .model, .newdata, ...) {
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model,
+      penalized = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_fusedlasso.R
+++ b/R/RLearner_surv_penalized_fusedlasso.R
@@ -35,7 +35,7 @@ trainLearner.surv.penalized.fusedlasso = function(.learner, .task, .subset, .wei
 predictLearner.surv.penalized.fusedlasso = function(.learner, .model, .newdata, ...) {
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_lasso.R
+++ b/R/RLearner_surv_penalized_lasso.R
@@ -26,18 +26,23 @@ makeRLearner.surv.penalized.lasso = function() {
 
 #' @export
 trainLearner.surv.penalized.lasso = function(.learner, .task, .subset, .weights = NULL,  ...) {
-  f = getTaskFormula(.task)
-  penalized::penalized(f, data = getTaskData(.task, subset = .subset),
-    model = "cox", fusedl = FALSE, ...)
+  data = getTaskData(.task, subset = .subset, target.extra = TRUE, recode.target = "rcens")
+  info = getFixDataInfo(data$data, factors.to.dummies = TRUE, ordered.to.int = TRUE)
+  data$data = as.matrix(fixDataForLearner(data$data, info))
+  attachTrainingInfo(
+    penalized::penalized(response = data$target, penalized = data$data, model = "cox",
+      fusedl = FALSE, ...),
+    info
+  )
 }
 
 #' @export
 predictLearner.surv.penalized.lasso = function(.learner, .model, .newdata, ...) {
-  #info = getTrainingInfo(.model)
-  #.newdata = as.matrix(fixDataForLearner(.newdata, info))
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_lasso.R
+++ b/R/RLearner_surv_penalized_lasso.R
@@ -37,7 +37,7 @@ predictLearner.surv.penalized.lasso = function(.learner, .model, .newdata, ...) 
   #.newdata = as.matrix(fixDataForLearner(.newdata, info))
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_ridge.R
+++ b/R/RLearner_surv_penalized_ridge.R
@@ -26,16 +26,23 @@ makeRLearner.surv.penalized.ridge = function() {
 
 #' @export
 trainLearner.surv.penalized.ridge = function(.learner, .task, .subset, .weights = NULL,  ...) {
-  f = getTaskFormula(.task)
-  penalized::penalized(f, data = getTaskData(.task, subset = .subset),
-    model = "cox", fusedl = FALSE, ...)
+  data = getTaskData(.task, subset = .subset, target.extra = TRUE, recode.target = "rcens")
+  info = getFixDataInfo(data$data, factors.to.dummies = TRUE, ordered.to.int = TRUE)
+  data$data = as.matrix(fixDataForLearner(data$data, info))
+  attachTrainingInfo(
+    penalized::penalized(response = data$target, penalized = data$data, model = "cox",
+      fusedl = FALSE, ...),
+    info
+  )
 }
 
 #' @export
 predictLearner.surv.penalized.ridge = function(.learner, .model, .newdata, ...) {
+  info = getTrainingInfo(.model)
+  .newdata = as.matrix(fixDataForLearner(.newdata, info))
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_ridge.R
+++ b/R/RLearner_surv_penalized_ridge.R
@@ -35,7 +35,7 @@ trainLearner.surv.penalized.ridge = function(.learner, .task, .subset, .weights 
 predictLearner.surv.penalized.ridge = function(.learner, .model, .newdata, ...) {
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/tests/testthat/test_surv_penalized_fusedlasso.R
+++ b/tests/testthat/test_surv_penalized_fusedlasso.R
@@ -11,19 +11,31 @@ test_that("surv_penalized_fusedlasso", {
 
   old.predicts.list = list()
 
+  # survival learners did not work for factors
+  surv.df$fac = factor(sample(c("a", "b"), nrow(surv.df), replace = TRUE,
+    prob = c(0.2, 0.8)))
+  surv.train = surv.df[surv.train.inds, ]
+  surv.test = surv.df[surv.test.inds, ]
+  surv.train.feats = surv.train[, names(surv.train) %nin% surv.target]
+  surv.train.feats = as.matrix(createDummyFeatures(surv.train.feats))
+  surv.test.feats = surv.test[, names(surv.test) %nin% surv.target]
+  surv.test.feats = as.matrix(createDummyFeatures(surv.test.feats))
+  
   for (i in 1:length(parset.list)) {
     if (is.null(parset.list[[i]]$lambda1))
       parset.list[[i]]$lambda1 = 1
     if (is.null(parset.list[[i]]$lambda2))
       parset.list[[i]]$lambda2 = 1
-    pars = c(list(response = surv.formula, data = surv.train[, -7L],
+    pars = c(list(response = Surv(surv.train$time, surv.train$status, type = "right"),
+      penalized = surv.train.feats,
       model = "cox", trace = FALSE, fusedl = TRUE), parset.list[[i]])
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(penalized::penalized, pars)
     p = penalized::survival(penalized::predict(m,
-      penalized = model.matrix(surv.formula, surv.test[, -7L])[, -1L]), Inf)
+      penalized = surv.test.feats), Inf)
     old.predicts.list[[i]] = p
   }
-  testSimpleParsets("surv.penalized.fusedlasso", surv.df[, -7L], surv.target,
+  testSimpleParsets("surv.penalized.fusedlasso", surv.df, surv.target,
     surv.train.inds, old.predicts.list, parset.list)
 })
+

--- a/tests/testthat/test_surv_penalized_lasso.R
+++ b/tests/testthat/test_surv_penalized_lasso.R
@@ -10,15 +10,28 @@ test_that("surv_penalized_lasso", {
 
   old.predicts.list = list()
 
+  # survival learners did not work for factors
+  surv.df$fac = factor(sample(c("a", "b"), nrow(surv.df), replace = TRUE,
+    prob = c(0.2, 0.8)))
+  surv.train = surv.df[surv.train.inds, ]
+  surv.test = surv.df[surv.test.inds, ]
+  surv.train.feats = surv.train[, names(surv.train) %nin% surv.target]
+  surv.train.feats = as.matrix(createDummyFeatures(surv.train.feats))
+  surv.test.feats = surv.test[, names(surv.test) %nin% surv.target]
+  surv.test.feats = as.matrix(createDummyFeatures(surv.test.feats))
   for (i in 1:length(parset.list)) {
-    pars = c(list(response = surv.formula, data = surv.train[, -7L],
-      model = "cox", trace = FALSE), parset.list[[i]])
+    pars = c(list(response = Surv(surv.train$time, surv.train$status, type = "right"),
+      penalized = surv.train.feats,
+      model = "cox", trace = FALSE, fusedl = FALSE), parset.list[[i]])
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(penalized::penalized, pars)
     p = penalized::survival(penalized::predict(m,
-      penalized = model.matrix(surv.formula, surv.test[, -7L])[, -1L]), Inf)
+      penalized = surv.test.feats), Inf)
     old.predicts.list[[i]] = p
   }
-  testSimpleParsets("surv.penalized.lasso", surv.df[, -7L], surv.target,
+  
+  testSimpleParsets("surv.penalized.lasso", surv.df, surv.target,
     surv.train.inds, old.predicts.list, parset.list)
 })
+
+

--- a/tests/testthat/test_surv_penalized_ridge.R
+++ b/tests/testthat/test_surv_penalized_ridge.R
@@ -9,16 +9,27 @@ test_that("surv_penalized_ridge", {
   )
 
   old.predicts.list = list()
-
+  
+  # survival learners did not work for factors
+  surv.df$fac = factor(sample(c("a", "b"), nrow(surv.df), replace = TRUE,
+    prob = c(0.2, 0.8)))
+  surv.train = surv.df[surv.train.inds, ]
+  surv.test = surv.df[surv.test.inds, ]
+  surv.train.feats = surv.train[, names(surv.train) %nin% surv.target]
+  surv.train.feats = as.matrix(createDummyFeatures(surv.train.feats))
+  surv.test.feats = surv.test[, names(surv.test) %nin% surv.target]
+  surv.test.feats = as.matrix(createDummyFeatures(surv.test.feats))
   for (i in 1:length(parset.list)) {
-    pars = c(list(response = surv.formula, data = surv.train[, -7L],
-      trace = FALSE, model = "cox", fused = FALSE), parset.list[[i]])
+    pars = c(list(response = Surv(surv.train$time, surv.train$status, type = "right"),
+      penalized = surv.train.feats,
+      model = "cox", trace = FALSE, fusedl = FALSE), parset.list[[i]])
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(penalized::penalized, pars)
     p = penalized::survival(penalized::predict(m,
-      penalized = model.matrix(surv.formula, surv.test[, -7L])[, -1L]), Inf)
+      penalized = surv.test.feats), Inf)
     old.predicts.list[[i]] = p
   }
-  testSimpleParsets("surv.penalized.ridge", surv.df[, -7L], surv.target,
+
+  testSimpleParsets("surv.penalized.ridge", surv.df, surv.target,
     surv.train.inds, old.predicts.list, parset.list)
 })


### PR DESCRIPTION
The survival learners from the penalized package were broken.
E.g: They were throwing an error for factor features.
@MariaErdmann detected this while she was working on #874 and we fixed it together.