### PR TITLE
Fix survival learners from penalized package II (shall replace #921)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -104,7 +104,7 @@ Suggests:
     numDeriv,
     pamr,
     party,
-    penalized (>= 0.9-46),
+    penalized (>= 0.9-47),
     pls,
     PMCMR (>= 4.1),
     pROC (>= 1.8),

--- a/R/RLearner_surv_penalized_fusedlasso.R
+++ b/R/RLearner_surv_penalized_fusedlasso.R
@@ -17,7 +17,7 @@ makeRLearner.surv.penalized.fusedlasso = function() {
       makeLogicalLearnerParam(id = "standardize", default = FALSE),
       makeLogicalLearnerParam(id = "trace", default = FALSE, tunable = FALSE)
     ),
-    par.vals = list(lambda1 = 1, lambda2 = 1),
+    par.vals = list(lambda1 = 1, lambda2 = 1, trace = FALSE),
     properties = c("numerics", "factors", "ordered", "rcens"),
     name = "Fused Lasso Regression",
     short.name = "fusedlasso",
@@ -35,7 +35,7 @@ trainLearner.surv.penalized.fusedlasso = function(.learner, .task, .subset, .wei
 predictLearner.surv.penalized.fusedlasso = function(.learner, .model, .newdata, ...) {
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_lasso.R
+++ b/R/RLearner_surv_penalized_lasso.R
@@ -37,7 +37,7 @@ predictLearner.surv.penalized.lasso = function(.learner, .model, .newdata, ...) 
   #.newdata = as.matrix(fixDataForLearner(.newdata, info))
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/R/RLearner_surv_penalized_ridge.R
+++ b/R/RLearner_surv_penalized_ridge.R
@@ -35,7 +35,7 @@ trainLearner.surv.penalized.ridge = function(.learner, .task, .subset, .weights 
 predictLearner.surv.penalized.ridge = function(.learner, .model, .newdata, ...) {
   if(.learner$predict.type == "response") {
     # Note: this is a rather ugly hack but should work according to Jelle
-    penalized::survival(penalized::predict(.model$learner.model, penalized = .newdata), Inf)
+    penalized::survival(penalized::predict(.model$learner.model, data = .newdata), Inf)
   } else {
     stop("Unknown predict type")
   }

--- a/tests/testthat/test_surv_penalized_fusedlasso.R
+++ b/tests/testthat/test_surv_penalized_fusedlasso.R
@@ -16,14 +16,13 @@ test_that("surv_penalized_fusedlasso", {
       parset.list[[i]]$lambda1 = 1
     if (is.null(parset.list[[i]]$lambda2))
       parset.list[[i]]$lambda2 = 1
-    pars = c(list(response = surv.formula, data = surv.train[, -7L],
+    pars = c(list(response = surv.formula, data = surv.train,
       model = "cox", trace = FALSE, fusedl = TRUE), parset.list[[i]])
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(penalized::penalized, pars)
-    p = penalized::survival(penalized::predict(m,
-      penalized = model.matrix(surv.formula, surv.test[, -7L])[, -1L]), Inf)
+    p = penalized::survival(penalized::predict(m, data = surv.test), Inf)
     old.predicts.list[[i]] = p
   }
-  testSimpleParsets("surv.penalized.fusedlasso", surv.df[, -7L], surv.target,
+  testSimpleParsets("surv.penalized.fusedlasso", surv.df, surv.target,
     surv.train.inds, old.predicts.list, parset.list)
 })

--- a/tests/testthat/test_surv_penalized_lasso.R
+++ b/tests/testthat/test_surv_penalized_lasso.R
@@ -11,14 +11,13 @@ test_that("surv_penalized_lasso", {
   old.predicts.list = list()
 
   for (i in 1:length(parset.list)) {
-    pars = c(list(response = surv.formula, data = surv.train[, -7L],
+    pars = c(list(response = surv.formula, data = surv.train,
       model = "cox", trace = FALSE), parset.list[[i]])
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(penalized::penalized, pars)
-    p = penalized::survival(penalized::predict(m,
-      penalized = model.matrix(surv.formula, surv.test[, -7L])[, -1L]), Inf)
+    p = penalized::survival(penalized::predict(m, data = surv.test), Inf)
     old.predicts.list[[i]] = p
   }
-  testSimpleParsets("surv.penalized.lasso", surv.df[, -7L], surv.target,
+  testSimpleParsets("surv.penalized.lasso", surv.df, surv.target,
     surv.train.inds, old.predicts.list, parset.list)
 })

--- a/tests/testthat/test_surv_penalized_ridge.R
+++ b/tests/testthat/test_surv_penalized_ridge.R
@@ -11,14 +11,13 @@ test_that("surv_penalized_ridge", {
   old.predicts.list = list()
 
   for (i in 1:length(parset.list)) {
-    pars = c(list(response = surv.formula, data = surv.train[, -7L],
+    pars = c(list(response = surv.formula, data = surv.train,
       trace = FALSE, model = "cox", fused = FALSE), parset.list[[i]])
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(penalized::penalized, pars)
-    p = penalized::survival(penalized::predict(m,
-      penalized = model.matrix(surv.formula, surv.test[, -7L])[, -1L]), Inf)
+    p = penalized::survival(penalized::predict(m, data = surv.test), Inf)
     old.predicts.list[[i]] = p
   }
-  testSimpleParsets("surv.penalized.ridge", surv.df[, -7L], surv.target,
+  testSimpleParsets("surv.penalized.ridge", surv.df, surv.target,
     surv.train.inds, old.predicts.list, parset.list)
 })


### PR DESCRIPTION
After taking a closer look at #921, we figured a better way to fix penalized survival learners:
In the predict()-function we use data = instead of penalized =. The tests were adapted accordingly.
This change requires the penalized package version >= 0.9-47 (see DESCRIPTION).
Additionally, in surv_penalized_fusedlasso trace = FALSE in par.vals() was missing. This disables output logging by default (see note).
What I did not do (yet): changing the tests in a way that they test if the penalized survival learners can handle factors. This is what @larskotthoff commented on #921. This will be implemented in a script called test_learners_all_surv (which I want to do a PR on asap).
So my question is: Shall the helper objects for surv.task be adapted such that they contain a factor and then adapt the tests for the penalized survival learners? Or will a test implemented in test_learners_all_surv (which will test all survial learners with property "factors") be enough?
