### PR TITLE
Added parameter 'grouped' in surv_cvglmnet 

### DIFF
--- a/R/RLearner_surv_cvglmnet.R
+++ b/R/RLearner_surv_cvglmnet.R
@@ -8,6 +8,7 @@ makeRLearner.surv.cvglmnet = function() {
       makeIntegerLearnerParam(id = "nfolds", default = 10L, lower = 3L),
       makeDiscreteLearnerParam(id = "type.measure", values = c("deviance"), default = "deviance"),
       makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
+      makeLogicalLearnerParam(id = "grouped", default = TRUE),
       makeDiscreteLearnerParam(id = "s", values = c("lambda.1se", "lambda.min"), default = "lambda.1se", when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),
       makeNumericLearnerParam(id = "lambda.min.ratio", lower = 0, upper = 1),

--- a/tests/testthat/test_surv_cvglmnet.R
+++ b/tests/testthat/test_surv_cvglmnet.R
@@ -5,7 +5,7 @@ test_that("surv_cvglmnet", {
 
   parset.list = list(
     list(),
-    list(alpha = 0.3),
+    list(alpha = 0.3, grouped = FALSE),
     list(alpha = 1, nlambda = 10),
     list(prec = 1e-3)
   )

--- a/tests/testthat/test_surv_cvglmnet.R
+++ b/tests/testthat/test_surv_cvglmnet.R
@@ -5,7 +5,7 @@ test_that("surv_cvglmnet", {
 
   parset.list = list(
     list(),
-    list(alpha = 0.3, grouped = FALSE),
+    list(alpha = 0.3),
     list(alpha = 1, nlambda = 10),
     list(prec = 1e-3)
   )


### PR DESCRIPTION
... and changed tests accordingly
I recognized that this parameter was missing. It is set to TRUE by default (then the "CV partial likelihood for the kth fold is obtained by substraction"). Setting it to FALSE will compute the log partial likelihood on the kth fold. 
But when there are less than three observations in a fold, grouped = TRUE will be enforced by cv.glmnet itself. Actually, this also happens in the test (because of the 'small' training set??). Therefore, one gets following warning:
1. surv_cvglmnet (@test_surv_cvglmnet.R#29) - Option grouped=TRUE enforced for cv.coxnet, since < 3 observations per fold
So I am not sure, if we want this parameter then or if I shall adapt the test (increasing training set or number of obs) or if everything is just alright.