### PR TITLE
#872 remove rfsrc filters for sequential testing

### DIFF
--- a/tests/testthat/test_featsel_filters.R
+++ b/tests/testthat/test_featsel_filters.R
@@ -6,9 +6,14 @@ test_that("filterFeatures", {
   # Loop through all filters
   filter.list = listFilterMethods(desc = FALSE, tasks = TRUE, features = FALSE)
   filter.list.classif = as.character(filter.list$id)[filter.list$task.classif]
-  # univariate.model.score and permutation.importance are handled extra test below
-  # 'univariate' is deprecated
-  filter.list.classif = setdiff(filter.list.classif, c("univariate.model.score", "permutation.importance", "univariate"))
+  # univariate.model.score and permutation.importance are handled extra test 
+  # below 'univariate' is deprecated
+  # rf.* tests removed to avoid sequential testing errors
+  filter.list.classif = setdiff(filter.list.classif, c("univariate.model.score", 
+                                                       "permutation.importance", 
+                                                       "univariate",
+                                                       "rf.importance",
+                                                       "rf.min.depth"))
   for (filter in filter.list.classif) {
     filterFeatures(task = multiclass.task, method = filter, perc = 0.5)
   }


### PR DESCRIPTION
It seems the only way to avoid this error is to remove rf.* from filters which I would assume we wouldn't want to do...putting this here just in case if not we can delete branch