### PR TITLE
Print hyperpars string NAs

### DIFF
--- a/R/Learner.R
+++ b/R/Learner.R
@@ -27,7 +27,7 @@ print.Learner = function(x, ...) {
     "Class: ", class(x)[1L], "\n",
     "Properties: ", collapse(getLearnerProperties(x)), "\n",
     "Predict-Type: ", x$predict.type, "\n",
-    "Hyperparameters: ", getHyperParsString(x), "\n\n",
+    "Hyperparameters: ", getHyperParsString(x, show.missing.values = TRUE), "\n\n",
     sep =""
   )
 }

--- a/R/RLearner_classif_xgboost.R
+++ b/R/RLearner_classif_xgboost.R
@@ -22,7 +22,7 @@ makeRLearner.classif.xgboost = function() {
       makeUntypedLearnerParam(id = "eval_metric", default = "error"),
       makeNumericLearnerParam(id = "base_score", default = 0.5),
 
-      makeNumericLearnerParam(id = "missing", default = 0, tunable = FALSE),
+      makeNumericLearnerParam(id = "missing", default = 0, tunable = FALSE, when = "both"),
       makeIntegerLearnerParam(id = "nthread", default = 16,lower = 1),
       makeIntegerLearnerParam(id = "nrounds", default = 1, lower = 1),
       # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant

--- a/R/RLearner_classif_xgboost.R
+++ b/R/RLearner_classif_xgboost.R
@@ -22,7 +22,7 @@ makeRLearner.classif.xgboost = function() {
       makeUntypedLearnerParam(id = "eval_metric", default = "error"),
       makeNumericLearnerParam(id = "base_score", default = 0.5),
 
-      makeNumericLearnerParam(id = "missing", default = 0),
+      makeNumericLearnerParam(id = "missing", default = 0, tunable = FALSE),
       makeIntegerLearnerParam(id = "nthread", default = 16,lower = 1),
       makeIntegerLearnerParam(id = "nrounds", default = 1, lower = 1),
       # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant
@@ -32,11 +32,11 @@ makeRLearner.classif.xgboost = function() {
       makeIntegerLearnerParam(id = "early.stop.round", default = 1, lower = 1),
       makeLogicalLearnerParam(id = "maximize", default = TRUE)
     ),
-    par.vals = list(nrounds = 1),
-    properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights"),
+    par.vals = list(nrounds = 1, missing = NA_real_),
+    properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights", "missings"),
     name = "eXtreme Gradient Boosting",
     short.name = "xgboost",
-    note = "All settings are passed directly, rather than through `xgboost`'s `params` argument. `nrounds` has been set to `1` by default. `num_class` is set internally, so do not set this manually."
+    note = "All settings are passed directly, rather than through `xgboost`'s `params` argument. `nrounds` has been set to `1` by default. `num_class` is set internally, so do not set this manually. `missing` is set by default to NA, as this is how mlr expects missing values to be encoded."
   )
 }
 

--- a/R/RLearner_regr_xgboost.R
+++ b/R/RLearner_regr_xgboost.R
@@ -22,7 +22,7 @@ makeRLearner.regr.xgboost = function() {
       makeUntypedLearnerParam(id = "eval_metric", default = "rmse"),
       makeNumericLearnerParam(id = "base_score", default = 0.5),
 
-      makeNumericLearnerParam(id = "missing", default = 0),
+      makeNumericLearnerParam(id = "missing", default = 0, tunable = FALSE),
       makeIntegerLearnerParam(id = "nthread", default = 16, lower = 1),
       makeIntegerLearnerParam(id = "nrounds", default = 1, lower = 1),
       # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant
@@ -32,11 +32,11 @@ makeRLearner.regr.xgboost = function() {
       makeIntegerLearnerParam(id = "early.stop.round", default = 1, lower = 1),
       makeLogicalLearnerParam(id = "maximize", default = FALSE)
     ),
-    par.vals = list(nrounds = 1),
+    par.vals = list(nrounds = 1, missing = NA_real_, tunable = FALSE),
     properties = c("numerics", "factors", "weights"),
     name = "eXtreme Gradient Boosting",
     short.name = "xgboost",
-    note = "All settings are passed directly, rather than through `xgboost`'s `params` argument. `nrounds` has been set to `1` by default."
+    note = "All settings are passed directly, rather than through `xgboost`'s `params` argument. `nrounds` has been set to `1` by default. `missing` is set by default to NA, as this is how mlr expects missing values to be encoded."
   )
 }
 

--- a/R/RLearner_regr_xgboost.R
+++ b/R/RLearner_regr_xgboost.R
@@ -22,7 +22,7 @@ makeRLearner.regr.xgboost = function() {
       makeUntypedLearnerParam(id = "eval_metric", default = "rmse"),
       makeNumericLearnerParam(id = "base_score", default = 0.5),
 
-      makeNumericLearnerParam(id = "missing", default = 0, tunable = FALSE),
+      makeNumericLearnerParam(id = "missing", default = 0, tunable = FALSE, when = "both"),
       makeIntegerLearnerParam(id = "nthread", default = 16, lower = 1),
       makeIntegerLearnerParam(id = "nrounds", default = 1, lower = 1),
       # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant

--- a/R/WrappedModel.R
+++ b/R/WrappedModel.R
@@ -57,7 +57,7 @@ print.WrappedModel = function(x, ...) {
     "Model for learner.id=", x$learner$id, "; learner.class=", getClass1(x$learner), "\n",
     sprintf("Trained on: task.id = %s; obs = %i; features = %i",
       x$task.desc$id, length(x$subset), length(x$features)), "\n",
-    "Hyperparameters: ", getHyperParsString(x$learner), "\n",
+    "Hyperparameters: ", getHyperParsString(x$learner, show.missing.values = TRUE), "\n",
     sep = ""
   )
   if (isFailureModel(x))

--- a/R/getHyperPars.R
+++ b/R/getHyperPars.R
@@ -27,11 +27,11 @@ getHyperPars.Learner = function(learner, for.fun = c("train", "predict", "both")
   pv[ns]
 }
 
-getHyperParsString = function(learner) {
+getHyperParsString = function(learner, show.missing.values) {
   hps = getHyperPars(learner)
   ns = names(hps)
   pars = getParamSet(learner)$pars[ns]
-  s = Map(paramValueToString, pars, hps)
+  s = mapply(paramValueToString, pars, hps, MoreArgs = list(show.missing.values = show.missing.values))
   stri_paste(ns, s, sep = "=", collapse = ",")
 }
 

--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -20,5 +20,9 @@ test_that("getHyperPars", {
   expect_true(setequal(getHyperPars(lrn), list()))
 
   lrn = makeMultilabelBinaryRelevanceWrapper("classif.rpart")  
-  expect_true(setequal(getHyperPars(lrn), list(xval=0)))
+  expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
+  
+  #Missing values should not be ommited
+  lrn = makeLearner("classif.xgboost")
+  expect_true(setequal(getHyperPars(lrn), list(nrounes = 1, missing = NA)))
 })

--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -22,7 +22,10 @@ test_that("getHyperPars", {
   lrn = makeMultilabelBinaryRelevanceWrapper("classif.rpart")  
   expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
   
-  #Missing values should not be ommited
+  #Missing values should not be ommited and printed
   lrn = makeLearner("classif.xgboost")
-  expect_true(setequal(getHyperPars(lrn), list(nrounes = 1, missing = NA)))
+  expect_true(setequal(getHyperPars(lrn), list(nrounds = 1, missing = NA)))
+  
+  expect_output(print(getHyperPars(lrn)), "NA")
+  
 })

--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -26,6 +26,6 @@ test_that("getHyperPars", {
   lrn = makeLearner("classif.xgboost")
   expect_true(setequal(getHyperPars(lrn), list(nrounds = 1, missing = NA)))
   
-  expect_output(print(getHyperPars(lrn)), "NA")
+  expect_output(print(lrn), "missing=NA")
   
 })

--- a/tests/testthat/test_classif_xgboost.R
+++ b/tests/testthat/test_classif_xgboost.R
@@ -6,7 +6,7 @@ test_that("classif_xgboost", {
   set.seed(getOption("mlr.debug.seed"))
   model = xgboost::xgboost(data = data.matrix(binaryclass.train[,1:60]),
                            label = as.numeric(binaryclass.train[,61])-1,
-                           nrounds = 20, objective = "binary:logistic")
+                           nrounds = 20, objective = "binary:logistic", missing = NA_real_)
   pred = xgboost::predict(model, data.matrix(binaryclass.test[,1:60]))
   pred = factor(as.numeric(pred>0.5), labels = binaryclass.class.levs)
 

--- a/tests/testthat/test_regr_xgboost.R
+++ b/tests/testthat/test_regr_xgboost.R
@@ -6,7 +6,7 @@ test_that("regr_xgboost", {
   set.seed(getOption("mlr.debug.seed"))
   model = xgboost::xgboost(data = data.matrix(regr.train[,1:13]),
                            label = as.numeric(regr.train[,14]),
-                           nrounds = 20, objective = "reg:linear")
+                           nrounds = 20, objective = "reg:linear", missing = NA_real_)
   pred = xgboost::predict(model, data.matrix(regr.test[,1:13]))
 
   set.seed(getOption("mlr.debug.seed"))


### PR DESCRIPTION
when a value in learner$par.vals was NA, this was not printed.
i fixed this here.

comments:
- unit test must still be added
- caution: in tuning we treat NAs as "param not applicable due to subordinate / requires not fulfilled". this in in general a problem but we should not yet "clash" with just this here
