### PR TITLE
GSoC: Add support for two hyperpars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,6 @@ Imports:
 Suggests:
     ada,
     adabag,
-    akima,
     bartMachine,
     brnn,
     bst,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,7 @@ Imports:
 Suggests:
     ada,
     adabag,
+    akima,
     bartMachine,
     brnn,
     bst,

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -61,10 +61,14 @@ generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
   # in case we have nested CV
   if (getClass1(tune.result) == "ResampleResult"){
     if (trafo.scale){
-      d = data.frame()
-      for (i in 1:length(tune.result$extract)){
-        d = rbind(d, as.data.frame(trafoOptPath(tune.result$extract[[i]])))
-      }
+      ops = extractSubList(tune.result$extract, "opt.path", simplify = FALSE)
+      ops = lapply(ops, trafoOptPath)
+      op.dfs = lapply(ops, as.data.frame)
+      op.dfs = lapply(seq_along(op.dfs), function(i) {
+        op.dfs[[i]][,"iter"] = i
+        op.dfs[[i]]
+      })
+      d = do.call(plyr::rbind.fill, op.dfs)
     } else {
       d = getNestedTuneResultsOptPathDf(tune.result)
     }

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -173,6 +173,13 @@ print.HyperParsEffectData = function(x, ...) {
 #'  cases of irregular hyperparameter paths, you will most likely need to use
 #'  this to have a meaningful visualization.
 #'  Default is \code{TRUE}.
+#' @param show.experiments [\code{logical(1)}]\cr
+#'  If TRUE, will overlay the plot with points indicating where an experiment
+#'  ran. This is only useful when creating a heatmap or contour plot with 
+#'  interpolation so that you can see which points were actually on the 
+#'  original path. Note: if any learner crashes occurred within the path, this
+#'  will default to TRUE.
+#'  Default is \code{FALSE}.
 #'
 #' @template ret_gg2
 #'  
@@ -189,7 +196,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
                                z = NULL, plot.type = "scatter", 
                                loess.smooth = FALSE, facet = NULL, 
                                pretty.names = TRUE, global.only = TRUE, 
-                               interpolate = TRUE) {
+                               interpolate = TRUE, show.experiments = TRUE) {
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
   assertChoice(y, choices = names(hyperpars.effect.data$data))
@@ -200,6 +207,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   assertFlag(pretty.names)
   assertFlag(global.only)
   assertFlag(interpolate)
+  assertFlag(show.experiments)
  
   if (length(x) > 1 || length(y) > 1 || length(z) > 1 || length(facet) > 1)
     stopf("Greater than 1 length x, y, z or facet not yet supported")
@@ -341,7 +349,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     if (heatcontour_flag){
       plt = ggplot(data = d[d$learner_status == "Interpolated Point", ], 
                    aes_string(x = x, y = y, fill = z, z = z)) + geom_tile()
-      if (na_flag || interpolate){
+      if (na_flag || (interpolate && show.experiments)){
         plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
                                                                 "Failure"), ],
                                         aes_string(shape = "learner_status"), 

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -240,18 +240,17 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     d$nested_cv_run = as.factor(d$nested_cv_run)
   
   # set flags for building plots
-  na_flag = any(is.na(d[, hyperpars.effect.data$measures]))
-  z_flag = !is.null(z)
-  facet_flag = !is.null(facet)
-  grid_flag = hyperpars.effect.data$optimization == "TuneControlGrid"
-  heatcontour_flag = plot.type %in% c("heatmap", "contour")
+  na.flag = any(is.na(d[, hyperpars.effect.data$measures]))
+  z.flag = !is.null(z)
+  facet.flag = !is.null(facet)
+  heatcontour.flag = plot.type %in% c("heatmap", "contour")
   
   # deal with NAs where optimizer failed
-  if (na_flag){
+  if (na.flag){
     d$learner_status = ifelse(is.na(d[, "exec.time"]), "Failure", "Success")
     for (col in hyperpars.effect.data$measures) {
       col_name = stri_split_fixed(col, ".test.mean", omit_empty = TRUE)[[1]]
-      if (heatcontour_flag){
+      if (heatcontour.flag){
         d[,col][is.na(d[,col])] = get(col_name)$worst
       } else {
         if (get(col_name)$minimize){
@@ -279,7 +278,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     }
   }
   
-  if ((!is.null(interpolate)) && z_flag && (heatcontour_flag)){
+  if ((!is.null(interpolate)) && z.flag && (heatcontour.flag)){
     # create grid
     xo = seq(min(d[,x]), max(d[,x]), length.out = 100)
     yo = seq(min(d[,y]), max(d[,y]), length.out = 100)
@@ -322,13 +321,13 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     d = grid
   }
   
-  if (hyperpars.effect.data$nested && z_flag){
+  if (hyperpars.effect.data$nested && z.flag){
     averaging = d[, !(names(d) %in% c("iteration", "nested_cv_run", 
                                       hyperpars.effect.data$hyperparams, "eol",
                                       "error.message", "learner_status")), 
                   drop = FALSE]
     # keep experiments if we need it
-    if (na_flag || (!is.null(interpolate)) || show.experiments){
+    if (na.flag || (!is.null(interpolate)) || show.experiments){
       hyperpars = lapply(d[, c(hyperpars.effect.data$hyperparams, 
                                "learner_status")], "[")
     } else {
@@ -339,13 +338,13 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   }
   
   # just x, y  
-  if ((length(x) == 1) && (length(y) == 1) && !(z_flag)){
+  if ((length(x) == 1) && (length(y) == 1) && !(z.flag)){
     if (hyperpars.effect.data$nested){
       plt = ggplot(d, aes_string(x = x, y = y, color = "nested_cv_run"))
     } else {
       plt = ggplot(d, aes_string(x = x, y = y))
     }
-    if (na_flag){
+    if (na.flag){
       plt = plt + geom_point(aes_string(shape = "learner_status", 
                                         color = "learner_status")) +
         scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
@@ -357,15 +356,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       plt = plt + geom_line()
     if (loess.smooth)
       plt = plt + geom_smooth()
-    if (facet_flag)
+    if (facet.flag)
       plt = plt + facet_wrap(facet)
-  } else if ((length(x) == 1) && (length(y) == 1) && (z_flag)){
+  } else if ((length(x) == 1) && (length(y) == 1) && (z.flag)){
     # the data we use depends on if interpolation
-    if (heatcontour_flag){
+    if (heatcontour.flag){
       if (!is.null(interpolate)){
         plt = ggplot(data = d[d$learner_status == "Interpolated Point", ], 
                    aes_string(x = x, y = y, fill = z, z = z)) + geom_raster()
-        if (show.interpolated && !(na_flag || show.experiments)){
+        if (show.interpolated && !(na.flag || show.experiments)){
           plt = plt + geom_point(aes_string(shape = "learner_status")) +
             scale_shape_manual(values = c("Interpolated Point" = 6))
         }
@@ -373,13 +372,13 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
         plt = ggplot(data = d, aes_string(x = x, y = y, fill = z, z = z)) +
           geom_tile()
       }
-      if ((na_flag || show.experiments) && !(show.interpolated)){
+      if ((na.flag || show.experiments) && !(show.interpolated)){
         plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
                                                                 "Failure"), ],
                                         aes_string(shape = "learner_status"), 
                                fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0))
-      } else if ((na_flag || show.experiments) && (show.interpolated)) {
+      } else if ((na.flag || show.experiments) && (show.interpolated)) {
         plt = plt + geom_point(data = d, aes_string(shape = "learner_status"), 
                                fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0, 
@@ -389,7 +388,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
         plt = plt + geom_contour()
     } else {
       plt = ggplot(d, aes_string(x = x, y = y, color = z))
-      if (na_flag){
+      if (na.flag){
         plt = plt + geom_point(aes_string(shape = "learner_status", 
                                           color = "learner_status")) +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -152,14 +152,10 @@ print.HyperParsEffectData = function(x, ...) {
 #' @param interpolate [\code{logical(1)}]\cr
 #'  If TRUE, will interpolate non-complete grids in order to visualize a more 
 #'  complete path. Only meaningful when attempting to plot a heatmap or contour.
-#'  This will fill in "empty" cells in the heatmap or contour plot.
+#'  This will fill in "empty" cells in the heatmap or contour plot. Note that 
+#'  cases of irregular hyperparameter paths, you will most likely need to use
+#'  this to have a meaningful visualization.
 #'  Default is \code{TRUE}.
-#' @param heatmap.size [\code{numeric(1)}]\cr
-#'  Adjust the size of rectangles that compose the "heatmap". Increasing this 
-#'  will increase the length and width of each rectangle. You may need to adjust
-#'  this to generate a satisfactory heatmap. Only meaningful when attempting to
-#'  plot a heatmap or contour plot.
-#'  Default is \code{4}.
 #'
 #' @template ret_gg2
 #'  
@@ -176,7 +172,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
                                z = NULL, plot.type = "scatter", 
                                loess.smooth = FALSE, facet = NULL, 
                                pretty.names = TRUE, global.only = TRUE, 
-                               interpolate = TRUE, heatmap.size = 4) {
+                               interpolate = TRUE) {
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
   assertChoice(y, choices = names(hyperpars.effect.data$data))
@@ -187,7 +183,6 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   assertFlag(pretty.names)
   assertFlag(global.only)
   assertFlag(interpolate)
-  assertNumber(heatmap.size, lower = 0)
  
   if (length(x) > 1 || length(y) > 1 || length(z) > 1 || length(facet) > 1)
     stopf("Greater than 1 length x, y, z or facet not yet supported")
@@ -261,7 +256,6 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
         df$learner_status = "Interpolated Point"
         df$iteration = NA
         combined = rbind(d_run[,c(x,y,z,"learner_status", "iteration")], df)
-        combined = combined[!duplicated(combined[,c(x,y)]),]
         new_d = rbind(new_d, combined)
       }
       d = new_d
@@ -282,7 +276,6 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       df$learner_status = "Interpolated Point"
       df$iteration = NA
       combined = rbind(d_new[,c(x,y,z,"learner_status", "iteration")], df)
-      combined = combined[!duplicated(combined[,c(x,y,z)]),]
       d = combined
     }
     
@@ -329,17 +322,17 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   } else if ((length(x) == 1) && (length(y) == 1) && (z_flag)){
     # FIXME: generalize logic here
     if (heatcontour_flag){
-      plt = ggplot(d, aes_string(x = x, y = y)) + 
-        geom_point(aes_string(color = z), shape = 15, size = heatmap.size)
+      plt = ggplot(data = d[d$learner_status == "Interpolated Point", ], 
+                   aes_string(x = x, y = y, fill = z, z = z)) + geom_tile()
       if (na_flag || interpolate){
         plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
                                                                 "Failure"), ],
-                                        aes_string(shape = "learner_status"),
+                                        aes_string(shape = "learner_status"), 
                                fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0))
       } 
       if (plot.type == "contour")
-        plt = plt + stat_density2d(aes_string(z = z))
+        plt = plt + geom_contour()
     } else {
       plt = ggplot(d, aes_string(x = x, y = y, color = z))
       if (na_flag){

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -202,7 +202,8 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
                                z = NULL, plot.type = "scatter", 
                                loess.smooth = FALSE, facet = NULL, 
                                pretty.names = TRUE, global.only = TRUE, 
-                               interpolate = FALSE, show.experiments = FALSE) {
+                               interpolate = FALSE, show.experiments = FALSE, 
+                               nested.agg = mean) {
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
   assertChoice(y, choices = names(hyperpars.effect.data$data))
@@ -254,9 +255,8 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     }
     d$exec.time[is.na(d$exec.time)] = max(d$exec.time, na.rm = TRUE)
   } else {
-    # in case the user wants to show this despite no errors
-    if (show.experiments)
-      d$learner_status = "Success"
+    # in case the user wants to show this despite no learner crashes
+    d$learner_status = "Success"
   }
   
   # assign for global only
@@ -326,7 +326,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     } else {
       hyperpars = lapply(d[, hyperpars.effect.data$hyperparams], "[")
     }
-    d = aggregate(averaging, hyperpars, mean)
+    d = aggregate(averaging, hyperpars, nested.agg)
     d$iteration = 1:nrow(d)
   }
   

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -52,10 +52,11 @@
 #' @export
 #' @importFrom utils type.convert
 generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
-                                       trafo = FALSE)
-  {
-  assert(checkClass(tune.result, "ResampleResult"), 
-         checkClass(tune.result, classes = c("TuneResult", "OptResult")))
+                                       trafo = FALSE) {
+  assert(
+    checkClass(tune.result, "ResampleResult"), 
+    checkClass(tune.result, classes = c("TuneResult", "OptResult"))
+  )
   assertFlag(include.diagnostics)
   
   # in case we have nested CV
@@ -111,10 +112,10 @@ generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
   names(d)[names(d) == "dob"] = "iteration"
   
   makeS3Obj("HyperParsEffectData", data = d, measures = measures,
-            hyperparams = hyperparams, 
-            diagnostics = include.diagnostics, 
-            optimization = optimization,
-            nested = nested)
+    hyperparams = hyperparams, 
+    diagnostics = include.diagnostics, 
+    optimization = optimization,
+    nested = nested)
 }
 
 #' @export
@@ -226,7 +227,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
          checkNull(interpolate))
   # assign learner for interpolation
   if (checkClass(interpolate, "Learner") == TRUE || 
-      checkString(interpolate) == TRUE){
+      checkString(interpolate) == TRUE) {
     lrn = checkLearnerRegr(interpolate)
   }
   assertFlag(show.experiments)
@@ -292,7 +293,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       for (run in unique(d$nested_cv_run)){
         d_run = d_new[d_new$nested_cv_run == run, ]
         regr.task = makeRegrTask(id = "interp", data = d_run[,c(x,y,z)], 
-                                 target = z)
+          target = z)
         mod = train(lrn, regr.task)
         prediction = predict(mod, newdata = grid)
         grid[, z] = prediction$data[, prediction$predict.type]
@@ -323,13 +324,13 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   
   if (hyperpars.effect.data$nested && z.flag){
     averaging = d[, !(names(d) %in% c("iteration", "nested_cv_run", 
-                                      hyperpars.effect.data$hyperparams, "eol",
-                                      "error.message", "learner_status")), 
-                  drop = FALSE]
+      hyperpars.effect.data$hyperparams, "eol",
+      "error.message", "learner_status")), 
+      drop = FALSE]
     # keep experiments if we need it
     if (na.flag || (!is.null(interpolate)) || show.experiments){
       hyperpars = lapply(d[, c(hyperpars.effect.data$hyperparams, 
-                               "learner_status")], "[")
+        "learner_status")], "[")
     } else {
       hyperpars = lapply(d[, hyperpars.effect.data$hyperparams], "[")
     }
@@ -346,7 +347,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     }
     if (na.flag){
       plt = plt + geom_point(aes_string(shape = "learner_status", 
-                                        color = "learner_status")) +
+        color = "learner_status")) +
         scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
         scale_color_manual(values = c("red", "black"))
     } else {
@@ -363,7 +364,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     if (heatcontour.flag){
       if (!is.null(interpolate)){
         plt = ggplot(data = d[d$learner_status == "Interpolated Point", ], 
-                   aes_string(x = x, y = y, fill = z, z = z)) + geom_raster()
+          aes_string(x = x, y = y, fill = z, z = z)) + geom_raster()
         if (show.interpolated && !(na.flag || show.experiments)){
           plt = plt + geom_point(aes_string(shape = "learner_status")) +
             scale_shape_manual(values = c("Interpolated Point" = 6))
@@ -374,15 +375,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       }
       if ((na.flag || show.experiments) && !(show.interpolated)){
         plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
-                                                                "Failure"), ],
-                                        aes_string(shape = "learner_status"), 
-                               fill = "red") +
+          "Failure"), ],
+          aes_string(shape = "learner_status"), 
+          fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0))
       } else if ((na.flag || show.experiments) && (show.interpolated)) {
         plt = plt + geom_point(data = d, aes_string(shape = "learner_status"), 
-                               fill = "red") +
+          fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0, 
-                                        "Interpolated Point" = 6))
+            "Interpolated Point" = 6))
       }
       if (plot.type == "contour")
         plt = plt + geom_contour()
@@ -390,7 +391,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       plt = ggplot(d, aes_string(x = x, y = y, color = z))
       if (na.flag){
         plt = plt + geom_point(aes_string(shape = "learner_status", 
-                                          color = "learner_status")) +
+          color = "learner_status")) +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
           scale_color_manual(values = c("red", "black"))
       } else{
@@ -413,7 +414,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       if (z %in% hyperpars.effect.data$measures)
         plt = plt +
           labs(fill = eval(as.name(stri_split_fixed(z, 
-                                                ".test.mean")[[1]][1]))$name) 
+            ".test.mean")[[1]][1]))$name) 
   }
   return(plt)
 }

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -150,12 +150,12 @@ print.HyperParsEffectData = function(x, ...) {
 #'  could be for the fill on a heatmap or color aesthetic for a line. Must be a 
 #'  column from \code{HyperParsEffectData$data}. Default is \code{NULL}.
 #' @param plot.type [\code{character(1)}]\cr
-#'  Specify the type of plot: "scatter" for a scatterplot, "heatmap" for a 
-#'  heatmap, "line" for a scatterplot with a connecting line, or "contour" for a
+#'  Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a 
+#'  heatmap, \dQuote{line} for a scatterplot with a connecting line, or \dQuote{contour} for a
 #'  contour plot layered ontop of a heatmap.
-#'  Default is scatter.
+#'  Default is \dQuote{scatter}.
 #' @param loess.smooth [\code{logical(1)}]\cr
-#'  If TRUE, will add loess smoothing line to plots where possible. Note that 
+#'  If \code{TRUE}, will add loess smoothing line to plots where possible. Note that 
 #'  this is probably only useful when \code{plot.type} is set to either 
 #'  \dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{FALSE}.
@@ -172,7 +172,7 @@ print.HyperParsEffectData = function(x, ...) {
 #'  performance of every iteration, even if it is not an improvement.
 #'  Default is \code{TRUE}.
 #' @param interpolate [\code{\link{Learner}} | \code{character(1)}]\cr
-#'  If not \code{FALSE}, will interpolate non-complete grids in order to visualize a more 
+#'  If not \code{NULL}, will interpolate non-complete grids in order to visualize a more 
 #'  complete path. Only meaningful when attempting to plot a heatmap or contour.
 #'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that 
 #'  cases of irregular hyperparameter paths, you will most likely need to use

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -18,7 +18,7 @@
 #'  Default is \code{FALSE}.
 #' @param trafo [\code{logical(1)}]\cr
 #'  Should the units of the hyperparameter path be converted to the 
-#'  transformed scale? This is only necessary when trafo was used to create the
+#'  transformed scale? This is only useful when trafo was used to create the
 #'  path.
 #'  Default is \code{FALSE}.
 #'
@@ -254,8 +254,9 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     }
     d$exec.time[is.na(d$exec.time)] = max(d$exec.time, na.rm = TRUE)
   } else {
-    # in case the user wants to show this later
-    d$learner_status = "Success"
+    # in case the user wants to show this despite no errors
+    if (show.experiments)
+      d$learner_status = "Success"
   }
   
   # assign for global only
@@ -339,7 +340,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     if (na_flag){
       plt = plt + geom_point(aes_string(shape = "learner_status", 
                                         color = "learner_status")) +
-        scale_shape_manual(values = c("Failure" = 4, "Success" = 0)) +
+        scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
         scale_color_manual(values = c("red", "black"))
     } else {
       plt = plt + geom_point()
@@ -374,7 +375,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       if (na_flag){
         plt = plt + geom_point(aes_string(shape = "learner_status", 
                                           color = "learner_status")) +
-          scale_shape_manual(values = c("Failure" = 4, "Success" = 0)) +
+          scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
           scale_color_manual(values = c("red", "black"))
       } else{
         plt = plt + geom_point()

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -322,14 +322,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   } else if ((length(x) == 1) && (length(y) == 1) && (z_flag)){
     # FIXME: generalize logic here
     if (heatcontour_flag){
-      plt = ggplot(d, aes_string(x = x, y = y)) + geom_raster(aes_string(fill = z))
+      plt = ggplot(d, aes_string(x = x, y = y)) + 
+        geom_point(aes_string(color = z), shape = 15)
       if (na_flag || interpolate){
-        plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
-                                                                "Failure"), ],
-                                        aes_string(shape = "learner_status", 
-                                          color = "learner_status")) +
-          scale_shape_manual(values = c("Failure" = 4, "Success" = 0)) +
-          scale_color_manual(values = c("Failure" = "red", "Success" = "black"))
+        plt = plt + geom_point(data = d[d$learner_status == "Failure", ],
+                                        aes_string(shape = "learner_status"), 
+                               color = "red", shape = 4, show.legend = T)
+        plt = plt + geom_point(data = d[d$learner_status == "Success", ],
+                               aes_string(shape = "learner_status"), 
+                               color = "black", shape = 0)
       } 
       if (plot.type == "contour")
         plt = plt + geom_contour(aes_string(z = z))

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -157,37 +157,37 @@ print.HyperParsEffectData = function(x, ...) {
 #' @param loess.smooth [\code{logical(1)}]\cr
 #'  If TRUE, will add loess smoothing line to plots where possible. Note that 
 #'  this is probably only useful when \code{plot.type} is set to either 
-#'  "scatter" or "line". Must be a column from \code{HyperParsEffectData$data}
+#'  \dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{FALSE}.
 #' @param facet [\code{character(1)}]\cr
 #'  Specify what should be used as the facet axis for a particular geom. When 
-#'  using nested cross validation, set this to "nested_cv_run" to obtain a facet
+#'  using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 #'  for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{NULL}.
 #' @template arg_prettynames
 #' @param global.only [\code{logical(1)}]\cr
-#'  If TRUE, will only plot the current global optima when setting 
+#'  If \code{TRUE}, will only plot the current global optima when setting 
 #'  x = "iteration" and y as a performance measure from 
 #'  \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the 
 #'  performance of every iteration, even if it is not an improvement.
 #'  Default is \code{TRUE}.
 #' @param interpolate [\code{\link{Learner}} | \code{character(1)}]\cr
-#'  If not FALSE, will interpolate non-complete grids in order to visualize a more 
+#'  If not \code{FALSE}, will interpolate non-complete grids in order to visualize a more 
 #'  complete path. Only meaningful when attempting to plot a heatmap or contour.
-#'  This will fill in "empty" cells in the heatmap or contour plot. Note that 
+#'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that 
 #'  cases of irregular hyperparameter paths, you will most likely need to use
 #'  this to have a meaningful visualization. Accepts either a \link{Learner}
 #'  object or the learner as a string for interpolation.
 #'  Default is \code{NULL}.
 #' @param show.experiments [\code{logical(1)}]\cr
-#'  If TRUE, will overlay the plot with points indicating where an experiment
+#'  If \code{TRUE}, will overlay the plot with points indicating where an experiment
 #'  ran. This is only useful when creating a heatmap or contour plot with 
 #'  interpolation so that you can see which points were actually on the 
 #'  original path. Note: if any learner crashes occurred within the path, this
-#'  will become TRUE.
+#'  will become \code{TRUE}.
 #'  Default is \code{FALSE}.
 #' @param show.interpolated [\code{logical(1)}]\cr
-#'  If TRUE, will overlay the plot with points indicating where interpolation
+#'  If \code{TRUE}, will overlay the plot with points indicating where interpolation
 #'  ran. This is only useful when creating a heatmap or contour plot with 
 #'  interpolation so that you can see which points were interpolated.
 #'  Default is \code{FALSE}.

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -4,7 +4,8 @@
 \alias{generateHyperParsEffectData}
 \title{Generate hyperparameter effect data.}
 \usage{
-generateHyperParsEffectData(tune.result, include.diagnostics = FALSE)
+generateHyperParsEffectData(tune.result, include.diagnostics = FALSE,
+  trafo.scale = FALSE)
 }
 \arguments{
 \item{tune.result}{[\code{\link{TuneResult}} | \code{\link{ResampleResult}}]\cr
@@ -17,6 +18,12 @@ included in the dataframe within the returned \code{HyperParsEffectData}.}
 
 \item{include.diagnostics}{[\code{logical(1)}]\cr
 Should diagnostic info (eol and error msg) be included?
+Default is \code{FALSE}.}
+
+\item{trafo.scale}{[\code{logical(1)}]\cr
+Should the units of the hyperparameter path be converted back to the 
+ordinary scale? This is only necessary when trafo was used to create the
+path.
 Default is \code{FALSE}.}
 }
 \value{

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -22,7 +22,7 @@ Default is \code{FALSE}.}
 
 \item{trafo}{[\code{logical(1)}]\cr
 Should the units of the hyperparameter path be converted to the 
-transformed scale? This is only necessary when trafo was used to create the
+transformed scale? This is only useful when trafo was used to create the
 path.
 Default is \code{FALSE}.}
 }

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -5,7 +5,7 @@
 \title{Generate hyperparameter effect data.}
 \usage{
 generateHyperParsEffectData(tune.result, include.diagnostics = FALSE,
-  trafo.scale = FALSE)
+  trafo = FALSE)
 }
 \arguments{
 \item{tune.result}{[\code{\link{TuneResult}} | \code{\link{ResampleResult}}]\cr
@@ -20,9 +20,9 @@ included in the dataframe within the returned \code{HyperParsEffectData}.}
 Should diagnostic info (eol and error msg) be included?
 Default is \code{FALSE}.}
 
-\item{trafo.scale}{[\code{logical(1)}]\cr
-Should the units of the hyperparameter path be converted back to the 
-ordinary scale? This is only necessary when trafo was used to create the
+\item{trafo}{[\code{logical(1)}]\cr
+Should the units of the hyperparameter path be converted to the 
+transformed scale? This is only necessary when trafo was used to create the
 path.
 Default is \code{FALSE}.}
 }

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -7,7 +7,7 @@
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
   pretty.names = TRUE, global.only = TRUE, interpolate = FALSE,
-  show.experiments = FALSE)
+  show.experiments = FALSE, nested.agg = mean)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -54,12 +54,13 @@ x = "iteration" and y as a performance measure from
 performance of every iteration, even if it is not an improvement.
 Default is \code{TRUE}.}
 
-\item{interpolate}{[\code{logical(1)}]\cr
-If TRUE, will interpolate non-complete grids in order to visualize a more 
+\item{interpolate}{[\code{\link{Learner}} | \code{character(1)} | \code{logical(1)}]\cr
+If not FALSE, will interpolate non-complete grids in order to visualize a more 
 complete path. Only meaningful when attempting to plot a heatmap or contour.
 This will fill in "empty" cells in the heatmap or contour plot. Note that 
 cases of irregular hyperparameter paths, you will most likely need to use
-this to have a meaningful visualization.
+this to have a meaningful visualization. Accepts either a \link{Learner}
+object, the learner as a string, or if TRUE "regr.earth" will be used.
 Default is \code{FALSE}.}
 
 \item{show.experiments}{[\code{logical(1)}]\cr
@@ -83,7 +84,8 @@ optimizer.
 Any NAs incurred from learning algorithm crashes will be indicated in 
 the plot and the NA values will be replaced with the column min/max depending
 on the optimal values for the respective measure. Execution time will be
-replaced with the max.
+replaced with the max. Interpolation by its nature will result in predicted 
+values for the performance measure. Use interpolation with caution.
 }
 \examples{
 # see generateHyperParsEffectData

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,7 +6,7 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE)
+  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -27,7 +27,8 @@ column from \code{HyperParsEffectData$data}. Default is \code{NULL}.}
 
 \item{plot.type}{[\code{character(1)}]\cr
 Specify the type of plot: "scatter" for a scatterplot, "heatmap" for a 
-heatmap, or "line" for a scatterplot with a connecting line.
+heatmap, "line" for a scatterplot with a connecting line, or "contour" for a
+contour plot layered ontop of a heatmap.
 Default is scatter.}
 
 \item{loess.smooth}{[\code{logical(1)}]\cr
@@ -50,6 +51,12 @@ If TRUE, will only plot the current global optima when setting
 x = "iteration" and y as a performance measure from 
 \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the 
 performance of every iteration, even if it is not an improvement.
+Default is \code{TRUE}.}
+
+\item{interpolate}{[\code{logical(1)}]\cr
+If TRUE, will interpolate non-complete grids in order to visualize a more 
+complete path. Only meaningful when attempting to plot a heatmap or contour.
+This will fill in "empty" cells in the heatmap or contour plot.
 Default is \code{TRUE}.}
 }
 \value{

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,8 +6,7 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE,
-  heatmap.size = 4)
+  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -57,15 +56,10 @@ Default is \code{TRUE}.}
 \item{interpolate}{[\code{logical(1)}]\cr
 If TRUE, will interpolate non-complete grids in order to visualize a more 
 complete path. Only meaningful when attempting to plot a heatmap or contour.
-This will fill in "empty" cells in the heatmap or contour plot.
+This will fill in "empty" cells in the heatmap or contour plot. Note that 
+cases of irregular hyperparameter paths, you will most likely need to use
+this to have a meaningful visualization.
 Default is \code{TRUE}.}
-
-\item{heatmap.size}{[\code{numeric(1)}]\cr
-Adjust the size of rectangles that compose the "heatmap". Increasing this 
-will increase the length and width of each rectangle. You may need to adjust
-this to generate a satisfactory heatmap. Only meaningful when attempting to
-plot a heatmap or contour plot.
-Default is \code{4}.}
 }
 \value{
 ggplot2 plot object.

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,7 +6,7 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE,
+  pretty.names = TRUE, global.only = TRUE, interpolate = FALSE,
   show.experiments = FALSE)
 }
 \arguments{
@@ -60,7 +60,7 @@ complete path. Only meaningful when attempting to plot a heatmap or contour.
 This will fill in "empty" cells in the heatmap or contour plot. Note that 
 cases of irregular hyperparameter paths, you will most likely need to use
 this to have a meaningful visualization.
-Default is \code{TRUE}.}
+Default is \code{FALSE}.}
 
 \item{show.experiments}{[\code{logical(1)}]\cr
 If TRUE, will overlay the plot with points indicating where an experiment

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,7 +6,8 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE)
+  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE,
+  heatmap.size = 4)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -58,6 +59,13 @@ If TRUE, will interpolate non-complete grids in order to visualize a more
 complete path. Only meaningful when attempting to plot a heatmap or contour.
 This will fill in "empty" cells in the heatmap or contour plot.
 Default is \code{TRUE}.}
+
+\item{heatmap.size}{[\code{numeric(1)}]\cr
+Adjust the size of rectangles that compose the "heatmap". Increasing this 
+will increase the length and width of each rectangle. You may need to adjust
+this to generate a satisfactory heatmap. Only meaningful when attempting to
+plot a heatmap or contour plot.
+Default is \code{4}.}
 }
 \value{
 ggplot2 plot object.

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,7 +6,8 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE)
+  pretty.names = TRUE, global.only = TRUE, interpolate = TRUE,
+  show.experiments = TRUE)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -60,6 +61,14 @@ This will fill in "empty" cells in the heatmap or contour plot. Note that
 cases of irregular hyperparameter paths, you will most likely need to use
 this to have a meaningful visualization.
 Default is \code{TRUE}.}
+
+\item{show.experiments}{[\code{logical(1)}]\cr
+If TRUE, will overlay the plot with points indicating where an experiment
+ran. This is only useful when creating a heatmap or contour plot with 
+interpolation so that you can see which points were actually on the 
+original path. Note: if any learner crashes occurred within the path, this
+will default to TRUE.
+Default is \code{FALSE}.}
 }
 \value{
 ggplot2 plot object.

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -7,7 +7,7 @@
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
   pretty.names = TRUE, global.only = TRUE, interpolate = TRUE,
-  show.experiments = TRUE)
+  show.experiments = FALSE)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -67,7 +67,7 @@ If TRUE, will overlay the plot with points indicating where an experiment
 ran. This is only useful when creating a heatmap or contour plot with 
 interpolation so that you can see which points were actually on the 
 original path. Note: if any learner crashes occurred within the path, this
-will default to TRUE.
+will become TRUE.
 Default is \code{FALSE}.}
 }
 \value{

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -27,20 +27,20 @@ could be for the fill on a heatmap or color aesthetic for a line. Must be a
 column from \code{HyperParsEffectData$data}. Default is \code{NULL}.}
 
 \item{plot.type}{[\code{character(1)}]\cr
-Specify the type of plot: "scatter" for a scatterplot, "heatmap" for a 
-heatmap, "line" for a scatterplot with a connecting line, or "contour" for a
+Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a 
+heatmap, \dQuote{line} for a scatterplot with a connecting line, or \dQuote{contour} for a
 contour plot layered ontop of a heatmap.
-Default is scatter.}
+Default is \dQuote{scatter}.}
 
 \item{loess.smooth}{[\code{logical(1)}]\cr
-If TRUE, will add loess smoothing line to plots where possible. Note that 
+If \code{TRUE}, will add loess smoothing line to plots where possible. Note that 
 this is probably only useful when \code{plot.type} is set to either 
-"scatter" or "line". Must be a column from \code{HyperParsEffectData$data}
+\dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
 Default is \code{FALSE}.}
 
 \item{facet}{[\code{character(1)}]\cr
 Specify what should be used as the facet axis for a particular geom. When 
-using nested cross validation, set this to "nested_cv_run" to obtain a facet
+using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 Default is \code{NULL}.}
 
@@ -48,31 +48,31 @@ Default is \code{NULL}.}
 Whether to use the short name of the learner instead of its ID in labels. Defaults to \code{TRUE}.}
 
 \item{global.only}{[\code{logical(1)}]\cr
-If TRUE, will only plot the current global optima when setting 
+If \code{TRUE}, will only plot the current global optima when setting 
 x = "iteration" and y as a performance measure from 
 \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the 
 performance of every iteration, even if it is not an improvement.
 Default is \code{TRUE}.}
 
 \item{interpolate}{[\code{\link{Learner}} | \code{character(1)}]\cr
-If not FALSE, will interpolate non-complete grids in order to visualize a more 
+If not \code{NULL}, will interpolate non-complete grids in order to visualize a more 
 complete path. Only meaningful when attempting to plot a heatmap or contour.
-This will fill in "empty" cells in the heatmap or contour plot. Note that 
+This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that 
 cases of irregular hyperparameter paths, you will most likely need to use
 this to have a meaningful visualization. Accepts either a \link{Learner}
 object or the learner as a string for interpolation.
 Default is \code{NULL}.}
 
 \item{show.experiments}{[\code{logical(1)}]\cr
-If TRUE, will overlay the plot with points indicating where an experiment
+If \code{TRUE}, will overlay the plot with points indicating where an experiment
 ran. This is only useful when creating a heatmap or contour plot with 
 interpolation so that you can see which points were actually on the 
 original path. Note: if any learner crashes occurred within the path, this
-will become TRUE.
+will become \code{TRUE}.
 Default is \code{FALSE}.}
 
 \item{show.interpolated}{[\code{logical(1)}]\cr
-If TRUE, will overlay the plot with points indicating where interpolation
+If \code{TRUE}, will overlay the plot with points indicating where interpolation
 ran. This is only useful when creating a heatmap or contour plot with 
 interpolation so that you can see which points were interpolated.
 Default is \code{FALSE}.}

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,8 +6,8 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = FALSE,
-  show.experiments = FALSE, nested.agg = mean)
+  pretty.names = TRUE, global.only = TRUE, interpolate = NULL,
+  show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -54,14 +54,14 @@ x = "iteration" and y as a performance measure from
 performance of every iteration, even if it is not an improvement.
 Default is \code{TRUE}.}
 
-\item{interpolate}{[\code{\link{Learner}} | \code{character(1)} | \code{logical(1)}]\cr
+\item{interpolate}{[\code{\link{Learner}} | \code{character(1)}]\cr
 If not FALSE, will interpolate non-complete grids in order to visualize a more 
 complete path. Only meaningful when attempting to plot a heatmap or contour.
 This will fill in "empty" cells in the heatmap or contour plot. Note that 
 cases of irregular hyperparameter paths, you will most likely need to use
 this to have a meaningful visualization. Accepts either a \link{Learner}
-object, the learner as a string, or if TRUE "regr.earth" will be used.
-Default is \code{FALSE}.}
+object or the learner as a string for interpolation.
+Default is \code{NULL}.}
 
 \item{show.experiments}{[\code{logical(1)}]\cr
 If TRUE, will overlay the plot with points indicating where an experiment
@@ -70,6 +70,18 @@ interpolation so that you can see which points were actually on the
 original path. Note: if any learner crashes occurred within the path, this
 will become TRUE.
 Default is \code{FALSE}.}
+
+\item{show.interpolated}{[\code{logical(1)}]\cr
+If TRUE, will overlay the plot with points indicating where interpolation
+ran. This is only useful when creating a heatmap or contour plot with 
+interpolation so that you can see which points were interpolated.
+Default is \code{FALSE}.}
+
+\item{nested.agg}{[\code{function}]\cr
+The function used to aggregate nested cross validation runs when plotting 2
+hyperpars simultaneously. This is only useful when nested cross validation 
+is used along with plotting a 2 hyperpars.
+Default is \code{mean}.}
 }
 \value{
 ggplot2 plot object.

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -1,12 +1,12 @@
 context("hyperparameterValidation")
 
 test_that("generate data", {
-  # generate data
+  # generate data with nested no trafo 
   ps = makeParamSet(makeNumericParam("C", lower = -5, upper = 5, 
                                      trafo = function(x) 2^x) 
   )
-  ctrl = makeTuneControlRandom(maxit = 25L)
-  rdesc = makeResampleDesc("CV", iters = 3L)
+  ctrl = makeTuneControlRandom(maxit = 10L)
+  rdesc = makeResampleDesc("Holdout")
   lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
                         resampling = rdesc, par.set = ps, 
                         show.info = F)
@@ -16,27 +16,22 @@ test_that("generate data", {
   new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
   expect_equivalent(new$data, orig)
   
-  # make sure plot is created and can be saved
-  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
-  print(plt)
-  dir = tempdir()
-  path = stri_paste(dir, "/test.svg")
-  ggsave(path)
-  
-  # make sure plot has expected attributes
-  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
-  expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Mean misclassification error")
-  
-  # FIXME: make sure plot looks as expected
+  # generate data, no include diag, trafo
+  rdesc = makeResampleDesc("Holdout")
+  res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
+                   par.set = ps, control = ctrl, measures = acc)
+  orig = as.data.frame(trafoOptPath(res$opt.path))
+  orig = within(orig, rm("eol", "error.message"))
+  names(orig)[names(orig) == "dob"] = "iteration"
+  new = generateHyperParsEffectData(res, trafo = TRUE)
+  expect_equivalent(new$data, orig)
 })
 
 test_that("1 numeric hyperparam", {
   # generate data
   ps = makeParamSet(makeDiscreteParam("C", values = 2^(-5:5)))
   ctrl = makeTuneControlGrid()
-  rdesc = makeResampleDesc("CV", iters = 3L)
+  rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
                    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(res$opt.path)
@@ -71,7 +66,7 @@ test_that("1 discrete hyperparam", {
                                                            "polydot", "rbfdot"))
                     )
   ctrl = makeTuneControlGrid()
-  rdesc = makeResampleDesc("CV", iters = 3L)
+  rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
                    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(res$opt.path)
@@ -100,7 +95,7 @@ test_that("1 numeric hyperparam with optimizer failure", {
                                                       0.4))
   )
   ctrl = makeTuneControlGrid()
-  rdesc = makeResampleDesc("CV", iters = 3L)
+  rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
                    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(res$opt.path)
@@ -128,8 +123,8 @@ test_that("1 numeric hyperparam with nested cv", {
   # generate data
   ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
   )
-  ctrl = makeTuneControlRandom(maxit = 25L)
-  rdesc = makeResampleDesc("CV", iters = 3L)
+  ctrl = makeTuneControlRandom(maxit = 10L)
+  rdesc = makeResampleDesc("Holdout")
   lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
                         resampling = rdesc, par.set = ps, 
                         show.info = F)
@@ -155,126 +150,124 @@ test_that("1 numeric hyperparam with nested cv", {
   # FIXME: make sure plot looks as expected
 })
 
-test_that("2 hyperparams line", {
+test_that("2 hyperparams", {
   # generate data
-  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
-  )
-  ctrl = makeTuneControlRandom(maxit = 25L)
-  rdesc = makeResampleDesc("CV", iters = 3L)
-  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
-                        resampling = rdesc, par.set = ps, 
-                        show.info = F)
-  res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
-  orig = getNestedTuneResultsOptPathDf(res)
-  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
-  expect_equivalent(new$data, orig)
+  ps = makeParamSet(
+    makeNumericParam("C", lower = -5, upper = 5, trafo = function(x) 2^x),
+    makeNumericParam("sigma", lower = -5, upper = 5, trafo = function(x) 2^x))
+  ctrl = makeTuneControlRandom(maxit = 10L)
+  rdesc = makeResampleDesc("Holdout")
+  learn = makeLearner("classif.ksvm", par.vals = list(kernel = "rbfdot"))
+  res = tuneParams(learn, task = pid.task, control = ctrl, measures = acc,
+                   resampling = rdesc, par.set = ps, show.info = F)
+  data = generateHyperParsEffectData(res)
   
-  # make sure plot is created and can be saved
-  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  
+  # test line creation
+  plt = plotHyperParsEffect(data, x = "iteration", y = "acc.test.mean", 
+                            plot.type = "line")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
-  
-  # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
-  expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Mean misclassification error")
+                   c("GeomLine", "GeomPoint"))
+  expect_equal(plt$labels$x, "iteration")
+  expect_equal(plt$labels$y, "Accuracy")
   
-  # FIXME: make sure plot looks as expected
-})
-
-test_that("2 hyperparams heatcontour", {
-  # generate data
-  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
-  )
-  ctrl = makeTuneControlRandom(maxit = 25L)
-  rdesc = makeResampleDesc("CV", iters = 3L)
-  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
-                        resampling = rdesc, par.set = ps, 
-                        show.info = F)
-  res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
-  orig = getNestedTuneResultsOptPathDf(res)
-  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
-  expect_equivalent(new$data, orig)
-  
-  # make sure plot is created and can be saved
-  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  # test heatcontour creation with interpolation
+  plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
+                      plot.type = "heatmap", interpolate = "regr.earth", 
+                      show.experiments = TRUE)
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
-  
-  # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
+                   c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Mean misclassification error")
+  expect_equal(plt$labels$y, "sigma")
+  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$shape, "learner_status")
   
-  # FIXME: make sure plot looks as expected
-})
-
-test_that("2 hyperparams learner crash", {
-  # generate data
-  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
-  )
-  ctrl = makeTuneControlRandom(maxit = 25L)
-  rdesc = makeResampleDesc("CV", iters = 3L)
-  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
-                        resampling = rdesc, par.set = ps, 
-                        show.info = F)
-  res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
-  orig = getNestedTuneResultsOptPathDf(res)
-  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
-  expect_equivalent(new$data, orig)
-  
-  # make sure plot is created and can be saved
-  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  # learner crash
+  ps = makeParamSet(
+    makeDiscreteParam("C", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 0.4, 5)),
+    makeDiscreteParam("sigma", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 0.4, 5)))
+  ctrl = makeTuneControlGrid()
+  rdesc = makeResampleDesc("Holdout")
+  learn = makeLearner("classif.ksvm", par.vals = list(kernel = "rbfdot"))
+  res = tuneParams(learn, task = pid.task, control = ctrl, measures = acc,
+                   resampling = rdesc, par.set = ps, show.info = F)
+  data = generateHyperParsEffectData(res)
+  plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
+                      plot.type = "heatmap", interpolate = "regr.earth")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
-  
-  # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
+                   c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Mean misclassification error")
+  expect_equal(plt$labels$y, "sigma")
+  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$shape, "learner_status")
   
-  # FIXME: make sure plot looks as expected
+  # FIXME: make sure plots looks as expected
 })
 
 test_that("2 hyperparams nested", {
   # generate data
-  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
-  )
-  ctrl = makeTuneControlRandom(maxit = 25L)
-  rdesc = makeResampleDesc("CV", iters = 3L)
-  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
-                        resampling = rdesc, par.set = ps, 
-                        show.info = F)
+  ps = makeParamSet(
+    makeNumericParam("C", lower = -5, upper = 5, trafo = function(x) 2^x),
+    makeNumericParam("sigma", lower = -5, upper = 5, trafo = function(x) 2^x))
+  ctrl = makeTuneControlRandom(maxit = 10L)
+  rdesc = makeResampleDesc("Holdout")
+  learn = makeLearner("classif.ksvm", par.vals = list(kernel = "rbfdot"))
+  lrn = makeTuneWrapper(learn, control = ctrl, 
+                        measures = list(acc, mmce), resampling = rdesc, 
+                        par.set = ps, show.info = F)
   res = resample(lrn, task = pid.task, resampling = cv2, 
                  extract = getTuneResult)
-  orig = getNestedTuneResultsOptPathDf(res)
-  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
-  expect_equivalent(new$data, orig)
+  data = generateHyperParsEffectData(res)
   
-  # make sure plot is created and can be saved
-  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  # contour plot
+  plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
+                      plot.type = "contour", interpolate = "regr.earth", 
+                      show.interpolated = TRUE)
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
-  
-  # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
+                   c("GeomPoint", "GeomRaster", "GeomContour"))
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Mean misclassification error")
+  expect_equal(plt$labels$y, "sigma")
+  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$shape, "learner_status")
   
-  # FIXME: make sure plot looks as expected
+  # learner crashes
+  ps = makeParamSet(
+    makeDiscreteParam("C", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 0.4, 5)),
+    makeDiscreteParam("sigma", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 0.4, 5)))
+  lrn = makeTuneWrapper(learn, control = ctrl, 
+                        measures = list(acc, mmce), resampling = rdesc, 
+                        par.set = ps, show.info = F)
+  res = resample(lrn, task = pid.task, resampling = cv2, 
+                 extract = getTuneResult)
+  data = generateHyperParsEffectData(res)
+  plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
+                            plot.type = "heatmap", interpolate = "regr.earth", 
+                            show.experiments = TRUE)
+  print(plt)
+  dir = tempdir()
+  path = stri_paste(dir, "/test.svg")
+  ggsave(path)
+  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
+                   c("GeomPoint", "GeomRaster"))
+  expect_equal(plt$labels$x, "C")
+  expect_equal(plt$labels$y, "sigma")
+  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$shape, "learner_status")
 })
+

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -1,5 +1,37 @@
 context("hyperparameterValidation")
 
+test_that("generate data", {
+  # generate data
+  ps = makeParamSet(makeNumericParam("C", lower = -5, upper = 5, 
+                                     trafo = function(x) 2^x) 
+  )
+  ctrl = makeTuneControlRandom(maxit = 25L)
+  rdesc = makeResampleDesc("CV", iters = 3L)
+  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
+                        resampling = rdesc, par.set = ps, 
+                        show.info = F)
+  res = resample(lrn, task = pid.task, resampling = cv2, 
+                 extract = getTuneResult)
+  orig = getNestedTuneResultsOptPathDf(res)
+  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
+  expect_equivalent(new$data, orig)
+  
+  # make sure plot is created and can be saved
+  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  print(plt)
+  dir = tempdir()
+  path = stri_paste(dir, "/test.svg")
+  ggsave(path)
+  
+  # make sure plot has expected attributes
+  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
+                   "GeomPoint")
+  expect_equal(plt$labels$x, "C")
+  expect_equal(plt$labels$y, "Mean misclassification error")
+  
+  # FIXME: make sure plot looks as expected
+})
+
 test_that("1 numeric hyperparam", {
   # generate data
   ps = makeParamSet(makeDiscreteParam("C", values = 2^(-5:5)))
@@ -108,8 +140,131 @@ test_that("1 numeric hyperparam with nested cv", {
   expect_equivalent(new$data, orig)
   
   # make sure plot is created and can be saved
-  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean", 
-                            facet = "nested_cv_run")
+  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  print(plt)
+  dir = tempdir()
+  path = stri_paste(dir, "/test.svg")
+  ggsave(path)
+  
+  # make sure plot has expected attributes
+  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
+                   "GeomPoint")
+  expect_equal(plt$labels$x, "C")
+  expect_equal(plt$labels$y, "Mean misclassification error")
+  
+  # FIXME: make sure plot looks as expected
+})
+
+test_that("2 hyperparams line", {
+  # generate data
+  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
+  )
+  ctrl = makeTuneControlRandom(maxit = 25L)
+  rdesc = makeResampleDesc("CV", iters = 3L)
+  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
+                        resampling = rdesc, par.set = ps, 
+                        show.info = F)
+  res = resample(lrn, task = pid.task, resampling = cv2, 
+                 extract = getTuneResult)
+  orig = getNestedTuneResultsOptPathDf(res)
+  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
+  expect_equivalent(new$data, orig)
+  
+  # make sure plot is created and can be saved
+  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  print(plt)
+  dir = tempdir()
+  path = stri_paste(dir, "/test.svg")
+  ggsave(path)
+  
+  # make sure plot has expected attributes
+  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
+                   "GeomPoint")
+  expect_equal(plt$labels$x, "C")
+  expect_equal(plt$labels$y, "Mean misclassification error")
+  
+  # FIXME: make sure plot looks as expected
+})
+
+test_that("2 hyperparams heatcontour", {
+  # generate data
+  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
+  )
+  ctrl = makeTuneControlRandom(maxit = 25L)
+  rdesc = makeResampleDesc("CV", iters = 3L)
+  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
+                        resampling = rdesc, par.set = ps, 
+                        show.info = F)
+  res = resample(lrn, task = pid.task, resampling = cv2, 
+                 extract = getTuneResult)
+  orig = getNestedTuneResultsOptPathDf(res)
+  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
+  expect_equivalent(new$data, orig)
+  
+  # make sure plot is created and can be saved
+  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  print(plt)
+  dir = tempdir()
+  path = stri_paste(dir, "/test.svg")
+  ggsave(path)
+  
+  # make sure plot has expected attributes
+  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
+                   "GeomPoint")
+  expect_equal(plt$labels$x, "C")
+  expect_equal(plt$labels$y, "Mean misclassification error")
+  
+  # FIXME: make sure plot looks as expected
+})
+
+test_that("2 hyperparams learner crash", {
+  # generate data
+  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
+  )
+  ctrl = makeTuneControlRandom(maxit = 25L)
+  rdesc = makeResampleDesc("CV", iters = 3L)
+  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
+                        resampling = rdesc, par.set = ps, 
+                        show.info = F)
+  res = resample(lrn, task = pid.task, resampling = cv2, 
+                 extract = getTuneResult)
+  orig = getNestedTuneResultsOptPathDf(res)
+  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
+  expect_equivalent(new$data, orig)
+  
+  # make sure plot is created and can be saved
+  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
+  print(plt)
+  dir = tempdir()
+  path = stri_paste(dir, "/test.svg")
+  ggsave(path)
+  
+  # make sure plot has expected attributes
+  expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
+                   "GeomPoint")
+  expect_equal(plt$labels$x, "C")
+  expect_equal(plt$labels$y, "Mean misclassification error")
+  
+  # FIXME: make sure plot looks as expected
+})
+
+test_that("2 hyperparams nested", {
+  # generate data
+  ps = makeParamSet(makeNumericParam("C", lower = 0.01, upper = 2)
+  )
+  ctrl = makeTuneControlRandom(maxit = 25L)
+  rdesc = makeResampleDesc("CV", iters = 3L)
+  lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
+                        resampling = rdesc, par.set = ps, 
+                        show.info = F)
+  res = resample(lrn, task = pid.task, resampling = cv2, 
+                 extract = getTuneResult)
+  orig = getNestedTuneResultsOptPathDf(res)
+  new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
+  expect_equivalent(new$data, orig)
+  
+  # make sure plot is created and can be saved
+  plt = plotHyperParsEffect(new, x = "C", y = "mmce.test.mean")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -53,10 +53,6 @@ test_that("1 numeric hyperparam", {
   expect_equal(plt$labels$x, "iteration")
   expect_equal(plt$labels$y, "Accuracy")
   
-  # test for global
-  orig$acc.test.mean = cummax(orig$acc.test.mean)
-  expect_equivalent(plt$data, orig) 
-  
   # FIXME: make sure plot looks as expected
 })
 

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -3,15 +3,15 @@ context("hyperparameterValidation")
 test_that("generate data", {
   # generate data with nested no trafo 
   ps = makeParamSet(makeNumericParam("C", lower = -5, upper = 5, 
-                                     trafo = function(x) 2^x) 
+    trafo = function(x) 2^x) 
   )
   ctrl = makeTuneControlRandom(maxit = 10L)
   rdesc = makeResampleDesc("Holdout")
   lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
-                        resampling = rdesc, par.set = ps, 
-                        show.info = F)
+    resampling = rdesc, par.set = ps, 
+    show.info = F)
   res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
+    extract = getTuneResult)
   orig = getNestedTuneResultsOptPathDf(res)
   new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
   expect_equivalent(new$data, orig)
@@ -19,7 +19,7 @@ test_that("generate data", {
   # generate data, no include diag, trafo
   rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
-                   par.set = ps, control = ctrl, measures = acc)
+    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(trafoOptPath(res$opt.path))
   orig = within(orig, rm("eol", "error.message"))
   names(orig)[names(orig) == "dob"] = "iteration"
@@ -33,7 +33,7 @@ test_that("1 numeric hyperparam", {
   ctrl = makeTuneControlGrid()
   rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
-                   par.set = ps, control = ctrl, measures = acc)
+    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(res$opt.path)
   orig$C = as.numeric(as.character(orig$C))
   new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
@@ -41,7 +41,7 @@ test_that("1 numeric hyperparam", {
   
   # make sure plot is created and can be saved
   plt = plotHyperParsEffect(new, x = "iteration", y = "acc.test.mean", 
-                 plot.type = "line")
+    plot.type = "line")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -49,7 +49,7 @@ test_that("1 numeric hyperparam", {
   
   # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   c("GeomPoint", "GeomLine"))
+    c("GeomPoint", "GeomLine"))
   expect_equal(plt$labels$x, "iteration")
   expect_equal(plt$labels$y, "Accuracy")
   
@@ -59,12 +59,12 @@ test_that("1 numeric hyperparam", {
 test_that("1 discrete hyperparam", {
   # generate data
   ps = makeParamSet(makeDiscreteParam("kernel", values = c("vanilladot", 
-                                                           "polydot", "rbfdot"))
-                    )
+    "polydot", "rbfdot"))
+  )
   ctrl = makeTuneControlGrid()
   rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
-                   par.set = ps, control = ctrl, measures = acc)
+    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(res$opt.path)
   new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
   expect_equivalent(new$data, orig)
@@ -78,7 +78,7 @@ test_that("1 discrete hyperparam", {
   
   # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
+    "GeomPoint")
   expect_equal(plt$labels$x, "kernel")
   expect_equal(plt$labels$y, "Accuracy")
   
@@ -88,12 +88,12 @@ test_that("1 discrete hyperparam", {
 test_that("1 numeric hyperparam with optimizer failure", {
   # generate data
   ps = makeParamSet(makeDiscreteParam("C", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 
-                                                      0.4))
+    0.4))
   )
   ctrl = makeTuneControlGrid()
   rdesc = makeResampleDesc("Holdout")
   res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc, 
-                   par.set = ps, control = ctrl, measures = acc)
+    par.set = ps, control = ctrl, measures = acc)
   orig = as.data.frame(res$opt.path)
   orig$C = as.numeric(as.character(orig$C))
   new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
@@ -108,7 +108,7 @@ test_that("1 numeric hyperparam with optimizer failure", {
   
   # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
+    "GeomPoint")
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "Accuracy")
   
@@ -122,10 +122,10 @@ test_that("1 numeric hyperparam with nested cv", {
   ctrl = makeTuneControlRandom(maxit = 10L)
   rdesc = makeResampleDesc("Holdout")
   lrn = makeTuneWrapper("classif.ksvm", control = ctrl, 
-                        resampling = rdesc, par.set = ps, 
-                        show.info = F)
+    resampling = rdesc, par.set = ps, 
+    show.info = F)
   res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
+    extract = getTuneResult)
   orig = getNestedTuneResultsOptPathDf(res)
   new = generateHyperParsEffectData(res, include.diagnostics = TRUE)
   expect_equivalent(new$data, orig)
@@ -139,7 +139,7 @@ test_that("1 numeric hyperparam with nested cv", {
   
   # make sure plot has expected attributes
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   "GeomPoint")
+    "GeomPoint")
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "Mean misclassification error")
   
@@ -155,32 +155,32 @@ test_that("2 hyperparams", {
   rdesc = makeResampleDesc("Holdout")
   learn = makeLearner("classif.ksvm", par.vals = list(kernel = "rbfdot"))
   res = tuneParams(learn, task = pid.task, control = ctrl, measures = acc,
-                   resampling = rdesc, par.set = ps, show.info = F)
+    resampling = rdesc, par.set = ps, show.info = F)
   data = generateHyperParsEffectData(res)
   
   
   # test line creation
   plt = plotHyperParsEffect(data, x = "iteration", y = "acc.test.mean", 
-                            plot.type = "line")
+    plot.type = "line")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   c("GeomLine", "GeomPoint"))
+    c("GeomLine", "GeomPoint"))
   expect_equal(plt$labels$x, "iteration")
   expect_equal(plt$labels$y, "Accuracy")
   
   # test heatcontour creation with interpolation
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
-                      plot.type = "heatmap", interpolate = "regr.earth", 
-                      show.experiments = TRUE)
+    plot.type = "heatmap", interpolate = "regr.earth", 
+    show.experiments = TRUE)
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   c("GeomPoint", "GeomRaster"))
+    c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
   expect_equal(plt$labels$fill, "Accuracy")
@@ -194,16 +194,16 @@ test_that("2 hyperparams", {
   rdesc = makeResampleDesc("Holdout")
   learn = makeLearner("classif.ksvm", par.vals = list(kernel = "rbfdot"))
   res = tuneParams(learn, task = pid.task, control = ctrl, measures = acc,
-                   resampling = rdesc, par.set = ps, show.info = F)
+    resampling = rdesc, par.set = ps, show.info = F)
   data = generateHyperParsEffectData(res)
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
-                      plot.type = "heatmap", interpolate = "regr.earth")
+    plot.type = "heatmap", interpolate = "regr.earth")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   c("GeomPoint", "GeomRaster"))
+    c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
   expect_equal(plt$labels$fill, "Accuracy")
@@ -221,22 +221,22 @@ test_that("2 hyperparams nested", {
   rdesc = makeResampleDesc("Holdout")
   learn = makeLearner("classif.ksvm", par.vals = list(kernel = "rbfdot"))
   lrn = makeTuneWrapper(learn, control = ctrl, 
-                        measures = list(acc, mmce), resampling = rdesc, 
-                        par.set = ps, show.info = F)
+    measures = list(acc, mmce), resampling = rdesc, 
+    par.set = ps, show.info = F)
   res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
+    extract = getTuneResult)
   data = generateHyperParsEffectData(res)
   
   # contour plot
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
-                      plot.type = "contour", interpolate = "regr.earth", 
-                      show.interpolated = TRUE)
+    plot.type = "contour", interpolate = "regr.earth", 
+    show.interpolated = TRUE)
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   c("GeomPoint", "GeomRaster", "GeomContour"))
+    c("GeomPoint", "GeomRaster", "GeomContour"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
   expect_equal(plt$labels$fill, "Accuracy")
@@ -247,20 +247,20 @@ test_that("2 hyperparams nested", {
     makeDiscreteParam("C", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 0.4, 5)),
     makeDiscreteParam("sigma", values = c(-1, 0.5, 1.5, 1, 0.2, 0.3, 0.4, 5)))
   lrn = makeTuneWrapper(learn, control = ctrl, 
-                        measures = list(acc, mmce), resampling = rdesc, 
-                        par.set = ps, show.info = F)
+    measures = list(acc, mmce), resampling = rdesc, 
+    par.set = ps, show.info = F)
   res = resample(lrn, task = pid.task, resampling = cv2, 
-                 extract = getTuneResult)
+    extract = getTuneResult)
   data = generateHyperParsEffectData(res)
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
-                            plot.type = "heatmap", interpolate = "regr.earth", 
-                            show.experiments = TRUE)
+    plot.type = "heatmap", interpolate = "regr.earth", 
+    show.experiments = TRUE)
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
   ggsave(path)
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]), 
-                   c("GeomPoint", "GeomRaster"))
+    c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
   expect_equal(plt$labels$fill, "Accuracy")


### PR DESCRIPTION
TODO:

- [x] Standardize visualizing learner crashes
- [x] Interpolate non-grid search optimization when needed
- [x] Nested CV support with aggregation
- [x] Trafo scaling for generate
- [x] Show experiments arg
- [x] Show interpolated points arg
- [x] Interpolation accepts any mlr regression learner
- [x] Add test cases
- [x] Example visualizations for tutorial


Example notebook will be updated here: https://github.com/MasonGallo/model-optimization/tree/master/visualize_hyperparam_tuning/big_picture 