### PR TITLE
Add trafo conversion support for tune result df extraction

### DIFF
--- a/R/getNestedTuneResults.R
+++ b/R/getNestedTuneResults.R
@@ -30,16 +30,24 @@ getNestedTuneResultsX = function(r) {
 #'
 #' @param r [\code{\link{ResampleResult}}] \cr
 #'   The result of resampling of a tuning wrapper.
+#' @param trafo [\code{logical(1)}]\cr
+#'   Should the units of the hyperparameter path be converted to the 
+#'   transformed scale? This is only necessary when trafo was used to create 
+#'   the \code{opt.path}s. Note that \code{opt.path}s are always stored on the
+#'   untransformed scale.
+#'   Default is \code{FALSE}.
 #' @return [\code{data.frame}]. See above.
 #' @family tune
 #' @examples
 #' # see example of makeTuneWrapper
 #' @export
-getNestedTuneResultsOptPathDf = function(r) {
+getNestedTuneResultsOptPathDf = function(r, trafo = FALSE) {
   assertClass(r, "ResampleResult")
   assertList(r$extract)
   lapply(r$extract, assertClass, classes = "TuneResult")
+  assertFlag(trafo)
   ops = extractSubList(r$extract, "opt.path", simplify = FALSE)
+  if (trafo) ops = lapply(ops, trafoOptPath)
   op.dfs = lapply(ops, as.data.frame)
   op.dfs = lapply(seq_along(op.dfs), function(i) {
     op.dfs[[i]][,"iter"] = i

--- a/man/getNestedTuneResultsOptPathDf.Rd
+++ b/man/getNestedTuneResultsOptPathDf.Rd
@@ -4,11 +4,18 @@
 \alias{getNestedTuneResultsOptPathDf}
 \title{Get the \code{opt.path}s from each tuning step from the outer resampling.}
 \usage{
-getNestedTuneResultsOptPathDf(r)
+getNestedTuneResultsOptPathDf(r, trafo = FALSE)
 }
 \arguments{
 \item{r}{[\code{\link{ResampleResult}}] \cr
 The result of resampling of a tuning wrapper.}
+
+\item{trafo}{[\code{logical(1)}]\cr
+Should the units of the hyperparameter path be converted to the 
+transformed scale? This is only necessary when trafo was used to create 
+the \code{opt.path}s. Note that \code{opt.path}s are always stored on the
+untransformed scale.
+Default is \code{FALSE}.}
 }
 \value{
 [\code{data.frame}]. See above.

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -84,11 +84,11 @@ test_that("TuneWrapper works with getTuneResult and getNestedTuneResults", {
   
   # check trafo arg
   ps2 = makeParamSet(makeNumericParam(id = "C", lower = -2, upper = 2, 
-                                      trafo = function(x) 2^x))
+    trafo = function(x) 2^x))
   lrn2 = makeTuneWrapper(lrn1a, resampling = inner, par.set = ps2, 
-                         control = makeTuneControlGrid())
+    control = makeTuneControlGrid())
   r = resample(lrn2, binaryclass.task, outer, measures = mlr::mmce, 
-               extract = getTuneResult)
+    extract = getTuneResult)
   opdf = getNestedTuneResultsOptPathDf(r, trafo = TRUE)
   expect_true(all(c("iter", "C", "mmce.test.mean") %in% colnames(opdf)))
   expect_equal(nrow(opdf), 20)

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -81,6 +81,18 @@ test_that("TuneWrapper works with getTuneResult and getNestedTuneResults", {
   opdf = getNestedTuneResultsOptPathDf(r)
   expect_true(all(c("iter", "C", "mmce.test.mean") %in% colnames(opdf)))
   expect_equal(nrow(opdf), 4)
+  
+  # check trafo arg
+  ps2 = makeParamSet(makeNumericParam(id = "C", lower = -2, upper = 2, 
+                                      trafo = function(x) 2^x))
+  lrn2 = makeTuneWrapper(lrn1a, resampling = inner, par.set = ps2, 
+                         control = makeTuneControlGrid())
+  r = resample(lrn2, binaryclass.task, outer, measures = mlr::mmce, 
+               extract = getTuneResult)
+  opdf = getNestedTuneResultsOptPathDf(r, trafo = TRUE)
+  expect_true(all(c("iter", "C", "mmce.test.mean") %in% colnames(opdf)))
+  expect_equal(nrow(opdf), 20)
+  expect_equal(opdf$C, rep(2^seq(-2, 2, length.out = 10), 2))                   
 })
 
 


### PR DESCRIPTION
I noticed `getNestedTuneResultsOptPathDf` lacked the ability to convert back from the trafo scale, so I added that in with a binary arg. The arg defaults to `False` so it should not affect any preexisting code. Tests didn't seem necessary, but lmk if so and I can add one.