### PR TITLE
Subset data to rows where target is notNA (Fixes #1035)

### DIFF
--- a/R/ImputeMethods.R
+++ b/R/ImputeMethods.R
@@ -283,7 +283,9 @@ imputeLearner = function(learner, features = NULL) {
         if (col %nin% features)
           features = c(col, features)
       }
-      ind = !is.na(data[[col]]) # we train only on data where the column is not NA
+      # Remove all observations with missing values in the target for training. This is required
+      # because it should not be possible to have tasks with missing values in the target.
+      ind = !is.na(data[[col]]) 
       task = constructor("impute", data = subset(data[ind, ], select = features), target = col,
         check.data = FALSE, fixup.data = "quiet")
       list(model = train(learner, subsetTask(task, features = features)), features = features)

--- a/R/ImputeMethods.R
+++ b/R/ImputeMethods.R
@@ -283,7 +283,8 @@ imputeLearner = function(learner, features = NULL) {
         if (col %nin% features)
           features = c(col, features)
       }
-      task = constructor("impute", data = subset(data, select = features), target = col,
+      ind = !is.na(data[[col]]) # we train only on data where the column is not NA
+      task = constructor("impute", data = subset(data[ind, ], select = features), target = col,
         check.data = FALSE, fixup.data = "quiet")
       list(model = train(learner, subsetTask(task, features = features)), features = features)
     },

--- a/tests/testthat/test_base_impute.R
+++ b/tests/testthat/test_base_impute.R
@@ -36,8 +36,11 @@ test_that("Impute data frame", {
   expect_true(imputed$y[6] >= 0 && imputed$y[6] <= 5)
   
   # learner
+  # we specifically want to check functionality with a learner that does not 
+  # support NAs. We don't check the data again when we create the task to train and the 
+  # observations we want to impute have to be removed in training.
   lrn = makeLearner("classif.fnn")
-  expect_false(hasLearnerProperties(lrn, "missings")) # we specifically want to check functionality with a learner that does not support NAs.
+  expect_false(hasLearnerProperties(lrn, "missings")) 
   data2 = data[1:5, 1:3]
   data2[1,1] = NA
   imputed = impute(data2, cols = list(f = imputeLearner(lrn)))$data

--- a/tests/testthat/test_base_impute.R
+++ b/tests/testthat/test_base_impute.R
@@ -34,6 +34,14 @@ test_that("Impute data frame", {
   expect_equal(imputed$x[6], 0.5)
   expect_equal(imputed$x[6], 0.5)
   expect_true(imputed$y[6] >= 0 && imputed$y[6] <= 5)
+  
+  # learner
+  lrn = makeLearner("classif.fnn")
+  expect_false(hasLearnerProperties(lrn, "missings")) # we specifically want to check functionality with a learner that does not support NAs.
+  data2 = data[1:5, 1:3]
+  data2[1,1] = NA
+  imputed = impute(data2, cols = list(f = imputeLearner(lrn)))$data
+  expect_true(imputed$f[1] == "a")
 
   # constant replacements
   imputed = impute(data, target = target, cols = list(f = "xxx", x = 999, y = 1000))$data


### PR DESCRIPTION
Before we trained with the complete data set including the observations where we had NAs in the column we wanted to impute.
This does not make so much sense to me.
Now we only train on the data, where the column to impute is not NA.