### PR TITLE
imputeLearner:return data directly if no NAs (Fixes #848)

### DIFF
--- a/R/ImputeMethods.R
+++ b/R/ImputeMethods.R
@@ -144,8 +144,8 @@ imputeMax = function(multiplier = 1) {
 #'   If NA (default), it will be estimated from the data.
 #' @rdname imputations
 imputeUniform = function(min = NA_real_, max = NA_real_) {
-  assertNumber(min)
-  assertNumber(max)
+  assertNumber(min, na.ok = TRUE)
+  assertNumber(max, na.ok = TRUE)
   makeImputeMethod(
     learn = function(data, target, col, min, max)  {
       if (is.na(min)) {
@@ -291,10 +291,11 @@ imputeLearner = function(learner, features = NULL) {
     impute = function(data, target, col, model, features) {
       x = data[[col]]
       ind = is.na(x)
+      if (all(!ind)) return(x)
       # FIXME: we do get a list instead of a data.frame?
       newdata = as.data.frame(data)[ind, features, drop = FALSE]
-     p = predict(model, newdata = newdata)$data$response
-     replace(x, ind, p)
+      p = predict(model, newdata = newdata)$data$response
+      replace(x, ind, p)
     },
     args = list(learner = learner, features = features)
   )

--- a/R/ImputeMethods.R
+++ b/R/ImputeMethods.R
@@ -291,6 +291,7 @@ imputeLearner = function(learner, features = NULL) {
     impute = function(data, target, col, model, features) {
       x = data[[col]]
       ind = is.na(x)
+      # if no NAs are present in data, we always return it unchanged
       if (all(!ind)) return(x)
       # FIXME: we do get a list instead of a data.frame?
       newdata = as.data.frame(data)[ind, features, drop = FALSE]

--- a/tests/testthat/test_base_impute.R
+++ b/tests/testthat/test_base_impute.R
@@ -123,3 +123,23 @@ test_that("ImputeWrapper", {
   expect_output(print(mm), "Model")
   expect_is(mm, "WrappedModel")
 })
+
+test_that("Impute works on non missing data", {
+  data = data.frame(a = c(1,1,2), b = 1:3)
+  impute.methods = list(
+    imputeConstant(0),
+    imputeMedian(),
+    imputeMean(),
+    imputeMode(),
+    imputeMin(),
+    imputeMax(),
+    imputeUniform(),
+    imputeNormal(),
+    imputeHist(),
+    imputeLearner(learner = makeLearner("regr.fnn"))
+  )
+  for (impute.method in impute.methods) {
+    imputed = impute(data, cols = list(a=impute.method))$data
+    expect_equal(data, imputed)
+  }
+})

--- a/tests/testthat/test_base_impute.R
+++ b/tests/testthat/test_base_impute.R
@@ -124,7 +124,7 @@ test_that("ImputeWrapper", {
   expect_is(mm, "WrappedModel")
 })
 
-test_that("Impute works on non missing data", {
+test_that("Impute works on non missing data", { # we had issues here: 848,893
   data = data.frame(a = c(1,1,2), b = 1:3)
   impute.methods = list(
     imputeConstant(0),
@@ -142,4 +142,10 @@ test_that("Impute works on non missing data", {
     imputed = impute(data, cols = list(a=impute.method))$data
     expect_equal(data, imputed)
   }
+  # test it in resampling
+  dat = data.frame(y = rnorm(10), a = c(NA, rnorm(9)), b = rnorm(10))
+  task = makeRegrTask(data = dat, target = "y")
+  implrn = imputeLearner(makeLearner("regr.rpart"))
+  lrn = makeImputeWrapper(makeLearner("regr.lm"), cols = list(a = implrn))
+  holdout(lrn, task)
 })


### PR DESCRIPTION
We could also debate if we allow predict for empty newdata. Until then this seems to be the best solution.