### PR TITLE
fix issue 1038, add corr paras to GPfit

### DIFF
--- a/R/RLearner_regr_GPfit.R
+++ b/R/RLearner_regr_GPfit.R
@@ -10,27 +10,28 @@ makeRLearner.regr.GPfit = function(){
       makeIntegerLearnerParam(id = "maxit", default = 100, lower = 1),
       makeUntypedLearnerParam(id = "optim_start", default = NULL),  
       makeLogicalLearnerParam(id = "scale", default = TRUE),
-      makeDiscreteLearnerParam(id = "corr_type", values = c("exponential", "matern"), default = "exponential"),
-      makeIntegerLearnerParam(id = "matern_nu_k", default = 0L, lower = 0L, requires = quote(corr_type == "matern")), 
-      makeNumericLearnerParam(id = "exp_power", default = 1.95, lower = 1.0, upper = 2.0, requires = quote(corr_type == "exponential"))
+      makeDiscreteLearnerParam(id = "type", values = c("exponential", "matern"), default = "exponential"),
+      makeIntegerLearnerParam(id = "matern_nu_k", default = 0L, lower = 0L, requires = quote(type == "matern")), 
+      makeNumericLearnerParam(id = "power", default = 1.95, lower = 1.0, upper = 2.0, requires = quote(type == "exponential"))
     ),
-    par.vals = list(scale = TRUE, corr_type = "exponential",  matern_nu_k = 0L, exp_power = 1.95),
+    par.vals = list(scale = TRUE, type = "exponential",  matern_nu_k = 0L, power = 1.95),
     properties = c("numerics","se"),
     name = "Gaussian Process",
     short.name = "GPfit",
-    note = "As the optimization routine assumes that the inputs are scaled to the unit hypercube [0,1]^d, 
+    note = "(1) As the optimization routine assumes that the inputs are scaled to the unit hypercube [0,1]^d, 
             the input gets scaled for each variable by default. If this is not wanted, scale = FALSE has
-            to be set."
+            to be set. (2) As in GPfit documentation, if the correlation kernal or type is set to be matern, 
+            we name this k to be called matern_nu_k"
   )
 }
 #' @export
-trainLearner.regr.GPfit = function(.learner, .task, .subset, .weights = NULL, scale, corr_type, matern_nu_k, exp_power, ...) {
+trainLearner.regr.GPfit = function(.learner, .task, .subset, .weights = NULL, scale, type, matern_nu_k, power, ...) {
   # tri_dots = list(...)
-  # trans.vec = c("corr_type", "matern_nu_k", "exp_power")
+  # trans.vec = c("type", "matern_nu_k", "power")
   # dots = dropNamed(tri_dots, trans.vec)
   # print(dots)
-  # if (tri_dots$corr_type == "exponential") {
-  #   corr = list(type="exponential", power = tri_dots$"exp_power")
+  # if (tri_dots$type == "exponential") {
+  #   corr = list(type="exponential", power = tri_dots$"power")
   # } else {
   #   k = tri_dots$matern_nu_k
   #   corr = list(type="matern",nu = k+0.5 )
@@ -47,7 +48,7 @@ trainLearner.regr.GPfit = function(.learner, .task, .subset, .weights = NULL, sc
   } else {
     mlist = list(scaled = FALSE, not.const = not.const)
   }
-  res = GPfit::GP_fit(d$data[, not.const], d$target, corr = list(type = corr_type, power = exp_power, nu = matern_nu_k+0.5 ), ...)
+  res = GPfit::GP_fit(d$data[, not.const], d$target, corr = list(type = type, power = power, nu = matern_nu_k+0.5 ), ...)
   # h.GPfit = function(...) {
   #   GPfit::GP_fit(X = d$data[, not.const], Y = d$target, ...)
   # }

--- a/R/RLearner_regr_GPfit.R
+++ b/R/RLearner_regr_GPfit.R
@@ -20,24 +20,14 @@ makeRLearner.regr.GPfit = function(){
     short.name = "GPfit",
     note = "(1) As the optimization routine assumes that the inputs are scaled to the unit hypercube [0,1]^d, 
             the input gets scaled for each variable by default. If this is not wanted, scale = FALSE has
-            to be set. (2) As in GPfit documentation, if the correlation kernal or type is set to be matern, 
-            we name this k to be called matern_nu_k"
+            to be set. (2) We replace the GPfit parameter 'corr = list(type='exponential',power=1.95)' to be seperate 
+            parameters 'type' and 'power', in the case of  corr = list(type='matern', nu = 0.5), the seperate parameters
+            are 'type' and 'matern_nu_k=0', and nu is computed by 'nu=(2*matern_nu_k+1)/2=0.5' 
+            "
   )
 }
 #' @export
 trainLearner.regr.GPfit = function(.learner, .task, .subset, .weights = NULL, scale, type, matern_nu_k, power, ...) {
-  # tri_dots = list(...)
-  # trans.vec = c("type", "matern_nu_k", "power")
-  # dots = dropNamed(tri_dots, trans.vec)
-  # print(dots)
-  # if (tri_dots$type == "exponential") {
-  #   corr = list(type="exponential", power = tri_dots$"power")
-  # } else {
-  #   k = tri_dots$matern_nu_k
-  #   corr = list(type="matern",nu = k+0.5 )
-  # }
-  # args = c(dots, list(corr))
-  
   d = getTaskData(.task, .subset, target.extra = TRUE)
   low = apply(d$data, 2, min)
   high = apply(d$data, 2, max)
@@ -49,10 +39,6 @@ trainLearner.regr.GPfit = function(.learner, .task, .subset, .weights = NULL, sc
     mlist = list(scaled = FALSE, not.const = not.const)
   }
   res = GPfit::GP_fit(d$data[, not.const], d$target, corr = list(type = type, power = power, nu = matern_nu_k+0.5 ), ...)
-  # h.GPfit = function(...) {
-  #   GPfit::GP_fit(X = d$data[, not.const], Y = d$target, ...)
-  # }
-  # res = do.call(h.GPfit, args)
   res = attachTrainingInfo(res, mlist)
   return(res)
 }
@@ -65,7 +51,6 @@ predictLearner.regr.GPfit = function(.learner, .model, .newdata, ...) {
     }
   } 
   rst=predict(.model$learner.model, xnew = .newdata[, tr.info$not.const])
-  
   se = (.learner$predict.type != "response")
   if (!se)
     return(rst$Y_hat)


### PR DESCRIPTION
1. Currently the GPfit package support exponential and matern kernel, The problem is according to the documentation of GPfit, the nu parameter for matern can only take 0.5,1.5,2.0....  and what I have done is set k to be an integer, then calculate k+0.5 to feed the GPfit function. 
Reference: 
"a list that specifies thetypeof correlation function along with the smooth-ness parameter. The default corresponds to power exponential correlation with smoothness parameter "power=1.95". One can specify a different power (be-tween 1.0 and 2.0) for the power exponential, or use the Matern correlation function, specified ascorr=list(type = "matern", nu=(2*k+1)/2), where k=0;1;2;3;...." 

2. Not sure if the commented out lines are a better implementation for this issue which I have tried earlier.

