### PR TITLE
DOC: add notes for also generating performance on train set (#1044)

### DIFF
--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -1,31 +1,31 @@
 #' @title Generate hyperparameter effect data.
 #'
-#' @description 
-#' Generate cleaned hyperparameter effect data from a tuning result or from a 
-#' nested cross-validation tuning result. The object returned can be used for 
-#' custom visualization or passed downstream to an out of the box mlr method, 
+#' @description
+#' Generate cleaned hyperparameter effect data from a tuning result or from a
+#' nested cross-validation tuning result. The object returned can be used for
+#' custom visualization or passed downstream to an out of the box mlr method,
 #' \code{\link{plotHyperParsEffect}}.
-#' 
+#'
 #' @param tune.result [\code{\link{TuneResult}} | \code{\link{ResampleResult}}]\cr
 #'  Result of \code{\link{tuneParams}} (or \code{\link{resample}} ONLY when used
-#'  for nested cross-validation). The tuning result (or results if the 
-#'  output is from nested cross-validation), also containing the 
-#'  optimizer results. If nested CV output is passed, each element in the list 
-#'  will be considered a separate run, and the data from each run will be 
+#'  for nested cross-validation). The tuning result (or results if the
+#'  output is from nested cross-validation), also containing the
+#'  optimizer results. If nested CV output is passed, each element in the list
+#'  will be considered a separate run, and the data from each run will be
 #'  included in the dataframe within the returned \code{HyperParsEffectData}.
 #' @param include.diagnostics [\code{logical(1)}]\cr
 #'  Should diagnostic info (eol and error msg) be included?
 #'  Default is \code{FALSE}.
 #' @param trafo [\code{logical(1)}]\cr
-#'  Should the units of the hyperparameter path be converted to the 
+#'  Should the units of the hyperparameter path be converted to the
 #'  transformed scale? This is only useful when trafo was used to create the
 #'  path.
 #'  Default is \code{FALSE}.
 #'
 #' @return [\code{HyperParsEffectData}]
-#'  Object containing the hyperparameter effects dataframe, the tuning 
-#'  performance measures used, the hyperparameters used, a flag for including 
-#'  diagnostic info, a flag for whether nested cv was used, and the optimization 
+#'  Object containing the hyperparameter effects dataframe, the tuning
+#'  performance measures used, the hyperparameters used, a flag for including
+#'  diagnostic info, a flag for whether nested cv was used, and the optimization
 #'  algorithm used.
 #'
 #' @examples \dontrun{
@@ -37,14 +37,14 @@
 #' par.set = ps, control = ctrl)
 #' data = generateHyperParsEffectData(res)
 #' plotHyperParsEffect(data, x = "C", y = "mmce.test.mean")
-#' 
+#'
 #' # nested cross validation
 #' ps = makeParamSet(makeDiscreteParam("C", values = 2^(-4:4)))
 #' ctrl = makeTuneControlGrid()
 #' rdesc = makeResampleDesc("CV", iters = 3L)
 #' lrn = makeTuneWrapper("classif.ksvm", control = ctrl,
 #'                       resampling = rdesc, par.set = ps)
-#' res = resample(lrn, task = pid.task, resampling = cv2, 
+#' res = resample(lrn, task = pid.task, resampling = cv2,
 #'                extract = getTuneResult)
 #' data = generateHyperParsEffectData(res)
 #' plotHyperParsEffect(data, x = "C", y = "mmce.test.mean", plot.type = "line")
@@ -54,11 +54,11 @@
 generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
                                        trafo = FALSE) {
   assert(
-    checkClass(tune.result, "ResampleResult"), 
-    checkClass(tune.result, classes = c("TuneResult", "OptResult"))
+    checkClass(tune.result, "ResampleResult"),
+    checkClass(tune.result, classes = "TuneResult")
   )
   assertFlag(include.diagnostics)
-  
+
   # in case we have nested CV
   if (getClass1(tune.result) == "ResampleResult"){
     if (trafo){
@@ -80,7 +80,7 @@ generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
     }
     # rename to be clear this denotes the nested cv
     names(d)[names(d) == "iter"] = "nested_cv_run"
-  
+
     # items for object
     measures = tune.result$extract[[1]]$opt.path$y.names
     hyperparams = names(tune.result$extract[[1]]$x)
@@ -103,17 +103,17 @@ generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
     optimization = getClass1(tune.result$control)
     nested = FALSE
   }
-    
+
   # off by default unless needed by user
   if (include.diagnostics == FALSE)
     d = within(d, rm("eol", "error.message"))
-  
+
   # users might not know what dob means, so let's call it iteration
   names(d)[names(d) == "dob"] = "iteration"
-  
+
   makeS3Obj("HyperParsEffectData", data = d, measures = measures,
-    hyperparams = hyperparams, 
-    diagnostics = include.diagnostics, 
+    hyperparams = hyperparams,
+    diagnostics = include.diagnostics,
     optimization = optimization,
     nested = nested)
 }
@@ -130,9 +130,9 @@ print.HyperParsEffectData = function(x, ...) {
 }
 
 #' @title Plot the hyperparameter effects data
-#' 
-#' @description 
-#' Plot hyperparameter validation path. Automated plotting method for 
+#'
+#' @description
+#' Plot hyperparameter validation path. Automated plotting method for
 #' \code{HyperParsEffectData} object. Useful for determining the importance
 #' or effect of a particular hyperparameter on some performance measure and/or
 #' optimizer.
@@ -147,72 +147,72 @@ print.HyperParsEffectData = function(x, ...) {
 #'  \code{HyperParsEffectData$data}
 #' @param z [\code{character(1)}]\cr
 #'  Specify what should be used as the extra axis for a particular geom. This
-#'  could be for the fill on a heatmap or color aesthetic for a line. Must be a 
+#'  could be for the fill on a heatmap or color aesthetic for a line. Must be a
 #'  column from \code{HyperParsEffectData$data}. Default is \code{NULL}.
 #' @param plot.type [\code{character(1)}]\cr
-#'  Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a 
+#'  Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a
 #'  heatmap, \dQuote{line} for a scatterplot with a connecting line, or \dQuote{contour} for a
 #'  contour plot layered ontop of a heatmap.
 #'  Default is \dQuote{scatter}.
 #' @param loess.smooth [\code{logical(1)}]\cr
-#'  If \code{TRUE}, will add loess smoothing line to plots where possible. Note that 
-#'  this is probably only useful when \code{plot.type} is set to either 
+#'  If \code{TRUE}, will add loess smoothing line to plots where possible. Note that
+#'  this is probably only useful when \code{plot.type} is set to either
 #'  \dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{FALSE}.
 #' @param facet [\code{character(1)}]\cr
-#'  Specify what should be used as the facet axis for a particular geom. When 
+#'  Specify what should be used as the facet axis for a particular geom. When
 #'  using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 #'  for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{NULL}.
 #' @template arg_prettynames
 #' @param global.only [\code{logical(1)}]\cr
-#'  If \code{TRUE}, will only plot the current global optima when setting 
-#'  x = "iteration" and y as a performance measure from 
-#'  \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the 
+#'  If \code{TRUE}, will only plot the current global optima when setting
+#'  x = "iteration" and y as a performance measure from
+#'  \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the
 #'  performance of every iteration, even if it is not an improvement.
 #'  Default is \code{TRUE}.
 #' @param interpolate [\code{\link{Learner}} | \code{character(1)}]\cr
-#'  If not \code{NULL}, will interpolate non-complete grids in order to visualize a more 
+#'  If not \code{NULL}, will interpolate non-complete grids in order to visualize a more
 #'  complete path. Only meaningful when attempting to plot a heatmap or contour.
-#'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that 
+#'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
 #'  cases of irregular hyperparameter paths, you will most likely need to use
 #'  this to have a meaningful visualization. Accepts either a \link{Learner}
 #'  object or the learner as a string for interpolation.
 #'  Default is \code{NULL}.
 #' @param show.experiments [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will overlay the plot with points indicating where an experiment
-#'  ran. This is only useful when creating a heatmap or contour plot with 
-#'  interpolation so that you can see which points were actually on the 
+#'  ran. This is only useful when creating a heatmap or contour plot with
+#'  interpolation so that you can see which points were actually on the
 #'  original path. Note: if any learner crashes occurred within the path, this
 #'  will become \code{TRUE}.
 #'  Default is \code{FALSE}.
 #' @param show.interpolated [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will overlay the plot with points indicating where interpolation
-#'  ran. This is only useful when creating a heatmap or contour plot with 
+#'  ran. This is only useful when creating a heatmap or contour plot with
 #'  interpolation so that you can see which points were interpolated.
 #'  Default is \code{FALSE}.
 #' @param nested.agg [\code{function}]\cr
 #'  The function used to aggregate nested cross validation runs when plotting 2
-#'  hyperpars simultaneously. This is only useful when nested cross validation 
+#'  hyperpars simultaneously. This is only useful when nested cross validation
 #'  is used along with plotting a 2 hyperpars.
-#'  Default is \code{mean}. 
+#'  Default is \code{mean}.
 #' @template ret_gg2
-#'  
-#' @note Any NAs incurred from learning algorithm crashes will be indicated in 
+#'
+#' @note Any NAs incurred from learning algorithm crashes will be indicated in
 #' the plot and the NA values will be replaced with the column min/max depending
 #' on the optimal values for the respective measure. Execution time will be
-#' replaced with the max. Interpolation by its nature will result in predicted 
+#' replaced with the max. Interpolation by its nature will result in predicted
 #' values for the performance measure. Use interpolation with caution.
-#' 
+#'
 #' @export
 #'
 #' @examples
 #' # see generateHyperParsEffectData
-plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL, 
-                               z = NULL, plot.type = "scatter", 
-                               loess.smooth = FALSE, facet = NULL, 
-                               pretty.names = TRUE, global.only = TRUE, 
-                               interpolate = NULL, show.experiments = FALSE, 
+plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
+                               z = NULL, plot.type = "scatter",
+                               loess.smooth = FALSE, facet = NULL,
+                               pretty.names = TRUE, global.only = TRUE,
+                               interpolate = NULL, show.experiments = FALSE,
                                show.interpolated = FALSE, nested.agg = mean) {
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
@@ -223,29 +223,29 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   assertSubset(facet, choices = names(hyperpars.effect.data$data))
   assertFlag(pretty.names)
   assertFlag(global.only)
-  assert(checkClass(interpolate, "Learner"), checkString(interpolate), 
+  assert(checkClass(interpolate, "Learner"), checkString(interpolate),
          checkNull(interpolate))
   # assign learner for interpolation
-  if (checkClass(interpolate, "Learner") == TRUE || 
+  if (checkClass(interpolate, "Learner") == TRUE ||
       checkString(interpolate) == TRUE) {
     lrn = checkLearnerRegr(interpolate)
   }
   assertFlag(show.experiments)
   assertFunction(nested.agg)
-  
+
   if (length(x) > 1 || length(y) > 1 || length(z) > 1 || length(facet) > 1)
     stopf("Greater than 1 length x, y, z or facet not yet supported")
-  
+
   d = hyperpars.effect.data$data
   if (hyperpars.effect.data$nested)
     d$nested_cv_run = as.factor(d$nested_cv_run)
-  
+
   # set flags for building plots
   na.flag = any(is.na(d[, hyperpars.effect.data$measures]))
   z.flag = !is.null(z)
   facet.flag = !is.null(facet)
   heatcontour.flag = plot.type %in% c("heatmap", "contour")
-  
+
   # deal with NAs where optimizer failed
   if (na.flag){
     d$learner_status = ifelse(is.na(d[, "exec.time"]), "Failure", "Success")
@@ -266,7 +266,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     # in case the user wants to show this despite no learner crashes
     d$learner_status = "Success"
   }
-  
+
   # assign for global only
   if (global.only && x == "iteration" && y %in% hyperpars.effect.data$measures){
     for (col in hyperpars.effect.data$measures) {
@@ -278,21 +278,21 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       }
     }
   }
-  
+
   if ((!is.null(interpolate)) && z.flag && (heatcontour.flag)){
     # create grid
     xo = seq(min(d[,x]), max(d[,x]), length.out = 100)
     yo = seq(min(d[,y]), max(d[,y]), length.out = 100)
     grid = expand.grid(xo, yo, KEEP.OUT.ATTRS = F)
     names(grid) = c(x, y)
-    
+
     if (hyperpars.effect.data$nested){
       d_new = d
       new_d = data.frame()
       # for loop for each nested cv run
       for (run in unique(d$nested_cv_run)){
         d_run = d_new[d_new$nested_cv_run == run, ]
-        regr.task = makeRegrTask(id = "interp", data = d_run[,c(x,y,z)], 
+        regr.task = makeRegrTask(id = "interp", data = d_run[,c(x,y,z)],
           target = z)
         mod = train(lrn, regr.task)
         prediction = predict(mod, newdata = grid)
@@ -321,15 +321,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     grid[grid[,z] > max(d[,z]), z] = max(d[,z])
     d = grid
   }
-  
+
   if (hyperpars.effect.data$nested && z.flag){
-    averaging = d[, !(names(d) %in% c("iteration", "nested_cv_run", 
+    averaging = d[, !(names(d) %in% c("iteration", "nested_cv_run",
       hyperpars.effect.data$hyperparams, "eol",
-      "error.message", "learner_status")), 
+      "error.message", "learner_status")),
       drop = FALSE]
     # keep experiments if we need it
     if (na.flag || (!is.null(interpolate)) || show.experiments){
-      hyperpars = lapply(d[, c(hyperpars.effect.data$hyperparams, 
+      hyperpars = lapply(d[, c(hyperpars.effect.data$hyperparams,
         "learner_status")], "[")
     } else {
       hyperpars = lapply(d[, hyperpars.effect.data$hyperparams], "[")
@@ -337,8 +337,8 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     d = aggregate(averaging, hyperpars, nested.agg)
     d$iteration = 1:nrow(d)
   }
-  
-  # just x, y  
+
+  # just x, y
   if ((length(x) == 1) && (length(y) == 1) && !(z.flag)){
     if (hyperpars.effect.data$nested){
       plt = ggplot(d, aes_string(x = x, y = y, color = "nested_cv_run"))
@@ -346,7 +346,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       plt = ggplot(d, aes_string(x = x, y = y))
     }
     if (na.flag){
-      plt = plt + geom_point(aes_string(shape = "learner_status", 
+      plt = plt + geom_point(aes_string(shape = "learner_status",
         color = "learner_status")) +
         scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
         scale_color_manual(values = c("red", "black"))
@@ -363,7 +363,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     # the data we use depends on if interpolation
     if (heatcontour.flag){
       if (!is.null(interpolate)){
-        plt = ggplot(data = d[d$learner_status == "Interpolated Point", ], 
+        plt = ggplot(data = d[d$learner_status == "Interpolated Point", ],
           aes_string(x = x, y = y, fill = z, z = z)) + geom_raster()
         if (show.interpolated && !(na.flag || show.experiments)){
           plt = plt + geom_point(aes_string(shape = "learner_status")) +
@@ -374,15 +374,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
           geom_tile()
       }
       if ((na.flag || show.experiments) && !(show.interpolated)){
-        plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
+        plt = plt + geom_point(data = d[d$learner_status %in% c("Success",
           "Failure"), ],
-          aes_string(shape = "learner_status"), 
+          aes_string(shape = "learner_status"),
           fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0))
       } else if ((na.flag || show.experiments) && (show.interpolated)) {
-        plt = plt + geom_point(data = d, aes_string(shape = "learner_status"), 
+        plt = plt + geom_point(data = d, aes_string(shape = "learner_status"),
           fill = "red") +
-          scale_shape_manual(values = c("Failure" = 24, "Success" = 0, 
+          scale_shape_manual(values = c("Failure" = 24, "Success" = 0,
             "Interpolated Point" = 6))
       }
       if (plot.type == "contour")
@@ -390,7 +390,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     } else {
       plt = ggplot(d, aes_string(x = x, y = y, color = z))
       if (na.flag){
-        plt = plt + geom_point(aes_string(shape = "learner_status", 
+        plt = plt + geom_point(aes_string(shape = "learner_status",
           color = "learner_status")) +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
           scale_color_manual(values = c("red", "black"))
@@ -401,20 +401,20 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
         plt = plt + geom_line()
     }
   }
-  
+
   # pretty name changing
   if (pretty.names) {
     if (x %in% hyperpars.effect.data$measures)
-      plt = plt + 
+      plt = plt +
         xlab(eval(as.name(stri_split_fixed(x, ".test.mean")[[1]][1]))$name)
     if (y %in% hyperpars.effect.data$measures)
-      plt = plt + 
+      plt = plt +
         ylab(eval(as.name(stri_split_fixed(y, ".test.mean")[[1]][1]))$name)
     if (!is.null(z))
       if (z %in% hyperpars.effect.data$measures)
         plt = plt +
-          labs(fill = eval(as.name(stri_split_fixed(z, 
-            ".test.mean")[[1]][1]))$name) 
+          labs(fill = eval(as.name(stri_split_fixed(z,
+            ".test.mean")[[1]][1]))$name)
   }
   return(plt)
 }

--- a/R/resample.R
+++ b/R/resample.R
@@ -49,9 +49,9 @@
 #' @template arg_showinfo
 #' @return [\code{\link{ResampleResult}}].
 #' @family resample
-#' @note If you would like to include results from the training data set, make 
-#' sure to appropriately adjust the resampling strategy and the aggregation for 
-#' the measure.
+#' @note If you would like to include results from the training data set, make
+#' sure to appropriately adjust the resampling strategy and the aggregation for
+#' the measure. See example code below.
 #' @export
 #' @examples
 #' task = makeClassifTask(data = iris, target = "Species")
@@ -60,10 +60,10 @@
 #' print(r$aggr)
 #' print(r$measures.test)
 #' print(r$pred)
-#' 
+#'
 #' # include the training set performance as well
 #' rdesc = makeResampleDesc("CV", iters = 2, predict = "both")
-#' r = resample(makeLearner("classif.qda"), task, rdesc, 
+#' r = resample(makeLearner("classif.qda"), task, rdesc,
 #'   measures = list(mmce, setAggregation(mmce, train.mean)))
 #' print(r$aggr)
 resample = function(learner, task, resampling, measures, weights = NULL, models = FALSE,

--- a/R/resample.R
+++ b/R/resample.R
@@ -49,6 +49,9 @@
 #' @template arg_showinfo
 #' @return [\code{\link{ResampleResult}}].
 #' @family resample
+#' @note If you would like to include results from the training data set, make 
+#' sure to appropriately adjust the resampling strategy and the aggregation for 
+#' the measure.
 #' @export
 #' @examples
 #' task = makeClassifTask(data = iris, target = "Species")
@@ -57,6 +60,12 @@
 #' print(r$aggr)
 #' print(r$measures.test)
 #' print(r$pred)
+#' 
+#' # include the training set performance as well
+#' rdesc = makeResampleDesc("CV", iters = 2, predict = "both")
+#' r = resample(makeLearner("classif.qda"), task, rdesc, 
+#'   measures = list(mmce, setAggregation(mmce, train.mean)))
+#' print(r$aggr)
 resample = function(learner, task, resampling, measures, weights = NULL, models = FALSE,
   extract, keep.pred = TRUE, ..., show.info = getMlrOption("show.info")) {
 

--- a/R/tuneParams.R
+++ b/R/tuneParams.R
@@ -43,8 +43,8 @@
 #' rdesc = makeResampleDesc("CV", iters = 2L)
 #' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 #' print(res)
-#' print(as.data.frame(res$opt.path))
-#' print(as.data.frame(trafoOptPath(res$opt.path)))
+#' print(generateHyperParsEffectData(res))
+#' print(generateHyperParsEffectData(res, trafo = TRUE))
 #'
 #' \dontrun{
 #' # we optimize the SVM over 3 kernels simultanously
@@ -62,15 +62,16 @@
 #' rdesc = makeResampleDesc("Holdout")
 #' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 #' print(res)
-#' print(head(as.data.frame(res$opt.path)))
+#' print(generateHyperParsEffectData(res))
 #' 
 #' # include the training set performance as well
 #' rdesc = makeResampleDesc("Holdout", predict = "both")
 #' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, 
 #'   control = ctrl, measures = list(mmce, setAggregation(mmce, train.mean)))
-#' 
+#' print(res)
+#' print(generateHyperParsEffectData(res))
 #' }
-#' @seealso [\code{\link{generateHyperParsEffectData}}]
+#' @seealso \code{\link{generateHyperParsEffectData}}
 tuneParams = function(learner, task, resampling, measures, par.set, control, show.info = getMlrOption("show.info")) {
   learner = checkLearner(learner)
   assertClass(task, classes = "Task")

--- a/R/tuneParams.R
+++ b/R/tuneParams.R
@@ -28,6 +28,9 @@
 #' @template arg_showinfo
 #' @return [\code{\link{TuneResult}}].
 #' @family tune
+#' @note If you would like to include results from the training data set, make 
+#' sure to appropriately adjust the resampling strategy and the aggregation for 
+#' the measure.
 #' @export
 #' @examples
 #' # a grid search for an SVM (with a tiny number of points...)
@@ -60,7 +63,14 @@
 #' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 #' print(res)
 #' print(head(as.data.frame(res$opt.path)))
+#' 
+#' # include the training set performance as well
+#' rdesc = makeResampleDesc("Holdout", predict = "both")
+#' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, 
+#'   control = ctrl, measures = list(mmce, setAggregation(mmce, train.mean)))
+#' 
 #' }
+#' @seealso [\code{\link{generateHyperParsEffectData}}]
 tuneParams = function(learner, task, resampling, measures, par.set, control, show.info = getMlrOption("show.info")) {
   learner = checkLearner(learner)
   assertClass(task, classes = "Task")

--- a/R/tuneParams.R
+++ b/R/tuneParams.R
@@ -28,9 +28,9 @@
 #' @template arg_showinfo
 #' @return [\code{\link{TuneResult}}].
 #' @family tune
-#' @note If you would like to include results from the training data set, make 
-#' sure to appropriately adjust the resampling strategy and the aggregation for 
-#' the measure.
+#' @note If you would like to include results from the training data set, make
+#' sure to appropriately adjust the resampling strategy and the aggregation for
+#' the measure. See example code below.
 #' @export
 #' @examples
 #' # a grid search for an SVM (with a tiny number of points...)
@@ -43,10 +43,13 @@
 #' rdesc = makeResampleDesc("CV", iters = 2L)
 #' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 #' print(res)
-#' print(generateHyperParsEffectData(res))
-#' print(generateHyperParsEffectData(res, trafo = TRUE))
+#' # access data for all evaluated points
+#' print(head(as.data.frame(res$opt.path)))
+#' print(head(as.data.frame(res$opt.path, trafo = TRUE)))
+#' # access data for all evaluated points - alternative
+#' print(head(generateHyperParsEffectData(res)))
+#' print(head(generateHyperParsEffectData(res, trafo = TRUE)))
 #'
-#' \dontrun{
 #' # we optimize the SVM over 3 kernels simultanously
 #' # note how we use dependent params (requires = ...) and iterated F-racing here
 #' ps = makeParamSet(
@@ -62,15 +65,14 @@
 #' rdesc = makeResampleDesc("Holdout")
 #' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 #' print(res)
-#' print(generateHyperParsEffectData(res))
-#' 
+#' print(head(as.data.frame(res$opt.path)))
+#'
 #' # include the training set performance as well
 #' rdesc = makeResampleDesc("Holdout", predict = "both")
-#' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, 
+#' res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps,
 #'   control = ctrl, measures = list(mmce, setAggregation(mmce, train.mean)))
 #' print(res)
-#' print(generateHyperParsEffectData(res))
-#' }
+#' print(head(as.data.frame(res$opt.path)))
 #' @seealso \code{\link{generateHyperParsEffectData}}
 tuneParams = function(learner, task, resampling, measures, par.set, control, show.info = getMlrOption("show.info")) {
   learner = checkLearner(learner)

--- a/man/resample.Rd
+++ b/man/resample.Rd
@@ -121,6 +121,11 @@ The remaining functions on this page are convenience wrappers for the various
 existing resampling strategies. Note that if you need to work with precomputed training and
 test splits (i.e., resampling instances), you have to stick with \code{resample}.
 }
+\note{
+If you would like to include results from the training data set, make 
+sure to appropriately adjust the resampling strategy and the aggregation for 
+the measure.
+}
 \examples{
 task = makeClassifTask(data = iris, target = "Species")
 rdesc = makeResampleDesc("CV", iters = 2)
@@ -128,6 +133,12 @@ r = resample(makeLearner("classif.qda"), task, rdesc)
 print(r$aggr)
 print(r$measures.test)
 print(r$pred)
+
+# include the training set performance as well
+rdesc = makeResampleDesc("CV", iters = 2, predict = "both")
+r = resample(makeLearner("classif.qda"), task, rdesc, 
+  measures = list(mmce, setAggregation(mmce, train.mean)))
+print(r$aggr)
 }
 \seealso{
 Other resample: \code{\link{ResamplePrediction}},

--- a/man/resample.Rd
+++ b/man/resample.Rd
@@ -122,9 +122,9 @@ existing resampling strategies. Note that if you need to work with precomputed t
 test splits (i.e., resampling instances), you have to stick with \code{resample}.
 }
 \note{
-If you would like to include results from the training data set, make 
-sure to appropriately adjust the resampling strategy and the aggregation for 
-the measure.
+If you would like to include results from the training data set, make
+sure to appropriately adjust the resampling strategy and the aggregation for
+the measure. See example code below.
 }
 \examples{
 task = makeClassifTask(data = iris, target = "Species")
@@ -136,7 +136,7 @@ print(r$pred)
 
 # include the training set performance as well
 rdesc = makeResampleDesc("CV", iters = 2, predict = "both")
-r = resample(makeLearner("classif.qda"), task, rdesc, 
+r = resample(makeLearner("classif.qda"), task, rdesc,
   measures = list(mmce, setAggregation(mmce, train.mean)))
 print(r$aggr)
 }

--- a/man/tuneParams.Rd
+++ b/man/tuneParams.Rd
@@ -66,8 +66,8 @@ ctrl = makeTuneControlGrid(resolution = 2L)
 rdesc = makeResampleDesc("CV", iters = 2L)
 res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 print(res)
-print(as.data.frame(res$opt.path))
-print(as.data.frame(trafoOptPath(res$opt.path)))
+print(generateHyperParsEffectData(res))
+print(generateHyperParsEffectData(res, trafo = TRUE))
 
 \dontrun{
 # we optimize the SVM over 3 kernels simultanously
@@ -85,17 +85,18 @@ ctrl = makeTuneControlIrace(maxExperiments = 200L)
 rdesc = makeResampleDesc("Holdout")
 res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 print(res)
-print(head(as.data.frame(res$opt.path)))
+print(generateHyperParsEffectData(res))
 
 # include the training set performance as well
 rdesc = makeResampleDesc("Holdout", predict = "both")
 res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, 
   control = ctrl, measures = list(mmce, setAggregation(mmce, train.mean)))
-
+print(res)
+print(generateHyperParsEffectData(res))
 }
 }
 \seealso{
-[\code{\link{generateHyperParsEffectData}}]
+\code{\link{generateHyperParsEffectData}}
 
 Other tune: \code{\link{TuneControl}},
   \code{\link{getNestedTuneResultsOptPathDf}},

--- a/man/tuneParams.Rd
+++ b/man/tuneParams.Rd
@@ -50,6 +50,11 @@ by passing a corresponding control object. For a complete list of implemented al
 
 Multi-criteria tuning can be done with \code{\link{tuneParamsMultiCrit}}.
 }
+\note{
+If you would like to include results from the training data set, make 
+sure to appropriately adjust the resampling strategy and the aggregation for 
+the measure.
+}
 \examples{
 # a grid search for an SVM (with a tiny number of points...)
 # note how easily we can optimize on a log-scale
@@ -81,9 +86,17 @@ rdesc = makeResampleDesc("Holdout")
 res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 print(res)
 print(head(as.data.frame(res$opt.path)))
+
+# include the training set performance as well
+rdesc = makeResampleDesc("Holdout", predict = "both")
+res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, 
+  control = ctrl, measures = list(mmce, setAggregation(mmce, train.mean)))
+
 }
 }
 \seealso{
+[\code{\link{generateHyperParsEffectData}}]
+
 Other tune: \code{\link{TuneControl}},
   \code{\link{getNestedTuneResultsOptPathDf}},
   \code{\link{getNestedTuneResultsX}},

--- a/man/tuneParams.Rd
+++ b/man/tuneParams.Rd
@@ -51,9 +51,9 @@ by passing a corresponding control object. For a complete list of implemented al
 Multi-criteria tuning can be done with \code{\link{tuneParamsMultiCrit}}.
 }
 \note{
-If you would like to include results from the training data set, make 
-sure to appropriately adjust the resampling strategy and the aggregation for 
-the measure.
+If you would like to include results from the training data set, make
+sure to appropriately adjust the resampling strategy and the aggregation for
+the measure. See example code below.
 }
 \examples{
 # a grid search for an SVM (with a tiny number of points...)
@@ -66,10 +66,13 @@ ctrl = makeTuneControlGrid(resolution = 2L)
 rdesc = makeResampleDesc("CV", iters = 2L)
 res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 print(res)
-print(generateHyperParsEffectData(res))
-print(generateHyperParsEffectData(res, trafo = TRUE))
+# access data for all evaluated points
+print(head(as.data.frame(res$opt.path)))
+print(head(as.data.frame(res$opt.path, trafo = TRUE)))
+# access data for all evaluated points - alternative
+print(head(generateHyperParsEffectData(res)))
+print(head(generateHyperParsEffectData(res, trafo = TRUE)))
 
-\dontrun{
 # we optimize the SVM over 3 kernels simultanously
 # note how we use dependent params (requires = ...) and iterated F-racing here
 ps = makeParamSet(
@@ -85,15 +88,14 @@ ctrl = makeTuneControlIrace(maxExperiments = 200L)
 rdesc = makeResampleDesc("Holdout")
 res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, control = ctrl)
 print(res)
-print(generateHyperParsEffectData(res))
+print(head(as.data.frame(res$opt.path)))
 
 # include the training set performance as well
 rdesc = makeResampleDesc("Holdout", predict = "both")
-res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps, 
+res = tuneParams("classif.ksvm", iris.task, rdesc, par.set = ps,
   control = ctrl, measures = list(mmce, setAggregation(mmce, train.mean)))
 print(res)
-print(generateHyperParsEffectData(res))
-}
+print(head(as.data.frame(res$opt.path)))
 }
 \seealso{
 \code{\link{generateHyperParsEffectData}}


### PR DESCRIPTION
I added note for `resample` and `tuneParams` along with an example. I also cleaned up references that should use the new `generateHyperParsEffectData`.

Closes #1044 