### PR TITLE
GSoC WIP: Add support for partial dependency on hyperpar effects tasks

### DIFF
--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -269,7 +269,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   # if single hyper and multiple measures, 1 graph/multiple colored lines or many graphs/1 line
   # if multiple hypers & single measure, pull from defaults and facet to get graph per hyper
   # if multiple hypers & multiple measures, graph for each hyper/multiple colored lines or column for each measure
-  if (!is.null(hyperpars.effect.data$partial) && 
+  if ((hyperpars.effect.data$partial) && 
       !("iteration" %in% c(x,y,z))) {
     partial = hyperpars.effect.data$partial.data
     # just x, y

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -1,31 +1,33 @@
 #' @title Generate hyperparameter effect data.
 #'
-#' @description
-#' Generate cleaned hyperparameter effect data from a tuning result or from a
-#' nested cross-validation tuning result. The object returned can be used for
-#' custom visualization or passed downstream to an out of the box mlr method,
+#' @description 
+#' Generate cleaned hyperparameter effect data from a tuning result or from a 
+#' nested cross-validation tuning result. The object returned can be used for 
+#' custom visualization or passed downstream to an out of the box mlr method, 
 #' \code{\link{plotHyperParsEffect}}.
-#'
+#' 
 #' @param tune.result [\code{\link{TuneResult}} | \code{\link{ResampleResult}}]\cr
 #'  Result of \code{\link{tuneParams}} (or \code{\link{resample}} ONLY when used
-#'  for nested cross-validation). The tuning result (or results if the
-#'  output is from nested cross-validation), also containing the
-#'  optimizer results. If nested CV output is passed, each element in the list
-#'  will be considered a separate run, and the data from each run will be
+#'  for nested cross-validation). The tuning result (or results if the 
+#'  output is from nested cross-validation), also containing the 
+#'  optimizer results. If nested CV output is passed, each element in the list 
+#'  will be considered a separate run, and the data from each run will be 
 #'  included in the dataframe within the returned \code{HyperParsEffectData}.
 #' @param include.diagnostics [\code{logical(1)}]\cr
 #'  Should diagnostic info (eol and error msg) be included?
 #'  Default is \code{FALSE}.
 #' @param trafo [\code{logical(1)}]\cr
-#'  Should the units of the hyperparameter path be converted to the
+#'  Should the units of the hyperparameter path be converted to the 
 #'  transformed scale? This is only useful when trafo was used to create the
 #'  path.
 #'  Default is \code{FALSE}.
+#' @param partial.dep [\code{logical(1)}]\cr
+#'  Should partial dependency be generated based on converting to reg task?
 #'
 #' @return [\code{HyperParsEffectData}]
-#'  Object containing the hyperparameter effects dataframe, the tuning
-#'  performance measures used, the hyperparameters used, a flag for including
-#'  diagnostic info, a flag for whether nested cv was used, and the optimization
+#'  Object containing the hyperparameter effects dataframe, the tuning 
+#'  performance measures used, the hyperparameters used, a flag for including 
+#'  diagnostic info, a flag for whether nested cv was used, and the optimization 
 #'  algorithm used.
 #'
 #' @examples \dontrun{
@@ -37,14 +39,14 @@
 #' par.set = ps, control = ctrl)
 #' data = generateHyperParsEffectData(res)
 #' plotHyperParsEffect(data, x = "C", y = "mmce.test.mean")
-#'
+#' 
 #' # nested cross validation
 #' ps = makeParamSet(makeDiscreteParam("C", values = 2^(-4:4)))
 #' ctrl = makeTuneControlGrid()
 #' rdesc = makeResampleDesc("CV", iters = 3L)
 #' lrn = makeTuneWrapper("classif.ksvm", control = ctrl,
 #'                       resampling = rdesc, par.set = ps)
-#' res = resample(lrn, task = pid.task, resampling = cv2,
+#' res = resample(lrn, task = pid.task, resampling = cv2, 
 #'                extract = getTuneResult)
 #' data = generateHyperParsEffectData(res)
 #' plotHyperParsEffect(data, x = "C", y = "mmce.test.mean", plot.type = "line")
@@ -52,13 +54,13 @@
 #' @export
 #' @importFrom utils type.convert
 generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
-                                       trafo = FALSE) {
+                                       trafo = FALSE, partial.dep = FALSE) {
   assert(
-    checkClass(tune.result, "ResampleResult"),
-    checkClass(tune.result, classes = "TuneResult")
+    checkClass(tune.result, "ResampleResult"), 
+    checkClass(tune.result, classes = c("TuneResult", "OptResult"))
   )
   assertFlag(include.diagnostics)
-
+  
   # in case we have nested CV
   if (getClass1(tune.result) == "ResampleResult"){
     if (trafo){
@@ -80,7 +82,7 @@ generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
     }
     # rename to be clear this denotes the nested cv
     names(d)[names(d) == "iter"] = "nested_cv_run"
-
+  
     # items for object
     measures = tune.result$extract[[1]]$opt.path$y.names
     hyperparams = names(tune.result$extract[[1]]$x)
@@ -103,19 +105,31 @@ generateHyperParsEffectData = function(tune.result, include.diagnostics = FALSE,
     optimization = getClass1(tune.result$control)
     nested = FALSE
   }
-
+    
   # off by default unless needed by user
   if (include.diagnostics == FALSE)
     d = within(d, rm("eol", "error.message"))
-
+  
   # users might not know what dob means, so let's call it iteration
   names(d)[names(d) == "dob"] = "iteration"
-
+  
+  if (partial.dep) {
+    data.task = d[, c(hyperparams, measures[1])]
+    data.task = makeRegrTask(id = "par_dep", data = data.task, 
+      target = measures[1])
+    fit.reg = train("regr.randomForest", data.task)
+  } else {
+    data.task = NULL
+    fit.reg = NULL
+  }
+  
   makeS3Obj("HyperParsEffectData", data = d, measures = measures,
-    hyperparams = hyperparams,
-    diagnostics = include.diagnostics,
+    hyperparams = hyperparams, 
+    diagnostics = include.diagnostics, 
     optimization = optimization,
-    nested = nested)
+    nested = nested,
+    partial = !is.null(fit.reg),
+    partial.data = list(fit.reg, data.task))
 }
 
 #' @export
@@ -125,14 +139,16 @@ print.HyperParsEffectData = function(x, ...) {
   catf("Measures: %s", collapse(x$measures))
   catf("Optimizer: %s", collapse(x$optimization))
   catf("Nested CV Used: %s", collapse(x$nested))
+  if (!is.null(x$partial))
+    print("Partial dependence generated")
   catf("Snapshot of $data:")
   print(head(x$data))
 }
 
 #' @title Plot the hyperparameter effects data
-#'
-#' @description
-#' Plot hyperparameter validation path. Automated plotting method for
+#' 
+#' @description 
+#' Plot hyperparameter validation path. Automated plotting method for 
 #' \code{HyperParsEffectData} object. Useful for determining the importance
 #' or effect of a particular hyperparameter on some performance measure and/or
 #' optimizer.
@@ -147,72 +163,72 @@ print.HyperParsEffectData = function(x, ...) {
 #'  \code{HyperParsEffectData$data}
 #' @param z [\code{character(1)}]\cr
 #'  Specify what should be used as the extra axis for a particular geom. This
-#'  could be for the fill on a heatmap or color aesthetic for a line. Must be a
+#'  could be for the fill on a heatmap or color aesthetic for a line. Must be a 
 #'  column from \code{HyperParsEffectData$data}. Default is \code{NULL}.
 #' @param plot.type [\code{character(1)}]\cr
-#'  Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a
+#'  Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a 
 #'  heatmap, \dQuote{line} for a scatterplot with a connecting line, or \dQuote{contour} for a
 #'  contour plot layered ontop of a heatmap.
 #'  Default is \dQuote{scatter}.
 #' @param loess.smooth [\code{logical(1)}]\cr
-#'  If \code{TRUE}, will add loess smoothing line to plots where possible. Note that
-#'  this is probably only useful when \code{plot.type} is set to either
+#'  If \code{TRUE}, will add loess smoothing line to plots where possible. Note that 
+#'  this is probably only useful when \code{plot.type} is set to either 
 #'  \dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{FALSE}.
 #' @param facet [\code{character(1)}]\cr
-#'  Specify what should be used as the facet axis for a particular geom. When
+#'  Specify what should be used as the facet axis for a particular geom. When 
 #'  using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 #'  for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{NULL}.
 #' @template arg_prettynames
 #' @param global.only [\code{logical(1)}]\cr
-#'  If \code{TRUE}, will only plot the current global optima when setting
-#'  x = "iteration" and y as a performance measure from
-#'  \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the
+#'  If \code{TRUE}, will only plot the current global optima when setting 
+#'  x = "iteration" and y as a performance measure from 
+#'  \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the 
 #'  performance of every iteration, even if it is not an improvement.
 #'  Default is \code{TRUE}.
 #' @param interpolate [\code{\link{Learner}} | \code{character(1)}]\cr
-#'  If not \code{NULL}, will interpolate non-complete grids in order to visualize a more
+#'  If not \code{NULL}, will interpolate non-complete grids in order to visualize a more 
 #'  complete path. Only meaningful when attempting to plot a heatmap or contour.
-#'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
+#'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that 
 #'  cases of irregular hyperparameter paths, you will most likely need to use
 #'  this to have a meaningful visualization. Accepts either a \link{Learner}
 #'  object or the learner as a string for interpolation.
 #'  Default is \code{NULL}.
 #' @param show.experiments [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will overlay the plot with points indicating where an experiment
-#'  ran. This is only useful when creating a heatmap or contour plot with
-#'  interpolation so that you can see which points were actually on the
+#'  ran. This is only useful when creating a heatmap or contour plot with 
+#'  interpolation so that you can see which points were actually on the 
 #'  original path. Note: if any learner crashes occurred within the path, this
 #'  will become \code{TRUE}.
 #'  Default is \code{FALSE}.
 #' @param show.interpolated [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will overlay the plot with points indicating where interpolation
-#'  ran. This is only useful when creating a heatmap or contour plot with
+#'  ran. This is only useful when creating a heatmap or contour plot with 
 #'  interpolation so that you can see which points were interpolated.
 #'  Default is \code{FALSE}.
 #' @param nested.agg [\code{function}]\cr
 #'  The function used to aggregate nested cross validation runs when plotting 2
-#'  hyperpars simultaneously. This is only useful when nested cross validation
+#'  hyperpars simultaneously. This is only useful when nested cross validation 
 #'  is used along with plotting a 2 hyperpars.
-#'  Default is \code{mean}.
+#'  Default is \code{mean}. 
 #' @template ret_gg2
-#'
-#' @note Any NAs incurred from learning algorithm crashes will be indicated in
+#'  
+#' @note Any NAs incurred from learning algorithm crashes will be indicated in 
 #' the plot and the NA values will be replaced with the column min/max depending
 #' on the optimal values for the respective measure. Execution time will be
-#' replaced with the max. Interpolation by its nature will result in predicted
+#' replaced with the max. Interpolation by its nature will result in predicted 
 #' values for the performance measure. Use interpolation with caution.
-#'
+#' 
 #' @export
 #'
 #' @examples
 #' # see generateHyperParsEffectData
-plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
-                               z = NULL, plot.type = "scatter",
-                               loess.smooth = FALSE, facet = NULL,
-                               pretty.names = TRUE, global.only = TRUE,
-                               interpolate = NULL, show.experiments = FALSE,
+plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL, 
+                               z = NULL, plot.type = "scatter", 
+                               loess.smooth = FALSE, facet = NULL, 
+                               pretty.names = TRUE, global.only = TRUE, 
+                               interpolate = NULL, show.experiments = FALSE, 
                                show.interpolated = FALSE, nested.agg = mean) {
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
@@ -223,122 +239,149 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   assertSubset(facet, choices = names(hyperpars.effect.data$data))
   assertFlag(pretty.names)
   assertFlag(global.only)
-  assert(checkClass(interpolate, "Learner"), checkString(interpolate),
+  assert(checkClass(interpolate, "Learner"), checkString(interpolate), 
          checkNull(interpolate))
   # assign learner for interpolation
-  if (checkClass(interpolate, "Learner") == TRUE ||
+  if (checkClass(interpolate, "Learner") == TRUE || 
       checkString(interpolate) == TRUE) {
     lrn = checkLearnerRegr(interpolate)
   }
   assertFlag(show.experiments)
   assertFunction(nested.agg)
-
+  
   if (length(x) > 1 || length(y) > 1 || length(z) > 1 || length(facet) > 1)
     stopf("Greater than 1 length x, y, z or facet not yet supported")
-
+  
   d = hyperpars.effect.data$data
   if (hyperpars.effect.data$nested)
     d$nested_cv_run = as.factor(d$nested_cv_run)
-
+  
   # set flags for building plots
   na.flag = any(is.na(d[, hyperpars.effect.data$measures]))
   z.flag = !is.null(z)
   facet.flag = !is.null(facet)
   heatcontour.flag = plot.type %in% c("heatmap", "contour")
-
-  # deal with NAs where optimizer failed
-  if (na.flag){
-    d$learner_status = ifelse(is.na(d[, "exec.time"]), "Failure", "Success")
-    for (col in hyperpars.effect.data$measures) {
-      col_name = stri_split_fixed(col, ".test.mean", omit_empty = TRUE)[[1]]
-      if (heatcontour.flag){
-        d[,col][is.na(d[,col])] = get(col_name)$worst
-      } else {
-        if (get(col_name)$minimize){
-          d[,col][is.na(d[,col])] = max(d[,col], na.rm = TRUE)
+  
+  # partial dep
+  # if heatcontour w k hypers, need interaction=T
+  # if iteration asked, need to use original hyperpars data
+  # if single hyper and single measure, pull from defaults
+  # if single hyper and multiple measures, 1 graph/multiple colored lines or many graphs/1 line
+  # if multiple hypers & single measure, pull from defaults and facet to get graph per hyper
+  # if multiple hypers & multiple measures, graph for each hyper/multiple colored lines or column for each measure
+  if (!is.null(hyperpars.effect.data$partial) && 
+      !("iteration" %in% c(x,y,z))) {
+    partial = hyperpars.effect.data$partial.data
+    # just x, y
+    if ((length(x) == 1) && (length(y) == 1) && !(z.flag)) {
+      # we only care about each feature by itself for this case
+      d = generatePartialDependenceData(partial[[1]], partial[[2]])$data
+    } else if ((length(x) == 1) && (length(y) == 1) && (z.flag)) {
+      # we need a grid if using more than 1 axis for hyperpars
+      d = generatePartialDependenceData(partial[[1]], partial[[2]], 
+        interaction = TRUE)$data
+      # need to aggregate depending on user choice
+      averaging = d[, c(hyperpars.effect.data$measures[1]), drop = FALSE]
+      combined_hypers = c(hyperpars.effect.data$hyperparams, x, y, z)
+      used_hypers = combined_hypers[duplicated(combined_hypers)]
+      hyperpars = lapply(d[, used_hypers], "[")
+      d = aggregate(averaging, hyperpars, mean)
+    }
+  } else {
+    # deal with NAs where optimizer failed
+    if (na.flag){
+      d$learner_status = ifelse(is.na(d[, "exec.time"]), "Failure", "Success")
+      for (col in hyperpars.effect.data$measures) {
+        col_name = stri_split_fixed(col, ".test.mean", omit_empty = TRUE)[[1]]
+        if (heatcontour.flag){
+          d[,col][is.na(d[,col])] = get(col_name)$worst
         } else {
-          d[,col][is.na(d[,col])] = min(d[,col], na.rm = TRUE)
+          if (get(col_name)$minimize){
+            d[,col][is.na(d[,col])] = max(d[,col], na.rm = TRUE)
+          } else {
+            d[,col][is.na(d[,col])] = min(d[,col], na.rm = TRUE)
+          }
+        }
+      }
+      d$exec.time[is.na(d$exec.time)] = max(d$exec.time, na.rm = TRUE)
+    } else {
+      # in case the user wants to show this despite no learner crashes
+      d$learner_status = "Success"
+    }
+    
+    # assign for global only
+    if (global.only && x == "iteration" && y %in% hyperpars.effect.data$measures){
+      for (col in hyperpars.effect.data$measures) {
+        col_name = stri_split_fixed(col, ".test.mean", omit_empty = TRUE)[[1]]
+        if (get(col_name)$minimize){
+          d[,col] = cummin(d[,col])
+        } else {
+          d[,col] = cummax(d[,col])
         }
       }
     }
-    d$exec.time[is.na(d$exec.time)] = max(d$exec.time, na.rm = TRUE)
-  } else {
-    # in case the user wants to show this despite no learner crashes
-    d$learner_status = "Success"
-  }
-
-  # assign for global only
-  if (global.only && x == "iteration" && y %in% hyperpars.effect.data$measures){
-    for (col in hyperpars.effect.data$measures) {
-      col_name = stri_split_fixed(col, ".test.mean", omit_empty = TRUE)[[1]]
-      if (get(col_name)$minimize){
-        d[,col] = cummin(d[,col])
+    
+    if ((!is.null(interpolate)) && z.flag && (heatcontour.flag)){
+      # create grid
+      xo = seq(min(d[,x]), max(d[,x]), length.out = 100)
+      yo = seq(min(d[,y]), max(d[,y]), length.out = 100)
+      grid = expand.grid(xo, yo, KEEP.OUT.ATTRS = F)
+      names(grid) = c(x, y)
+      
+      if (hyperpars.effect.data$nested){
+        d_new = d
+        new_d = data.frame()
+        # for loop for each nested cv run
+        for (run in unique(d$nested_cv_run)){
+          d_run = d_new[d_new$nested_cv_run == run, ]
+          regr.task = makeRegrTask(id = "interp", data = d_run[,c(x,y,z)], 
+            target = z)
+          mod = train(lrn, regr.task)
+          prediction = predict(mod, newdata = grid)
+          grid[, z] = prediction$data[, prediction$predict.type]
+          grid$learner_status = "Interpolated Point"
+          grid$iteration = NA
+          # combine the experiment data with interpolated data
+          combined = rbind(d_run[,c(x,y,z,"learner_status", "iteration")], grid)
+          # combine each loop
+          new_d = rbind(new_d, combined)
+        }
+        grid = new_d
       } else {
-        d[,col] = cummax(d[,col])
-      }
-    }
-  }
-
-  if ((!is.null(interpolate)) && z.flag && (heatcontour.flag)){
-    # create grid
-    xo = seq(min(d[,x]), max(d[,x]), length.out = 100)
-    yo = seq(min(d[,y]), max(d[,y]), length.out = 100)
-    grid = expand.grid(xo, yo, KEEP.OUT.ATTRS = F)
-    names(grid) = c(x, y)
-
-    if (hyperpars.effect.data$nested){
-      d_new = d
-      new_d = data.frame()
-      # for loop for each nested cv run
-      for (run in unique(d$nested_cv_run)){
-        d_run = d_new[d_new$nested_cv_run == run, ]
-        regr.task = makeRegrTask(id = "interp", data = d_run[,c(x,y,z)],
-          target = z)
+        regr.task = makeRegrTask(id = "interp", data = d[,c(x,y,z)], target = z)
         mod = train(lrn, regr.task)
         prediction = predict(mod, newdata = grid)
         grid[, z] = prediction$data[, prediction$predict.type]
         grid$learner_status = "Interpolated Point"
         grid$iteration = NA
         # combine the experiment data with interpolated data
-        combined = rbind(d_run[,c(x,y,z,"learner_status", "iteration")], grid)
-        # combine each loop
-        new_d = rbind(new_d, combined)
+        combined = rbind(d[,c(x,y,z,"learner_status", "iteration")], grid)
+        grid = combined
       }
-      grid = new_d
-    } else {
-      regr.task = makeRegrTask(id = "interp", data = d[,c(x,y,z)], target = z)
-      mod = train(lrn, regr.task)
-      prediction = predict(mod, newdata = grid)
-      grid[, z] = prediction$data[, prediction$predict.type]
-      grid$learner_status = "Interpolated Point"
-      grid$iteration = NA
-      # combine the experiment data with interpolated data
-      combined = rbind(d[,c(x,y,z,"learner_status", "iteration")], grid)
-      grid = combined
+      # remove any values that would extrapolate the z
+      grid[grid[,z] < min(d[,z]), z] = min(d[,z])
+      grid[grid[,z] > max(d[,z]), z] = max(d[,z])
+      d = grid
     }
-    # remove any values that would extrapolate the z
-    grid[grid[,z] < min(d[,z]), z] = min(d[,z])
-    grid[grid[,z] > max(d[,z]), z] = max(d[,z])
-    d = grid
-  }
-
-  if (hyperpars.effect.data$nested && z.flag){
-    averaging = d[, !(names(d) %in% c("iteration", "nested_cv_run",
-      hyperpars.effect.data$hyperparams, "eol",
-      "error.message", "learner_status")),
-      drop = FALSE]
-    # keep experiments if we need it
-    if (na.flag || (!is.null(interpolate)) || show.experiments){
-      hyperpars = lapply(d[, c(hyperpars.effect.data$hyperparams,
-        "learner_status")], "[")
-    } else {
-      hyperpars = lapply(d[, hyperpars.effect.data$hyperparams], "[")
+    
+    if (hyperpars.effect.data$nested && z.flag){
+      averaging = d[, !(names(d) %in% c("iteration", "nested_cv_run", 
+        hyperpars.effect.data$hyperparams, "eol",
+        "error.message", "learner_status")), 
+        drop = FALSE]
+      # keep experiments if we need it
+      if (na.flag || (!is.null(interpolate)) || show.experiments){
+        hyperpars = lapply(d[, c(hyperpars.effect.data$hyperparams, 
+          "learner_status")], "[")
+      } else {
+        hyperpars = lapply(d[, hyperpars.effect.data$hyperparams], "[")
+      }
+      d = aggregate(averaging, hyperpars, nested.agg)
+      d$iteration = 1:nrow(d)
     }
-    d = aggregate(averaging, hyperpars, nested.agg)
-    d$iteration = 1:nrow(d)
   }
-
-  # just x, y
+  
+  # just x, y  
   if ((length(x) == 1) && (length(y) == 1) && !(z.flag)){
     if (hyperpars.effect.data$nested){
       plt = ggplot(d, aes_string(x = x, y = y, color = "nested_cv_run"))
@@ -346,7 +389,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       plt = ggplot(d, aes_string(x = x, y = y))
     }
     if (na.flag){
-      plt = plt + geom_point(aes_string(shape = "learner_status",
+      plt = plt + geom_point(aes_string(shape = "learner_status", 
         color = "learner_status")) +
         scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
         scale_color_manual(values = c("red", "black"))
@@ -363,7 +406,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     # the data we use depends on if interpolation
     if (heatcontour.flag){
       if (!is.null(interpolate)){
-        plt = ggplot(data = d[d$learner_status == "Interpolated Point", ],
+        plt = ggplot(data = d[d$learner_status == "Interpolated Point", ], 
           aes_string(x = x, y = y, fill = z, z = z)) + geom_raster()
         if (show.interpolated && !(na.flag || show.experiments)){
           plt = plt + geom_point(aes_string(shape = "learner_status")) +
@@ -374,15 +417,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
           geom_tile()
       }
       if ((na.flag || show.experiments) && !(show.interpolated)){
-        plt = plt + geom_point(data = d[d$learner_status %in% c("Success",
+        plt = plt + geom_point(data = d[d$learner_status %in% c("Success", 
           "Failure"), ],
-          aes_string(shape = "learner_status"),
+          aes_string(shape = "learner_status"), 
           fill = "red") +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0))
       } else if ((na.flag || show.experiments) && (show.interpolated)) {
-        plt = plt + geom_point(data = d, aes_string(shape = "learner_status"),
+        plt = plt + geom_point(data = d, aes_string(shape = "learner_status"), 
           fill = "red") +
-          scale_shape_manual(values = c("Failure" = 24, "Success" = 0,
+          scale_shape_manual(values = c("Failure" = 24, "Success" = 0, 
             "Interpolated Point" = 6))
       }
       if (plot.type == "contour")
@@ -390,7 +433,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     } else {
       plt = ggplot(d, aes_string(x = x, y = y, color = z))
       if (na.flag){
-        plt = plt + geom_point(aes_string(shape = "learner_status",
+        plt = plt + geom_point(aes_string(shape = "learner_status", 
           color = "learner_status")) +
           scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
           scale_color_manual(values = c("red", "black"))
@@ -401,20 +444,20 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
         plt = plt + geom_line()
     }
   }
-
+  
   # pretty name changing
   if (pretty.names) {
     if (x %in% hyperpars.effect.data$measures)
-      plt = plt +
+      plt = plt + 
         xlab(eval(as.name(stri_split_fixed(x, ".test.mean")[[1]][1]))$name)
     if (y %in% hyperpars.effect.data$measures)
-      plt = plt +
+      plt = plt + 
         ylab(eval(as.name(stri_split_fixed(y, ".test.mean")[[1]][1]))$name)
     if (!is.null(z))
       if (z %in% hyperpars.effect.data$measures)
         plt = plt +
-          labs(fill = eval(as.name(stri_split_fixed(z,
-            ".test.mean")[[1]][1]))$name)
+          labs(fill = eval(as.name(stri_split_fixed(z, 
+            ".test.mean")[[1]][1]))$name) 
   }
   return(plt)
 }

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -292,7 +292,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     if (na.flag){
       d$learner_status = ifelse(is.na(d[, "exec.time"]), "Failure", "Success")
       for (col in hyperpars.effect.data$measures) {
-        col_name = stri_split_fixed(col, ".test.mean", omit_empty = TRUE)[[1]]
+        col_name = stri_split_fixed(col, ".", omit_empty = TRUE)[[1]][1]
         if (heatcontour.flag){
           d[,col][is.na(d[,col])] = get(col_name)$worst
         } else {
@@ -449,15 +449,14 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   if (pretty.names) {
     if (x %in% hyperpars.effect.data$measures)
       plt = plt + 
-        xlab(eval(as.name(stri_split_fixed(x, ".test.mean")[[1]][1]))$name)
+        xlab(eval(as.name(stri_split_fixed(x, ".")[[1]][1]))$name)
     if (y %in% hyperpars.effect.data$measures)
       plt = plt + 
-        ylab(eval(as.name(stri_split_fixed(y, ".test.mean")[[1]][1]))$name)
+        ylab(eval(as.name(stri_split_fixed(y, ".")[[1]][1]))$name)
     if (!is.null(z))
       if (z %in% hyperpars.effect.data$measures)
         plt = plt +
-          labs(fill = eval(as.name(stri_split_fixed(z, 
-            ".test.mean")[[1]][1]))$name) 
+          labs(fill = eval(as.name(stri_split_fixed(z, ".")[[1]][1]))$name) 
   }
   return(plt)
 }

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -5,15 +5,15 @@
 \title{Generate hyperparameter effect data.}
 \usage{
 generateHyperParsEffectData(tune.result, include.diagnostics = FALSE,
-  trafo = FALSE)
+  trafo = FALSE, partial.dep = FALSE)
 }
 \arguments{
 \item{tune.result}{[\code{\link{TuneResult}} | \code{\link{ResampleResult}}]\cr
 Result of \code{\link{tuneParams}} (or \code{\link{resample}} ONLY when used
-for nested cross-validation). The tuning result (or results if the
-output is from nested cross-validation), also containing the
-optimizer results. If nested CV output is passed, each element in the list
-will be considered a separate run, and the data from each run will be
+for nested cross-validation). The tuning result (or results if the 
+output is from nested cross-validation), also containing the 
+optimizer results. If nested CV output is passed, each element in the list 
+will be considered a separate run, and the data from each run will be 
 included in the dataframe within the returned \code{HyperParsEffectData}.}
 
 \item{include.diagnostics}{[\code{logical(1)}]\cr
@@ -21,22 +21,25 @@ Should diagnostic info (eol and error msg) be included?
 Default is \code{FALSE}.}
 
 \item{trafo}{[\code{logical(1)}]\cr
-Should the units of the hyperparameter path be converted to the
+Should the units of the hyperparameter path be converted to the 
 transformed scale? This is only useful when trafo was used to create the
 path.
 Default is \code{FALSE}.}
+
+\item{partial.dep}{[\code{logical(1)}]\cr
+Should partial dependency be generated based on converting to reg task?}
 }
 \value{
 [\code{HyperParsEffectData}]
- Object containing the hyperparameter effects dataframe, the tuning
- performance measures used, the hyperparameters used, a flag for including
- diagnostic info, a flag for whether nested cv was used, and the optimization
+ Object containing the hyperparameter effects dataframe, the tuning 
+ performance measures used, the hyperparameters used, a flag for including 
+ diagnostic info, a flag for whether nested cv was used, and the optimization 
  algorithm used.
 }
 \description{
-Generate cleaned hyperparameter effect data from a tuning result or from a
-nested cross-validation tuning result. The object returned can be used for
-custom visualization or passed downstream to an out of the box mlr method,
+Generate cleaned hyperparameter effect data from a tuning result or from a 
+nested cross-validation tuning result. The object returned can be used for 
+custom visualization or passed downstream to an out of the box mlr method, 
 \code{\link{plotHyperParsEffect}}.
 }
 \examples{
@@ -56,7 +59,7 @@ ctrl = makeTuneControlGrid()
 rdesc = makeResampleDesc("CV", iters = 3L)
 lrn = makeTuneWrapper("classif.ksvm", control = ctrl,
                       resampling = rdesc, par.set = ps)
-res = resample(lrn, task = pid.task, resampling = cv2,
+res = resample(lrn, task = pid.task, resampling = cv2, 
                extract = getTuneResult)
 data = generateHyperParsEffectData(res)
 plotHyperParsEffect(data, x = "C", y = "mmce.test.mean", plot.type = "line")

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -23,23 +23,23 @@ Specify what should be plotted on the y axis. Must be a column from
 
 \item{z}{[\code{character(1)}]\cr
 Specify what should be used as the extra axis for a particular geom. This
-could be for the fill on a heatmap or color aesthetic for a line. Must be a
+could be for the fill on a heatmap or color aesthetic for a line. Must be a 
 column from \code{HyperParsEffectData$data}. Default is \code{NULL}.}
 
 \item{plot.type}{[\code{character(1)}]\cr
-Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a
+Specify the type of plot: \dQuote{scatter} for a scatterplot, \dQuote{heatmap} for a 
 heatmap, \dQuote{line} for a scatterplot with a connecting line, or \dQuote{contour} for a
 contour plot layered ontop of a heatmap.
 Default is \dQuote{scatter}.}
 
 \item{loess.smooth}{[\code{logical(1)}]\cr
-If \code{TRUE}, will add loess smoothing line to plots where possible. Note that
-this is probably only useful when \code{plot.type} is set to either
+If \code{TRUE}, will add loess smoothing line to plots where possible. Note that 
+this is probably only useful when \code{plot.type} is set to either 
 \dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
 Default is \code{FALSE}.}
 
 \item{facet}{[\code{character(1)}]\cr
-Specify what should be used as the facet axis for a particular geom. When
+Specify what should be used as the facet axis for a particular geom. When 
 using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 Default is \code{NULL}.}
@@ -48,16 +48,16 @@ Default is \code{NULL}.}
 Whether to use the short name of the learner instead of its ID in labels. Defaults to \code{TRUE}.}
 
 \item{global.only}{[\code{logical(1)}]\cr
-If \code{TRUE}, will only plot the current global optima when setting
-x = "iteration" and y as a performance measure from
-\code{HyperParsEffectData$measures}. Set this to FALSE to always plot the
+If \code{TRUE}, will only plot the current global optima when setting 
+x = "iteration" and y as a performance measure from 
+\code{HyperParsEffectData$measures}. Set this to FALSE to always plot the 
 performance of every iteration, even if it is not an improvement.
 Default is \code{TRUE}.}
 
 \item{interpolate}{[\code{\link{Learner}} | \code{character(1)}]\cr
-If not \code{NULL}, will interpolate non-complete grids in order to visualize a more
+If not \code{NULL}, will interpolate non-complete grids in order to visualize a more 
 complete path. Only meaningful when attempting to plot a heatmap or contour.
-This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
+This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that 
 cases of irregular hyperparameter paths, you will most likely need to use
 this to have a meaningful visualization. Accepts either a \link{Learner}
 object or the learner as a string for interpolation.
@@ -65,21 +65,21 @@ Default is \code{NULL}.}
 
 \item{show.experiments}{[\code{logical(1)}]\cr
 If \code{TRUE}, will overlay the plot with points indicating where an experiment
-ran. This is only useful when creating a heatmap or contour plot with
-interpolation so that you can see which points were actually on the
+ran. This is only useful when creating a heatmap or contour plot with 
+interpolation so that you can see which points were actually on the 
 original path. Note: if any learner crashes occurred within the path, this
 will become \code{TRUE}.
 Default is \code{FALSE}.}
 
 \item{show.interpolated}{[\code{logical(1)}]\cr
 If \code{TRUE}, will overlay the plot with points indicating where interpolation
-ran. This is only useful when creating a heatmap or contour plot with
+ran. This is only useful when creating a heatmap or contour plot with 
 interpolation so that you can see which points were interpolated.
 Default is \code{FALSE}.}
 
 \item{nested.agg}{[\code{function}]\cr
 The function used to aggregate nested cross validation runs when plotting 2
-hyperpars simultaneously. This is only useful when nested cross validation
+hyperpars simultaneously. This is only useful when nested cross validation 
 is used along with plotting a 2 hyperpars.
 Default is \code{mean}.}
 }
@@ -87,16 +87,16 @@ Default is \code{mean}.}
 ggplot2 plot object.
 }
 \description{
-Plot hyperparameter validation path. Automated plotting method for
+Plot hyperparameter validation path. Automated plotting method for 
 \code{HyperParsEffectData} object. Useful for determining the importance
 or effect of a particular hyperparameter on some performance measure and/or
 optimizer.
 }
 \note{
-Any NAs incurred from learning algorithm crashes will be indicated in
+Any NAs incurred from learning algorithm crashes will be indicated in 
 the plot and the NA values will be replaced with the column min/max depending
 on the optimal values for the respective measure. Execution time will be
-replaced with the max. Interpolation by its nature will result in predicted
+replaced with the max. Interpolation by its nature will result in predicted 
 values for the performance measure. Use interpolation with caution.
 }
 \examples{


### PR DESCRIPTION
This will add support for performing partial dependency on hyperparameter effects data. Partial dependency will allow us to better visualize the effect of a given hyperparameter against a performance measure, especially when 2+ hyperparameters were tuned simultaneously.

TODO:

- [ ] Build out usecases and tutorial for partial dependency
- [ ] Decide on "facetting" support and usecases
- [ ] Integrate train and test on same plot
- [ ] Feature selection for hyperparameter importance
- [ ] Tests

Updated examples will be [HERE](https://github.com/MasonGallo/data-sci-scripts/blob/master/tutorial_draft.md#visualizing-the-effect-of-more-than-2-hyperparameters)