### PR TITLE
Add R oldrel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: r
 sudo: false
 cache: packages
 r:
+  - oldrel
   - release
   - devel
 

--- a/R/listLearners.R
+++ b/R/listLearners.R
@@ -1,5 +1,5 @@
 getLearnerTable = function() {
-  ids = as.character(.S3methods("makeRLearner"))
+  ids = as.character(methods("makeRLearner"))
   ids = ids[!stri_detect_fixed(ids, "__mlrmocklearners__")]
   ids = stri_replace_first_fixed(ids, "makeRLearner.", "")
   tab = rbindlist(lapply(ids, function(id) {


### PR DESCRIPTION
Adding r-oldrel does not seem to have an effect at the moment. In theory, this should run travis with a build matrix (https://docs.travis-ci.com/user/languages/r#R-Versions). This way we could at least check with R-3.1.x.

However, it should be save to add for now. I also replaced `.S3methods` with `methods`.