### PR TITLE
fix issue1057: add subsetting label functionality

### DIFF
--- a/R/Task_operators.R
+++ b/R/Task_operators.R
@@ -221,6 +221,7 @@ getTaskTargets.CostSensTask = function(task, recode.target = "no") {
 #' @template arg_task
 #' @template arg_subset
 #' @template arg_features
+#' @template arg_labels
 #' @param target.extra [\code{logical(1)}]\cr
 #'   Should target vector be returned separately?
 #'   If not, a single data.frame including the target columns is returned, otherwise a list
@@ -420,6 +421,7 @@ getTaskCosts = function(task, subset) {
 #' @template arg_task
 #' @template arg_subset
 #' @template arg_features
+#' @template arg_labels
 #' @return [\code{\link{Task}}]. Task with subsetted data.
 #' @family task
 #' @export

--- a/man-roxygen/arg_labels.R
+++ b/man-roxygen/arg_labels.R
@@ -1,0 +1,4 @@
+#' @param labels [\code{character}|\code{logical}|\code{numerical}|\code{integer}]\cr
+#'   supply the subset for the labels in the multi-label classification problem, can be integer index
+#'   which is the column index in the dataframe, or the column name directly or logical vector
+

--- a/man/getTaskData.Rd
+++ b/man/getTaskData.Rd
@@ -4,7 +4,7 @@
 \alias{getTaskData}
 \title{Extract data in task.}
 \usage{
-getTaskData(task, subset, features, target.extra = FALSE,
+getTaskData(task, subset, features, labels, target.extra = FALSE,
   recode.target = "no")
 }
 \arguments{
@@ -23,6 +23,10 @@ name returned by \code{\link{getTaskFeatureNames}}.\cr
 Note that the target feature is always included in the
 resulting task, you should not pass it here.
 Default is to use all features.}
+
+\item{labels}{[\code{character}|\code{logical}|\code{numerical}|\code{integer}]\cr
+supply the subset for the labels in the multi-label classification problem, can be integer index
+which is the column index in the dataframe, or the column name directly or logical vector}
 
 \item{target.extra}{[\code{logical(1)}]\cr
 Should target vector be returned separately?

--- a/man/subsetTask.Rd
+++ b/man/subsetTask.Rd
@@ -4,7 +4,7 @@
 \alias{subsetTask}
 \title{Subset data in task.}
 \usage{
-subsetTask(task, subset, features)
+subsetTask(task, subset, features, labels)
 }
 \arguments{
 \item{task}{[\code{\link{Task}}]\cr
@@ -22,6 +22,10 @@ name returned by \code{\link{getTaskFeatureNames}}.\cr
 Note that the target feature is always included in the
 resulting task, you should not pass it here.
 Default is to use all features.}
+
+\item{labels}{[\code{character}|\code{logical}|\code{numerical}|\code{integer}]\cr
+supply the subset for the labels in the multi-label classification problem, can be integer index
+which is the column index in the dataframe, or the column name directly or logical vector}
 }
 \value{
 [\code{\link{Task}}]. Task with subsetted data.

--- a/tests/testthat/test_base_getTaskData.R
+++ b/tests/testthat/test_base_getTaskData.R
@@ -50,8 +50,9 @@ test_that("getTaskData survival", {
   expect_equal(df, surv.df)
   cn = colnames(surv.df)[3:4]
   df = getTaskData(surv.task, subset = 1:10, features = cn)
-  expect_equal(df, surv.df[1:10, union(cn, surv.target)])
-
+  #expect_equal(df, surv.df[1:10, union(cn, surv.target)])
+  colns = names(surv.df)
+  expect_equal(df, surv.df[1:10,colns[is.element(colns,union(cn,surv.target))]])
   x = getTaskData(surv.task, target.extra = TRUE)
   expect_true(setequal(names(x), c("data", "target")))
   expect_true(is.data.frame(x$data))
@@ -84,4 +85,9 @@ test_that("getTaskData multilabel", {
 
   x = getTaskData(multilabel.task, target.extra = TRUE)
   expect_equal(dim(x$target), c(150L, 2L))
+})
+
+test_that("getTaskData yeast_multilabel", {
+  df_yeast = getTaskData(yeast.task, labels = c(TRUE,FALSE))
+  expect_true(!is.null(setdiff(getTaskTargetNames(yeast.task),names(df_yeast))))
 })

--- a/tests/testthat/test_base_subsetTask.R
+++ b/tests/testthat/test_base_subsetTask.R
@@ -1,0 +1,20 @@
+context("subsetTask")
+test_that("subsetTask subsampleFeature", {
+  sub.task = subsetTask(surv.task, subset = c(1:70), features = getTaskFeatureNames(surv.task)[c(1,2)])
+  ff = getTaskFeatureNames(surv.task)[c(1,2)]
+  sub.df = getTaskData(sub.task)
+  colns = names(surv.df)
+  expect_equal(sub.df, surv.df[1:70,colns[is.element(colns,union(ff,surv.target))]])  
+  })
+
+test_that("subsetTask subsampleFeatureLabel", {
+  sub.feature = getTaskFeatureNames(yeast.task)[c(1,2)]
+  sub.task = subsetTask(yeast.task, subset = c(1:70), 
+    features = sub.feature,
+    labels = getTaskTargetNames(yeast.task)[c(1,2)])
+  sub.df = getTaskData(sub.task)
+  df = getTaskData(yeast.task)
+  ff = getTaskTargetNames(yeast.task)[c(1,2)]
+  colns = names(getTaskData(yeast.task))
+  expect_equal(sub.df, df[1:70,colns[is.element(colns,union(sub.feature,ff))]])  
+})


### PR DESCRIPTION
1. i changed partly the old code, as there is a sub-bug, for example 

> names(surv.df)
>  [1] "time"   "status" "x1"     "x2"     "x3"     "x4"     "x5"     "x6"     "x7"     "x8"     "x9"   

after subseting the data, the old code will turn it into something 

[1]   "x6"     "x7"     "x8"     "x9"   "time"   "status"   
1. i can't resolve the error locally regarding the different version of java which is required to install 'RWeka', so i just use travis to run the tests like '''test('~/mlr', filter = 'base_measures')'''
