### PR TITLE
Bugfix: fix #1066, argument pass-down in rf.min.depth filter

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -161,9 +161,9 @@ makeFilter(
   pkg  = "randomForestSRC",
   supported.tasks = c("classif", "regr", "surv"),
   supported.features = c("numerics", "factors"),
-  fun = function(task, nselect, ...) {
+  fun = function(task, nselect, method = "md", ...) {
     im = randomForestSRC::var.select(getTaskFormula(task), getTaskData(task),
-      method = "md", verbose = FALSE, ...)$md.obj$order
+      method = method, verbose = FALSE, ...)$md.obj$order
     setNames(-im[, 1L], rownames(im))
   }
 )


### PR DESCRIPTION
The `method` argument was passed twice to `randomForestSRC::var.select` directly by passing `method` argument and via `...` resulting in a `formal argument "method" matched by multiple actual arguments` error.