### PR TITLE
Fix #1025: remove minprob, pvalue and randomsplits params from cforest

### DIFF
--- a/R/RLearner_classif_cforest.R
+++ b/R/RLearner_classif_cforest.R
@@ -10,16 +10,13 @@ makeRLearner.classif.cforest = function() {
       makeNumericLearnerParam(id = "fraction", lower = 0, upper = 1, default = 0.632),
       makeLogicalLearnerParam(id = "trace", default = FALSE, tunable = FALSE),
       makeDiscreteLearnerParam(id = "teststat", values = c("quad", "max"), default = "quad"),
-      makeLogicalLearnerParam(id = "pvalue", default = TRUE),
       makeDiscreteLearnerParam(id = "testtype",
         values = c("Bonferroni", "MonteCarlo", "Univariate", "Teststatistic"),
         default = "Univariate"),
       makeNumericLearnerParam(id = "mincriterion", lower = 0, default = 0),
-      makeNumericLearnerParam(id = "minprob", lower = 0, default = 0.01),
       makeIntegerLearnerParam(id = "minsplit", lower = 1L, default = 20L),
       makeIntegerLearnerParam(id = "minbucket", lower = 1L, default = 7L),
       makeLogicalLearnerParam(id = "stump", default = FALSE),
-      makeLogicalLearnerParam(id = "randomsplits", default = TRUE),
       makeIntegerLearnerParam(id = "nresample", lower = 1L, default = 9999L),
       makeIntegerLearnerParam(id = "maxsurrogate", lower = 0L, default = 0L),
       makeIntegerLearnerParam(id = "maxdepth", lower = 0L, default = 0L),
@@ -35,8 +32,8 @@ makeRLearner.classif.cforest = function() {
 
 #' @export
 trainLearner.classif.cforest = function(.learner, .task, .subset,
-  .weights = NULL, ntree, mtry, replace, fraction, trace, pvalue, teststat,
-  testtype, mincriterion, minprob, minsplit, minbucket, stump, randomsplits,
+  .weights = NULL, ntree, mtry, replace, fraction, trace, teststat,
+  testtype, mincriterion, minsplit, minbucket, stump,
   nresample, maxsurrogate, maxdepth, savesplitstats, ...) {
   f = getTaskFormula(.task)
   d = getTaskData(.task, .subset)
@@ -47,8 +44,8 @@ trainLearner.classif.cforest = function(.learner, .task, .subset,
   if (missing(replace)) replace = defaults$replace
   if (missing(fraction)) fraction = defaults$fraction
   ctrl = learnerArgsToControl(party::cforest_control, ntree, mtry, replace,
-    fraction, trace, pvalue, teststat, testtype, mincriterion, minprob,
-    minsplit, minbucket, stump, randomsplits, nresample, maxsurrogate,
+    fraction, trace, teststat, testtype, mincriterion,
+    minsplit, minbucket, stump, nresample, maxsurrogate,
     maxdepth, savesplitstats)
   party::cforest(f, data = d, controls = ctrl, weights = .weights, ...)
 }


### PR DESCRIPTION
@berndbischl and me decided to get rid of the parameters `minprob`, `pvalue` and `randomsplits`, since these are set internally to fixed values inside `cforest_control()` and cannot be changed by the user.