### PR TITLE
bug fixes and enhancements for feature filtering (fixes #940)

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -96,8 +96,8 @@ makeFilter(
   name = "mrmr",
   desc = "Minimum redundancy, maximum relevance filter",
   pkg  = "mRMRe",
-  supported.tasks = c("classif", "regr", "surv"),
-  supported.features = c("numerics", "factors"),
+  supported.tasks = c("regr", "surv"),
+  supported.features = c("numerics", "ordered"),
   fun = function(task, nselect, ...) {
     if (inherits(task, "SurvTask")) {
       data = getTaskData(task, target.extra = TRUE, recode.target = "rcens")
@@ -109,8 +109,6 @@ makeFilter(
     }
 
     # some required conversions
-    ind = vlapply(data, is.factor)
-    data[ind] = lapply(data[ind], as.ordered)
     ind = which(vlapply(data, is.integer))
     data[ind] = lapply(data[ind], as.double)
     data = mRMRe::mRMR.data(data = data)
@@ -141,7 +139,7 @@ makeFilter(
   desc = "Importance of random forests fitted in package 'randomForestSRC'. Importance is calculated using argument 'permute'.",
   pkg  = "randomForestSRC",
   supported.tasks = c("classif", "regr", "surv"),
-  supported.features = c("numerics", "factors"),
+  supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, nselect, ...) {
     im = randomForestSRC::rfsrc(getTaskFormula(task), data = getTaskData(task), proximity = FALSE, forest = FALSE, importance = "permute", ...)$importance
     if (inherits(task, "ClassifTask")) {
@@ -160,7 +158,7 @@ makeFilter(
   desc = "Minimal depth of random forest fitted in package 'randomForestSRC'",
   pkg  = "randomForestSRC",
   supported.tasks = c("classif", "regr", "surv"),
-  supported.features = c("numerics", "factors"),
+  supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, nselect, method = "md", ...) {
     im = randomForestSRC::var.select(getTaskFormula(task), getTaskData(task),
       method = method, verbose = FALSE, ...)$md.obj$order
@@ -173,7 +171,7 @@ makeFilter(
   desc = "Permutation importance of random forest fitted in package 'party'",
   pkg = "party",
   supported.tasks = c("classif", "regr", "surv"),
-  supported.features = c("numerics", "factors"),
+  supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, nselect, mtry = 5L, ...) {
     args = list(...)
     # we need to set mtry, which is 5 by default in cforest, to p if p < mtry
@@ -322,7 +320,7 @@ univariate = makeFilter(
   desc = "Resamples an mlr learner for each input feature individually. The resampling performance is used as filter score, with rpart as default learner.",
   pkg  = character(0L),
   supported.tasks = c("classif", "regr", "surv"),
-  supported.features = c("numerics", "factors"),
+  supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, nselect, perf.learner = NULL, perf.measure = NULL, perf.resampling = NULL, ...) {
     typ = getTaskType(task)
     if (is.null(perf.learner))
@@ -423,7 +421,7 @@ makeFilter(
   desc = "Aggregated difference between feature permuted and unpermuted predictions",
   pkg = character(0L),
   supported.tasks = c("classif", "regr", "surv"),
-  supported.features = c("numerics", "factors"),
+  supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, imp.learner, measure, contrast = function(x, y) x - y,
                  aggregation = mean, nperm = 1, replace = FALSE, nselect) {
     imp.learner = checkLearner(imp.learner)

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -41,15 +41,15 @@ generateFilterValuesData = function(task, method = "rf.importance", nselect = ge
     lapply(filter, function(x) requirePackages(x$pkg, why = "generateFilterValuesData", default.method = "load"))
   check_task = sapply(filter, function(x) td$type %nin% x$supported.tasks)
   if (any(check_task))
-    stopf("Filter(s) '%s' not campatible with task of type '%s'",
-          stri_paste(method[check_task], collapse = ", ", sep = " "), td$type)
+    stopf("Filter(s) %s not compatible with task of type '%s'",
+          stri_paste("'", method[check_task], "'", collapse = ", "), td$type)
 
-  check_feat = lapply(filter, function(x) setdiff(names(td$nfeat[td$n.feat > 0L]), x$supported.features))
+  check_feat = lapply(filter, function(x) setdiff(names(td$n.feat[td$n.feat > 0L]), x$supported.features))
   check_length = sapply(check_feat, length) > 0L
   if (any(check_length)) {
-    stopf("Filter(s) '%s' not compatible with features of type '%s' respectively.",
-          method[check_length],
-          stri_paste(sapply(check_feat[check_length], function(x) stri_paste(x, collapse = ", ", sep = " ")), collapse = ", and", sep = " "))
+    stopf("Filter(s) %s not compatible with features of type %s respectively",
+          stri_paste("'", method[check_length], "'", collapse = ", "),
+          stri_paste(sapply(check_feat[check_length], function(x) stri_paste("'", x, "'", collapse = ", ")), collapse = ", and "))
   }
   assertCount(nselect)
   assertList(more.args, names = "unique", max.len = length(method))

--- a/tests/testthat/test_base_generateFilterValuesData.R
+++ b/tests/testthat/test_base_generateFilterValuesData.R
@@ -86,12 +86,12 @@ test_that("plotFilterValues", {
 
 test_that("args are passed down to filter methods", { # we had an issue here, see #941
 
-  expect_error(generateFilterValuesData(binaryclass.task, method = c("mrmr","univariate.model.score"),
-    nselect = 3, perf.learner = "classif.lda"), "Please pass extra arguments")
+  expect_error(generateFilterValuesData(regr.num.task, method = c("mrmr","univariate.model.score"),
+    nselect = 3, perf.learner = "regr.lm"), "Please pass extra arguments")
 
   # check that we can pass down perf.learner to univariate.model.score, and get no error from mrmr call
-  f = generateFilterValuesData(iris.task, method = c("mrmr","univariate.model.score"),
-    nselect = 3, more.args = list(univariate.model.score = list(perf.learner = "classif.lda")))
+  f = generateFilterValuesData(regr.num.task, method = c("mrmr","univariate.model.score"),
+    nselect = 3, more.args = list(univariate.model.score = list(perf.learner = "regr.lm")))
 
   # create stupid dummy data and check that we can change the na.rm arg of filter "variance" in multiple ways
   d = iris; d[1L, 1L] = NA_real_
@@ -106,6 +106,12 @@ test_that("args are passed down to filter methods", { # we had an issue here, se
   expect_false(is.na(f2$data$variance[1L]))
   expect_false(is.na(f3$data$variance[1L]))
   expect_false(is.na(f4$data$variance[1L]))
+})
+
+test_that("errors for unsupported task and feature types", {
+  expect_error(generateFilterValuesData(multiclass.task, method = c("mrmr", "anova.test", "linear.correlation")), "Filter(s) 'mrmr', 'linear.correlation' not compatible with task of type 'classif'", fixed = TRUE)
+  expect_error(generateFilterValuesData(regr.task, method = c("mrmr", "carscore")), "Filter(s) 'mrmr', 'carscore' not compatible with features of type 'factors', and 'factors' respectively", fixed = TRUE)
+  expect_error(generateFilterValuesData(regr.task, method = "carscore"), "Filter(s) 'carscore' not compatible with features of type 'factors' respectively", fixed = TRUE)
 })
 
 test_that("filter values are named and ordered correctly", { # we had an issue here, see #940


### PR DESCRIPTION
Regarding #940:
* for filter "mrmr": I removed "classif" and "factors" from supported tasks and features
* consequently I needed to change some tests that used filter "mrmr" for classification tasks

Moreover:
* fixed a typo in `generateFilterValuesData` that prevented stopping if the data contains unsupported types of features; also the error message was broken; added a test for this
* added "ordered" to supported features for some filters where I'm sure that they can cope with this type of features
