### PR TITLE
Better print for predictions (fixes #1049)

### DIFF
--- a/R/Prediction.R
+++ b/R/Prediction.R
@@ -189,8 +189,6 @@ print.Prediction = function(x, ...) {
   catf("threshold: %s", collapse(sprintf("%s=%.2f", names(x$threshold), x$threshold)))
   catf("time: %.2f", x$time)
   if (!is.na(x$error)) catf("errors: %s", x$error)
-  df = as.data.frame(x)
-  print(head(x))
-  catf("... (%i rows, %i cols)", nrow(x), ncol(x))
+  printHead(as.data.frame(x))
 }
 

--- a/R/Prediction.R
+++ b/R/Prediction.R
@@ -190,5 +190,6 @@ print.Prediction = function(x, ...) {
   catf("time: %.2f", x$time)
   if (!is.na(x$error)) catf("errors: %s", x$error)
   print(head(as.data.frame(x)))
+  catf("... (%i rows, %i cols)", nrow(iris), ncol(iris))
 }
 

--- a/R/Prediction.R
+++ b/R/Prediction.R
@@ -189,7 +189,8 @@ print.Prediction = function(x, ...) {
   catf("threshold: %s", collapse(sprintf("%s=%.2f", names(x$threshold), x$threshold)))
   catf("time: %.2f", x$time)
   if (!is.na(x$error)) catf("errors: %s", x$error)
-  print(head(as.data.frame(x)))
-  catf("... (%i rows, %i cols)", nrow(iris), ncol(iris))
+  df = as.data.frame(x)
+  print(head(x))
+  catf("... (%i rows, %i cols)", nrow(x), ncol(x))
 }
 

--- a/R/ResamplePrediction.R
+++ b/R/ResamplePrediction.R
@@ -51,5 +51,5 @@ print.ResamplePrediction = function(x, ...) {
   catf("predict.type: %s", x$predict.type)
   catf("threshold: %s", collapse(sprintf("%s=%.2f", names(x$threshold), x$threshold)))
   catf("time (mean): %.2f", mean(x$time))
-  print(head(as.data.frame(x)))
+  printHead(as.data.frame(x))
 }

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -90,7 +90,7 @@ generateFilterValuesData = function(task, method = "rf.importance", nselect = ge
 print.FilterValues = function(x, ...) {
   catf("FilterValues:")
   catf("Task: %s", x$task.desc$id)
-  print(head(x$data))
+  printHead(x$data)
 }
 #' @title Calculates feature filter values.
 #'

--- a/R/generateLearningCurve.R
+++ b/R/generateLearningCurve.R
@@ -97,7 +97,7 @@ print.LearningCurveData = function(x, ...) {
   catf("LearningCurveData:")
   catf("Task: %s", x$task$task.desc$id)
   catf("Measures: %s", collapse(extractSubList(x$measures, "name")))
-  print(head(x$data))
+  printHead(x$data)
 }
 #' @title Plot learning curve data using ggplot2.
 #'

--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -378,7 +378,7 @@ generateFunctionalANOVAData = function(obj, input, features, depth = 1L, fun = m
     assertDataFrame(data, col.names = "unique", min.rows = 1L, min.cols = length(obj$features) + length(td$target))
     assertSetEqual(colnames(data), c(obj$features, td$target), ordered = FALSE)
   }
-  
+
   if (!td$type == "regr")
     stop("only regression tasks are permitted")
   excluded = colnames(data)
@@ -417,7 +417,7 @@ generateFunctionalANOVAData = function(obj, input, features, depth = 1L, fun = m
   ## generate list of effects to evaluate and associate with grid
   U = unlist(lapply(1:depth, function(x) combn(features, x, simplify = FALSE)), recursive = FALSE)
   depths = sapply(U, length)
-  
+
   effects = sapply(U, function(u) stri_paste(u, collapse = ":"))
   fixed_grid = lapply(U, function(u) expand.grid(fixed[u]))
   names(fixed_grid) = effects
@@ -472,7 +472,7 @@ print.FunctionalANOVAData = function(x, ...) {
   catf("Target: %s", stri_paste(x$target, collapse = ", "))
   catf("Interaction Depth: %s", x$depth)
   catf("Effects Computed: %s", stri_paste(levels(x$data$effect), collapse = ", "))
-  print(head(x$data))
+  printHead(x$data)
 }
 
 doPartialDerivativeIteration = function(x, obj, data, features, fun, td, individual, ...) {
@@ -602,7 +602,7 @@ print.PartialDependenceData = function(x, ...) {
   catf("Individual: %s", x$individual)
   if (x$individual)
     catf("Predictions centered: %s", x$center)
-  print(head(x$data))
+  printHead(x$data)
 }
 #' @title Plot a partial dependence with ggplot2.
 #' @description
@@ -677,14 +677,14 @@ plotPartialDependence = function(obj, geom = "line", facet = NULL, facet.wrap.nr
       stop("obj argument created by generatePartialDependenceData must be called with two or three features to use this argument!")
     if (!obj$interaction)
       stop("obj argument created by generatePartialDependenceData must be called with interaction = TRUE to use this argument!")
-    
+
     features = obj$features[which(obj$features != facet)]
-    
+
     if (!is.factor(obj$data[[facet]]))
       obj$data[[facet]] = stri_paste(facet, "=", as.factor(obj$data[[facet]]), sep = " ")
     else
       obj$data[[facet]] = stri_paste(facet, "=", obj$data[[facet]], sep = " ")
-    
+
     scales = "fixed"
   } else {
     features = obj$features
@@ -775,7 +775,7 @@ plotPartialDependence = function(obj, geom = "line", facet = NULL, facet.wrap.nr
           data[[facet]] = stri_paste(facet, "=", data[[facet]], sep = " ")
       }
     }
-    
+
     if (geom == "line") {
       if (obj$task.desc$type %in% c("classif", "surv")) {
         if (obj$task.desc$type == "classif") {
@@ -799,7 +799,7 @@ plotPartialDependence = function(obj, geom = "line", facet = NULL, facet.wrap.nr
       plt = plt + geom_point(aes_string(plt$labels$x, plt$labels$y), data, alpha = .25, inherit.aes = FALSE)
     }
   }
-  
+
   plt
 }
 #' @title Plot a partial dependence using ggvis.
@@ -884,7 +884,7 @@ plotPartialDependenceGGVIS = function(obj, interact = NULL, p = 1) {
         plt = ggvis(data, prop("x", as.name(x)),
                     prop("y", as.name("Probability")),
                     prop("stroke", as.name("Class")))
-      
+
     } else { ## regression/survival
       if (interaction)
         plt = ggvis(data, prop("x", as.name(x)),

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,3 +11,9 @@ getColEls = function(mat, inds) {
   getRowEls(t(mat), inds)
 }
 
+# prints more meaningful 'head' output indicating that there is more output
+printHead = function(x, n = 6L, ...) {
+  print(head(x, n = n, ...))
+  if (nrow(x) > n)
+    catf("... (%i rows, %i cols)\n", nrow(x), ncol(x))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,6 +16,7 @@ printHead = function(x, n = 6L, ...) {
   print(head(x, n = n, ...))
   if (nrow(x) > n)
     catf("... (%i rows, %i cols)\n", nrow(x), ncol(x))
+}
 
 # Do fuzzy string matching between input and a set of valid inputs
 # and return the most similar valid inputs.


### PR DESCRIPTION
The `head` output is now followed by a single line mentioning the number of rows and columns in the data.frame as proposed by @berndbischl in #1049.