### PR TITLE
Fix 1070 name suggestion for make learner

### DIFF
--- a/R/makeLearner.R
+++ b/R/makeLearner.R
@@ -55,7 +55,13 @@ makeLearner = function(cl, id = cl, predict.type = "response", predict.threshold
 
   assertString(cl)
   assertFlag(fix.factors.prediction)
-  constructor = getS3method("makeRLearner", class = cl)
+
+  constructor = try(getS3method("makeRLearner", class = cl), silent = TRUE)
+  if (inherits(constructor, "try-error")) {
+    possibles = getNameProposals(cl, possible.inputs = suppressWarnings(listLearners()$class))
+    stopf("Couldn't find learner '%s'\nDid you mean one of these learners instead: %s",
+      cl, stri_flatten(possibles, collapse = " "))
+  }
   wl = do.call(constructor, list())
 
   if (!missing(id)) {

--- a/R/setHyperPars.R
+++ b/R/setHyperPars.R
@@ -53,18 +53,17 @@ setHyperPars2.Learner = function(learner, par.vals) {
     pd = pars[[n]]
     if (is.null(pd)) {
       # since we couldn't find the par let's look for 3 most similar
-      parnames = names(pars)
-      indices = order(adist(n, parnames))[1:3]
-      possibles = na.omit(parnames[indices])
+      possibles = getNameProposals(n, names(pars))
+
       if (length(possibles) > 0) {
-        messagef("%s: couldn't find hyperparameter '%s'\nDid you mean one of these hyperparameters instead: %s", 
+        messagef("%s: couldn't find hyperparameter '%s'\nDid you mean one of these hyperparameters instead: %s",
           learner$id, n, stri_flatten(possibles, collapse = " "))
       }
-      
+
       # no description: stop warn or quiet
-      msg = sprintf("%s: Setting parameter %s without available description object!\nYou can switch off this check by using configureMlr!", 
+      msg = sprintf("%s: Setting parameter %s without available description object!\nYou can switch off this check by using configureMlr!",
         learner$id, n)
-      
+
       if (on.par.without.desc == "stop") {
         stop(msg)
       } else if (on.par.without.desc == "warn") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,3 +11,16 @@ getColEls = function(mat, inds) {
   getRowEls(t(mat), inds)
 }
 
+# Do fuzzy string matching between input and a set of valid inputs
+# and return the most similar valid inputs.
+getNameProposals = function(input, possible.inputs, nproposals = 3L) {
+  assertString(input)
+  assertCharacter(possible.inputs)
+  assertInt(nproposals, lower = 1L)
+
+  # compute the approximate string distance (using the generalized Levenshtein / edit distance)
+  # and get the nproposals most similar valid inputs.
+  indices = order(adist(input, possible.inputs))[1:nproposals]
+  possibles = na.omit(possible.inputs[indices])
+  return(possibles)
+}

--- a/tests/testthat/test_learners_all_general.R
+++ b/tests/testthat/test_learners_all_general.R
@@ -40,6 +40,6 @@ test_that("listLearners for task", {
 })
 
 test_that("fuzzy matching works for mistyped learners", {
-  expect_message(makeLearner("classi.randomFore", config = list(on.par.without.desc = "quiet"),
+  expect_error(makeLearner("classi.randomFore", config = list(on.par.without.desc = "quiet"),
     expected = "classif.randomForest"))
 })

--- a/tests/testthat/test_learners_all_general.R
+++ b/tests/testthat/test_learners_all_general.R
@@ -38,3 +38,8 @@ test_that("listLearners for task", {
   expect_true(length(intersect(x2$id, x3$id)) == 0)
   expect_true(all(x2$id %in% x1$id))
 })
+
+test_that("fuzzy matching works for mistyped learners", {
+  expect_message(makeLearner("classi.randomFore", config = list(on.par.without.desc = "quiet"),
+    expected = "classif.randomForest"))
+})


### PR DESCRIPTION
- wrapped fuzzy string/name proposal in function `getNameProposals`. Placed that function in utils.R. Ok? Or is there a better place for that?
- Adapted `setHyperPars` accordingly.
- Added learner name suggestions to `makeLearner` if user mistyped learner name.
- Added a small test for that.