### PR TITLE
Fix #1046: plotLearnerPrediction now works if a single learner is passed

### DIFF
--- a/R/generateLearningCurve.R
+++ b/R/generateLearningCurve.R
@@ -46,6 +46,9 @@
 generateLearningCurveData = function(learners, task, resampling = NULL,
   percs = seq(0.1, 1, by = 0.1), measures, stratify = FALSE, show.info = getMlrOption("show.info"))  {
 
+  # if single learner is passed, wrap it in list
+  if (inherits(learners, "Learner"))
+    learners = list(learners)
   learners = lapply(learners, checkLearner)
   assertClass(task, "Task")
   assertNumeric(percs, lower = 0L, upper = 1L, min.len = 2L, any.missing = FALSE)

--- a/tests/testthat/test_base_generateLearningCurve.R
+++ b/tests/testthat/test_base_generateLearningCurve.R
@@ -48,3 +48,10 @@ test_that("generateLearningCurve", {
   testFacetting(q, ncol = 2L)
 
 })
+
+test_that("generateLearningCurve works if single learner is passed (not wrapped in list)", {
+  # see issue #1046
+  r = generateLearningCurveData(makeLearner("classif.rpart"), task = binaryclass.task,
+    percs = c(0.1, 0.7), measures = list(acc, timeboth))
+  expect_true(all(c("learner", "percentage", "acc", "timeboth") %in% colnames(r$data)))
+})


### PR DESCRIPTION
See #1046.
Added a check for `learners` being a single learner and a corresponding unit test.