### PR TITLE
getDefaultMeasure now actually works with strings

### DIFF
--- a/R/Measure.R
+++ b/R/Measure.R
@@ -131,7 +131,7 @@ makeMeasure = function(id, minimize, properties = character(0L),
 #' }
 #'
 #' @param x [\code{character(1)} | \code{\link{Task}} | \code{\link{TaskDesc}} | \code{\link{Learner}}]\cr
-#'  Task type, task, task description, learner name, or a learner.
+#'  Task type, task, task description, learner name, a learner, or a type of learner (e.g. "classif").
 #' @return [\code{\link{Measure}}].
 #' @export
 getDefaultMeasure = function(x) {

--- a/R/Measure.R
+++ b/R/Measure.R
@@ -131,7 +131,7 @@ makeMeasure = function(id, minimize, properties = character(0L),
 #' }
 #'
 #' @param x [\code{character(1)} | \code{\link{Task}} | \code{\link{TaskDesc}} | \code{\link{Learner}}]\cr
-#'  Task type, task, task description or a learner.
+#'  Task type or learner name, task, task description or a learner.
 #' @return [\code{\link{Measure}}].
 #' @export
 getDefaultMeasure = function(x) {
@@ -141,6 +141,10 @@ getDefaultMeasure = function(x) {
     x$task.desc$type
   else if (inherits(x, "Learner"))
     x$type
+  else if (!inherits(try(checkLearner(x), silent = TRUE), "try-error"))
+    checkLearner(x)$type
+  else
+    x
   switch(type,
     classif = mmce,
     cluster = db,

--- a/R/Measure.R
+++ b/R/Measure.R
@@ -131,7 +131,7 @@ makeMeasure = function(id, minimize, properties = character(0L),
 #' }
 #'
 #' @param x [\code{character(1)} | \code{\link{Task}} | \code{\link{TaskDesc}} | \code{\link{Learner}}]\cr
-#'  Task type or learner name, task, task description or a learner.
+#'  Task type, task, task description, learner name, or a learner.
 #' @return [\code{\link{Measure}}].
 #' @export
 getDefaultMeasure = function(x) {

--- a/R/Measure.R
+++ b/R/Measure.R
@@ -141,8 +141,8 @@ getDefaultMeasure = function(x) {
     x$task.desc$type
   else if (inherits(x, "Learner"))
     x$type
-  else if (!inherits(try(checkLearner(x), silent = TRUE), "try-error"))
-    checkLearner(x)$type
+  else if (x %in% listLearners()$class)
+    stri_split_fixed(x, ".", simplify = TRUE)[1]
   else
     x
   switch(type,

--- a/man/getDefaultMeasure.Rd
+++ b/man/getDefaultMeasure.Rd
@@ -8,7 +8,7 @@ getDefaultMeasure(x)
 }
 \arguments{
 \item{x}{[\code{character(1)} | \code{\link{Task}} | \code{\link{TaskDesc}} | \code{\link{Learner}}]\cr
-Task type, task, task description or a learner.}
+Task type or learner name, task, task description or a learner.}
 }
 \value{
 [\code{\link{Measure}}].

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -565,6 +565,14 @@ test_that("check measure calculations", {
   expect_equal(object = silhouette.test, as.numeric(silhouette.perf))
 })
 
+test_that("getDefaultMeasure", {
+  expect_equal(mmce, getDefaultMeasure(iris.task))
+  expect_equal(mmce, getDefaultMeasure(getTaskDescription(iris.task)))
+  expect_equal(mmce, getDefaultMeasure(makeLearner("classif.rpart")))
+  expect_equal(mmce, getDefaultMeasure("classif.rpart"))
+  expect_equal(mmce, getDefaultMeasure("classif"))
+})
+
 test_that("measures quickcheck", {
   options(warn = 2)
   ms = list(mmce, acc, bac, tp, fp, tn, fn, tpr, fpr, tnr, fnr, ppv, npv, mcc, f1)


### PR DESCRIPTION
The documentation to `getDefaultMeasure` states that you can use a character like `"classif"` to get the default measure but that didn't work.

```
> getDefaultMeasure("classif")
Error in switch(type, classif = mmce, cluster = db, regr = mse, surv = cindex,  : 
  EXPR must be a length 1 vector
```

Now it works with strings of the type as well as strings of learners


```
> getDefaultMeasure("classif")
Name: Mean misclassification error
Performance measure: mmce
Properties: classif,classif.multi,req.pred,req.truth
Minimize: TRUE
Best: 0; Worst: 1
Aggregated by: test.mean
Note: 
> getDefaultMeasure("classif.rpart")
Name: Mean misclassification error
Performance measure: mmce
Properties: classif,classif.multi,req.pred,req.truth
Minimize: TRUE
Best: 0; Worst: 1
Aggregated by: test.mean
Note: 
```

I also added a test.

