### PR TITLE
remove show.info from setHyperPars

### DIFF
--- a/R/BaseEnsemble_operators.R
+++ b/R/BaseEnsemble_operators.R
@@ -23,7 +23,7 @@ getHyperPars.BaseEnsemble = function(learner, for.fun = c("train", "predict", "b
 
 # set hyper pars down in ensemble base learners, identify correct base learner + remove prefix
 #' @export
-setHyperPars2.BaseEnsemble = function(learner, par.vals, show.info = getMlrOption("show.info")) {
+setHyperPars2.BaseEnsemble = function(learner, par.vals) {
   ns = names(par.vals)
   parnames.bls = names(learner$par.set.bls$pars)
   for (i in seq_along(par.vals)) {
@@ -32,10 +32,10 @@ setHyperPars2.BaseEnsemble = function(learner, par.vals, show.info = getMlrOptio
       # param of ensapsulated learner, remove prefix, set it in the bl list
       z = matchBaseEnsembleLearner(learner, pn)
       learner$base.learners[[z$ind]] = setHyperPars2(learner$base.learners[[z$ind]],
-        par.vals = setNames(par.vals[i], z$par.id), show.info = show.info)
+        par.vals = setNames(par.vals[i], z$par.id))
     } else {
       # extra param of ensemble learner, just set it normally
-      learner = setHyperPars2.Learner(learner, par.vals = par.vals[i], show.info = show.info)
+      learner = setHyperPars2.Learner(learner, par.vals = par.vals[i])
     }
   }
   return(learner)

--- a/R/BaseWrapper_operators.R
+++ b/R/BaseWrapper_operators.R
@@ -11,14 +11,14 @@ getHyperPars.BaseWrapper = function(learner, for.fun = c("train", "predict", "bo
 
 
 #' @export
-setHyperPars2.BaseWrapper = function(learner, par.vals, show.info = getMlrOption("show.info")) {
+setHyperPars2.BaseWrapper = function(learner, par.vals) {
   ns = names(par.vals)
   pds.n = names(learner$par.set$pars)
   for (i in seq_along(par.vals)) {
     if (ns[i] %in% pds.n) {
-      learner = setHyperPars2.Learner(learner, par.vals = par.vals[i], show.info = show.info)
+      learner = setHyperPars2.Learner(learner, par.vals = par.vals[i])
     } else {
-      learner$next.learner = setHyperPars2(learner$next.learner, par.vals = par.vals[i], show.info = show.info)
+      learner$next.learner = setHyperPars2(learner$next.learner, par.vals = par.vals[i])
     }
   }
   return(learner)

--- a/R/makeLearner.R
+++ b/R/makeLearner.R
@@ -56,7 +56,9 @@ makeLearner = function(cl, id = cl, predict.type = "response", predict.threshold
   assertString(cl)
   assertFlag(fix.factors.prediction)
   assertList(config, names = "named")
-  # FIXME: maybe forbid show.info here issue #1098:
+  if ("show.info" %in% names(config)) {
+    stop("show.info cannot be set in makeLearner please use configureMlr() instead.")
+  }
   assertSubset(names(config), choices = names(getMlrOptions()))
   constructor = try(getS3method("makeRLearner", class = cl), silent = TRUE)
   if (inherits(constructor, "try-error")) {

--- a/R/makeLearner.R
+++ b/R/makeLearner.R
@@ -57,7 +57,7 @@ makeLearner = function(cl, id = cl, predict.type = "response", predict.threshold
   assertFlag(fix.factors.prediction)
   assertList(config, names = "named")
   if ("show.info" %in% names(config)) {
-    stop("show.info cannot be set in makeLearner please use configureMlr() instead.")
+    stop("'show.info' cannot be set in 'makeLearner', please use 'configureMlr' instead.")
   }
   assertSubset(names(config), choices = names(getMlrOptions()))
   constructor = try(getS3method("makeRLearner", class = cl), silent = TRUE)

--- a/R/makeLearner.R
+++ b/R/makeLearner.R
@@ -56,9 +56,8 @@ makeLearner = function(cl, id = cl, predict.type = "response", predict.threshold
   assertString(cl)
   assertFlag(fix.factors.prediction)
   assertList(config, names = "named")
-  if ("show.info" %in% names(config)) {
+  if ("show.info" %in% names(config)) 
     stop("'show.info' cannot be set in 'makeLearner', please use 'configureMlr' instead.")
-  }
   assertSubset(names(config), choices = names(getMlrOptions()))
   constructor = try(getS3method("makeRLearner", class = cl), silent = TRUE)
   if (inherits(constructor, "try-error")) {

--- a/R/setHyperPars.R
+++ b/R/setHyperPars.R
@@ -7,7 +7,6 @@
 #' @param par.vals [\code{list}]\cr
 #'   Optional list of named (hyper)parameter settings. The arguments in
 #'   \code{...} take precedence over values in this list.
-#' @template arg_showinfo
 #' @template ret_learner
 #' @note If a named (hyper)parameter can't be found for the given learner, the 3
 #' closest (hyper)parameter names will be output in case the user mistyped.
@@ -20,12 +19,12 @@
 #' print(cl1)
 #' # note the now set and altered hyperparameters:
 #' print(cl2)
-setHyperPars = function(learner, ..., par.vals = list(), show.info = getMlrOption("show.info")) {
+setHyperPars = function(learner, ..., par.vals = list()) {
   args = list(...)
   assertClass(learner, classes = "Learner")
   assertList(args, names = "named", .var.name = "parameter settings")
   assertList(par.vals, names = "named", .var.name = "parameter settings")
-  setHyperPars2(learner, insert(par.vals, args), show.info = show.info)
+  setHyperPars2(learner, insert(par.vals, args))
 }
 
 #' Only exported for internal use.
@@ -33,14 +32,13 @@ setHyperPars = function(learner, ..., par.vals = list(), show.info = getMlrOptio
 #'   The learner.
 #' @param par.vals [\code{list}]\cr
 #'   List of named (hyper)parameter settings.
-#' @template arg_showinfo
 #' @export
-setHyperPars2 = function(learner, par.vals, show.info = getMlrOption("show.info")) {
+setHyperPars2 = function(learner, par.vals) {
   UseMethod("setHyperPars2")
 }
 
 #' @export
-setHyperPars2.Learner = function(learner, par.vals, show.info = getMlrOption("show.info")) {
+setHyperPars2.Learner = function(learner, par.vals) {
   ns = names(par.vals)
   # ensure that even the empty list is named, we had problems here, see #759
   if (is.null(ns) && is.null(names(learner$par.vals))) {
@@ -54,20 +52,19 @@ setHyperPars2.Learner = function(learner, par.vals, show.info = getMlrOption("sh
     p = par.vals[[i]]
     pd = pars[[n]]
     if (is.null(pd)) {
-      # since we couldn't find the par let's look for 3 most similar
-      if (show.info & on.par.without.desc != "quiet") {
+      if (on.par.without.desc != "quiet") {
+        # no description: stop warn or quiet
+        msg = sprintf("%s: Setting parameter %s without available description object!",
+          learner$id, n)
+        # since we couldn't find the par let's look for 3 most similar
         parnames = names(pars)
         indices = head(order(adist(n, parnames)), 3L)
         possibles = parnames[indices]
         if (length(possibles) > 0L) {
-          messagef("%s: couldn't find hyperparameter '%s'\nDid you mean one of these hyperparameters instead: %s",
-            learner$id, n, stri_flatten(possibles, collapse = " "))
+          msg = paste(msg, sprintf("\nDid you mean one of these hyperparameters instead: %s", stri_flatten(possibles, collapse = " ")))
         }
+        msg = paste(msg, "\nYou can switch off this check by using configureMlr!")
       }
-
-      # no description: stop warn or quiet
-      msg = sprintf("%s: Setting parameter %s without available description object!\nYou can switch off this check by using configureMlr!",
-        learner$id, n)
 
       if (on.par.without.desc == "stop") {
         stop(msg)

--- a/man/setHyperPars.Rd
+++ b/man/setHyperPars.Rd
@@ -4,8 +4,7 @@
 \alias{setHyperPars}
 \title{Set the hyperparameters of a learner object.}
 \usage{
-setHyperPars(learner, ..., par.vals = list(),
-  show.info = getMlrOption("show.info"))
+setHyperPars(learner, ..., par.vals = list())
 }
 \arguments{
 \item{learner}{[\code{\link{Learner}} | \code{character(1)}]\cr
@@ -19,10 +18,6 @@ using the \code{par.vals} argument.}
 \item{par.vals}{[\code{list}]\cr
 Optional list of named (hyper)parameter settings. The arguments in
 \code{...} take precedence over values in this list.}
-
-\item{show.info}{[\code{logical(1)}]\cr
-Print verbose output on console?
-Default is set via \code{\link{configureMlr}}.}
 }
 \value{
 [\code{\link{Learner}}].

--- a/man/setHyperPars2.Rd
+++ b/man/setHyperPars2.Rd
@@ -4,7 +4,7 @@
 \alias{setHyperPars2}
 \title{Only exported for internal use.}
 \usage{
-setHyperPars2(learner, par.vals, show.info = getMlrOption("show.info"))
+setHyperPars2(learner, par.vals)
 }
 \arguments{
 \item{learner}{[\code{\link{Learner}}]\cr
@@ -12,10 +12,6 @@ The learner.}
 
 \item{par.vals}{[\code{list}]\cr
 List of named (hyper)parameter settings.}
-
-\item{show.info}{[\code{logical(1)}]\cr
-Print verbose output on console?
-Default is set via \code{\link{configureMlr}}.}
 }
 \description{
 Only exported for internal use.

--- a/tests/testthat/test_base_hyperpars.R
+++ b/tests/testthat/test_base_hyperpars.R
@@ -62,42 +62,27 @@ test_that("setting 'when' works for hyperpars", {
 })
 
 test_that("fuzzy matching works for mistyped hyperpars", {
-  expected = "classif.ksvm: couldn't find hyperparameter 'sigm'\nDid you mean one of these hyperparameters instead: sigma fit type"
-  warn.msg = "Setting parameter sigm without available description object!"
+  msg = "classif.ksvm: Setting parameter sigm without available description object! \nDid you mean one of these hyperparameters instead: sigma fit type \nYou can switch off this check by using configureMlr!"
   mlr.opts = getMlrOptions()
 
   # test if config arg works properly in combination with show.info
   cq = list(on.par.without.desc = "quiet")
   cw = list(on.par.without.desc = "warn")
   cs = list(on.par.without.desc = "stop")
-  # never print message when quiet, no matter hat show.info is
-  expect_silent(makeLearner("classif.ksvm", config = cq, sigm = 1, show.info = TRUE))
-  expect_silent(makeLearner("classif.ksvm", config = cq, sigm = 1, show.info = FALSE))
+  # never print message when quiet
+  expect_silent(makeLearner("classif.ksvm", config = cq, sigm = 1))
   configureMlr(on.par.without.desc = "quiet")
-  expect_silent(makeLearner("classif.ksvm", sigm = 1, show.info = TRUE))
-  expect_silent(makeLearner("classif.ksvm", sigm = 1, show.info = FALSE))
+  expect_silent(makeLearner("classif.ksvm", sigm = 1))
 
-  # show.info on/off and warn -- need nested expectations here because we get 2 different kinds of messages
-  expect_message(expect_warning(makeLearner("classif.ksvm", config = cw, sigm = 1, show.info = TRUE),
-    warn.msg), expected)
-  expect_silent(expect_warning(makeLearner("classif.ksvm", config = cw, sigm = 1, show.info = FALSE),
-    warn.msg))
+  # print message and warn
+  expect_warning(makeLearner("classif.ksvm", config = cw, sigm = 1), msg)
   configureMlr(on.par.without.desc = "warn")
-  expect_message(expect_warning(makeLearner("classif.ksvm", sigm = 1, show.info = TRUE),
-    warn.msg), expected)
-  expect_silent(expect_warning(makeLearner("classif.ksvm", sigm = 1, show.info = FALSE),
-    warn.msg))
-
-  # show.info on/off and error
-  expect_message(expect_error(makeLearner("classif.ksvm", config = cs, sigm = 1, show.info = TRUE),
-    warn.msg), expected)
-  expect_silent(expect_error(makeLearner("classif.ksvm", config = cs, sigm = 1, show.info = FALSE),
-    warn.msg))
+  expect_warning(makeLearner("classif.ksvm", sigm = 1), msg)
+  
+  # print message and error
+  expect_error(makeLearner("classif.ksvm", config = cs, sigm = 1), msg)
   configureMlr(on.par.without.desc = "stop")
-  expect_message(expect_error(makeLearner("classif.ksvm", sigm = 1, show.info = TRUE),
-    warn.msg), expected)
-  expect_silent(expect_error(makeLearner("classif.ksvm", sigm = 1, show.info = FALSE),
-    warn.msg))
+  expect_error(makeLearner("classif.ksvm", sigm = 1), msg)
 
   # docu says: for warn and quiet parameter is passed, check if this is true
   lrn = makeLearner("classif.ksvm",


### PR DESCRIPTION
We don't need show info since we already have `on.par.out.of.bound` there.

See Issue #1098 and #1059 