### PR TITLE
fix the edge case for PPV measure issue #1006 and issue #937

### DIFF
--- a/R/RLearner_classif_gbm.R
+++ b/R/RLearner_classif_gbm.R
@@ -44,7 +44,13 @@ trainLearner.classif.gbm = function(.learner, .task, .subset, .weights = NULL,  
 predictLearner.classif.gbm = function(.learner, .model, .newdata, ...) {
   td = .model$task.desc
   m = .model$learner.model
-  p = gbm::predict.gbm(m, newdata = .newdata, type = "response", n.trees = m$n.trees, single.tree = FALSE, ...)
+  tridots = list(...)
+  if(is.null(tridots$n.trees))
+    m.n.trees = m$n.trees
+  else{
+    m.n.trees = tridots$n.trees
+  }
+  p = gbm::predict.gbm(m, newdata = .newdata, type = "response", n.trees = m.n.trees, single.tree = FALSE, ...)
   if (length(td$class.levels) == 2L) {
     levs = c(td$negative, td$positive)
     if (.learner$predict.type == "prob") {

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -591,3 +591,22 @@ test_that("measures quickcheck", {
     sample.size = 100
   )
 })
+
+
+test_that("measures edge case ppv", {
+  set.seed(1)
+  task = sonar.task
+  lrn = makeLearner("classif.rpart", predict.type = "prob")
+  r = holdout(lrn, task)
+  d = generateThreshVsPerfData(r, measures = list(tpr, ppv), gridsize = 5)
+  expect_equal(length(which(is.na(d$data))), 0)
+  
+  lrns = list(makeLearner("classif.randomForest",predict.type = "prob"), makeLearner("classif.rpart",predict.type = "prob"))
+  tasks = list(bc.task, sonar.task)
+  rdesc = makeResampleDesc("CV", iters = 2L)
+  meas = list(acc, ber)
+  bmrk = benchmark(lrns, tasks, rdesc, measures = meas)
+  pr <- generateThreshVsPerfData(bmrk, measures=list(tpr, ppv))
+  expect_equal(length(which(is.na(pr$data))), 0)
+  })
+

--- a/tests/testthat/test_classif_gbm.R
+++ b/tests/testthat/test_classif_gbm.R
@@ -44,3 +44,44 @@ test_that("classif_gbm keep.data is passed correctly", {
   train(makeLearner("classif.gbm", keep.data = FALSE), binaryclass.task)
   train(makeLearner("classif.gbm", keep.data = TRUE), binaryclass.task)
 })
+
+
+test_that("classif_gbm_ntrees", {
+  requirePackagesOrSkip("gbm", default.method = "load")
+  
+  parset.list = list(
+    list(),
+    list(n.trees = 600),
+    list(interaction.depth = 2)
+  )
+  
+  old.predicts.list = list()
+  old.probs.list = list()
+  
+  mydata = binaryclass.train
+  mydata[, binaryclass.target] = as.numeric(mydata[, binaryclass.target] ==  getTaskDescription(binaryclass.task)$positive)
+  for (i in 1:length(parset.list)) {
+    parset = parset.list[[i]]
+    pars = list(binaryclass.formula, data = mydata, distribution = "bernoulli")
+    pars = c(pars, parset)
+    set.seed(getOption("mlr.debug.seed"))
+    capture.output(
+      m <- do.call(gbm::gbm, pars)
+    )
+    set.seed(getOption("mlr.debug.seed"))
+    p = gbm::predict.gbm(m, newdata = binaryclass.test, n.trees = length(m$trees), type = "response")
+    old.probs.list[[i]] = p
+    p = as.factor(ifelse(p > 0.5, "M", "R"))
+    old.predicts.list[[i]] = p
+  }
+  
+  testSimpleParsets("classif.gbm", binaryclass.df, binaryclass.target, binaryclass.train.inds, old.predicts.list, parset.list)
+  testProbParsets("classif.gbm", binaryclass.df, binaryclass.target, binaryclass.train.inds, old.probs.list, parset.list)
+  
+  set.seed(getOption("mlr.debug.seed"))
+  m = gbm::gbm(multiclass.formula, data = multiclass.train, n.trees = 300, interaction.depth = 2, distribution = "multinomial")
+  p = gbm::predict.gbm(m, newdata = multiclass.test, n.trees = 10)
+  y = factor(apply(p[,,1],1, function(r) colnames(p)[which.max(r)]))
+  testSimple("classif.gbm", multiclass.df, multiclass.target, multiclass.train.inds, y,
+    parset = list(n.trees = 10, interaction.depth = 2, distribution = "multinomial"))
+})


### PR DESCRIPTION
1. issue #937 said in the plot of ROC like curves, there are truncated part because of the NA values in computing PPV

2. issue #1006 give an example of the edge case, which basically means when the output are all negative, TP+FP =0,  and there are 0/0 .  

3.In this edge case, I set the 0/0 to be either 0 or 1 according whether the highest predicted probability is negative(0) or positive instance(1). 

4.Now both the ROC plotting and the PPV NA valued are eliminated

5. Here I leave the code for TPR and FPR unchanged, since if there are NA value, which means there is only one class in test set, they should always be NA regardless of the threshold. The user should be responsible for this. 