### PR TITLE
fix printer and add test

### DIFF
--- a/R/generateFeatureImportance.R
+++ b/R/generateFeatureImportance.R
@@ -210,7 +210,7 @@ print.FeatureImportance = function(x, ...) {
   catf("Task: %s", x$task.desc$id)
   catf("Interaction: %s", x$interaction)
   catf("Learner: %s", x$learner$id)
-  catf("Measure: %s", ifelse(!is.na(imp$measure), imp$measure$id, NA))
+  catf("Measure: %s", ifelse(!is.na(x$measure), x$measure[[1]]$id, NA))
   catf("Contrast: %s", stri_paste(format(x$contrast), collapse = " "))
   catf("Aggregation: %s", stri_paste(format(x$aggregation), collapse = " "))
   catf("Replace: %s", x$replace)

--- a/tests/testthat/test_base_generateFeatureImportanceData.R
+++ b/tests/testthat/test_base_generateFeatureImportanceData.R
@@ -10,4 +10,8 @@ test_that("generateFeatureImportanceData", {
     "classif.rpart", c("Petal.Width", "Petal.Length"), TRUE, ber, nmc = 1L, local = TRUE)
   expect_that(colnames(classif.imp$res), equals(stri_paste("Petal.Width", "Petal.Length", sep = ":")))
   expect_that(dim(classif.imp$res), equals(c(getTaskSize(multiclass.task), 1)))
+  
+  # Test printer
+  expect_output(print(classif.imp), regexp = "FeatureImportance:")
+  
 })


### PR DESCRIPTION
There was a bug in the printer of `FeatureImportance` objects.

This fixes the undefined global warning warning in master.


I also added a test for that.


And for some reason the measure slot is a list so we have to use the first element. It seems that that `makeS3obj` does this for some reason 