### PR TITLE
calculateROCMeasures and calculateConfusionMatrix: mini fixes

### DIFF
--- a/R/calculateConfusionMatrix.R
+++ b/R/calculateConfusionMatrix.R
@@ -10,7 +10,7 @@
 #' A list is returned that contains multiple matrices.
 #' If \code{relative = TRUE} we compute three matrices, one with absolute values and two with relative.
 #' The relative confusion matrices are normalized based on rows and columns respectively,
-#' if {FALSE} we only compute the absolute value matrix.
+#' if \code{FALSE} we only compute the absolute value matrix.
 #'
 #' The \code{print} function returns the relative matrices in
 #' a compact way so that both row and column marginals can be seen in one matrix.
@@ -18,7 +18,7 @@
 #'
 #' Note that for resampling no further aggregation is currently performed.
 #' All predictions on all test sets are joined to a vector yhat, as are all labels
-#' joined to a vector y. Then yhat is simply tabulated vs y, as if both were computed on
+#' joined to a vector y. Then yhat is simply tabulated vs. y, as if both were computed on
 #' a single test set. This probably mainly makes sense when cross-validation is used for resampling.
 #'
 #' @template arg_pred

--- a/R/calculateConfusionMatrix.R
+++ b/R/calculateConfusionMatrix.R
@@ -14,7 +14,7 @@
 #'
 #' The \code{print} function returns the relative matrices in
 #' a compact way so that both row and column marginals can be seen in one matrix.
-#' For details see \code{\link{ConfMatrix}}.
+#' For details see \code{\link{ConfusionMatrix}}.
 #'
 #' Note that for resampling no further aggregation is currently performed.
 #' All predictions on all test sets are joined to a vector yhat, as are all labels
@@ -27,7 +27,7 @@
 #'   columns.
 #' @param sums {\code{logical(1)}}\cr
 #'   If \code{TRUE} add absolute number of observations in each group.
-#' @return [\code{\link{ConfMatrix}}].
+#' @return [\code{\link{ConfusionMatrix}}].
 #' @family performance
 #' @export
 #' @examples
@@ -96,13 +96,13 @@ calculateConfusionMatrix = function(pred, relative = FALSE, sums = FALSE) {
     result$relative.error = sum(result$result[k+1, 1:(k+1)])/n
   }
 
-  addClasses(result, "ConfMatrix")
+  addClasses(result, "ConfusionMatrix")
 }
 
 #' @export
 #' @describeIn calculateConfusionMatrix
 #'
-#' @param x [\code{\link{ConfMatrix}}]\cr
+#' @param x [\code{\link{ConfusionMatrix}}]\cr
 #'   Object to print.
 #' @param both [\code{logical(1)}]\cr
 #'   If \code{TRUE} both the absolute and relative confusion matrices are printed.
@@ -110,7 +110,7 @@ calculateConfusionMatrix = function(pred, relative = FALSE, sums = FALSE) {
 #'   How many numbers after the decimal point should be printed, only relevant for relative confusion matrices.
 #' @param ... [any]\cr
 #'  Currently not used.
-print.ConfMatrix = function(x, both = TRUE, digits = 2, ...) {
+print.ConfusionMatrix = function(x, both = TRUE, digits = 2, ...) {
 
   assertFlag(both)
   assertInt(digits, lower = 1)
@@ -177,6 +177,6 @@ print.ConfMatrix = function(x, both = TRUE, digits = 2, ...) {
 #' \item{relative.col [\code{matrix}]}{Confusion matrix of relative values and marginals normalized by column.}
 #' \item{relative.error [\code{numeric(1)}]}{Relative error overall.}
 #' }
-#' @name ConfMatrix
+#' @name ConfusionMatrix
 #' @family performance
 NULL

--- a/R/calculateROCMeasures.R
+++ b/R/calculateROCMeasures.R
@@ -5,17 +5,17 @@
 #' 
 #' 
 #' \itemize{
-#'  \item \code{tpr} True positive rate (Sensisivity, Recall)
-#'  \item \code{fpr} False positve rate (Fall-out)
+#'  \item \code{tpr} True positive rate (Sensitivity, Recall)
+#'  \item \code{fpr} False positive rate (Fall-out)
 #'  \item \code{fnr} False negative rate (Miss rate)
-#'  \item \code{tnr} True negative rate (Specifity)
+#'  \item \code{tnr} True negative rate (Specificity)
 #'  \item \code{ppv} Positive predictive value (Precision)
 #'  \item \code{for} False omission rate
 #'  \item \code{lrp} Positive likelihood ratio (LR+)
 #'  \item \code{fdr} False discovery rate
 #'  \item \code{npv} Negative predictive value
 #'  \item \code{acc} Accuracy
-#'  \item \code{lrm} Nevative likelihood ratio (LR-)
+#'  \item \code{lrm} Negative likelihood ratio (LR-)
 #'  \item \code{dor} Diagnostic odds ratio
 #' }
 #' 
@@ -29,9 +29,10 @@
 #' 
 #' @return [\code{ROCMeasures}]. 
 #'    A list containing two elements \code{confusion.matrix} which is 
-#'    the 2 times 2 confusion matrix of relative frequencies and \code{measures}, a list of the above mentioned measures. 
+#'    the 2 times 2 confusion matrix of relative frequencies and \code{measures}, a list of the above mentioned measures.
 #' @export
-#' @family roc performance
+#' @family roc
+#' @family performance
 #' @examples 
 #' lrn = makeLearner("classif.rpart", predict.type = "prob")
 #' fit = train(lrn, sonar.task)
@@ -82,7 +83,7 @@ calculateROCMeasures = function(pred) {
 #' @param x [\code{ROCMeasures}]\cr
 #'   Created by \code{\link{calculateROCMeasures}}.
 #' @param abbreviations [\code{logical(1)}]\cr
-#'   If \code{TRUE} a short paragraph with explainations of the used measures is printed additionally.
+#'   If \code{TRUE} a short paragraph with explanations of the used measures is printed additionally.
 #' @param digits [\code{integer(1)}]\cr
 #'   Number of digits the measures are rounded to.
 #' @param ... \code{[any]}\cr
@@ -110,10 +111,10 @@ print.ROCMeasures = function(x, abbreviations = TRUE, digits = 2, ...) {
   print(noquote(res))
   if (abbreviations) {
     cat("\n\nAbbreviations:\n")
-    cat("tpr - True positive rate (Sensisivity, Recall)\n")
-    cat("fpr - False positve rate (Fall-out)\n")
+    cat("tpr - True positive rate (Sensitivity, Recall)\n")
+    cat("fpr - False positive rate (Fall-out)\n")
     cat("fnr - False negative rate (Miss rate)\n")
-    cat("tnr - True negative rate (Specifity)\n")
+    cat("tnr - True negative rate (Specificity)\n")
     cat("ppv - Positive predictive value (Precision)\n")
     cat("for - False omission rate\n")
     cat("lrp - Positive likelihood ratio (LR+)\n")

--- a/R/getConfMatrix.R
+++ b/R/getConfMatrix.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' 
-#' getConfMatrix is deprecated please use \code{\link{calculateConfusionMatrix}}.
+#' \code{getConfMatrix} is deprecated. Please use \code{\link{calculateConfusionMatrix}}.
 #' 
 #' 
 #' Calculates confusion matrix for (possibly resampled) prediction.


### PR DESCRIPTION
Fixed some typos and repaired family.

One nit-picky detail question: At the moment function calculateConfusionMatrix generates an object of class ConfMatrix. Do we want to make the names more consistent i.e. rename the class to ConfusionMatrix or the function to calculateConfMatrix?