### PR TITLE
Relative error measures

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -271,6 +271,77 @@ arsq = makeMeasure(id = "adjrsq", minimize = FALSE, best = 1, worst = 0,
   }
 )
 
+#' @export rrse
+#' @rdname measures
+#' @format none
+rrse = makeMeasure(id = "rrse", minimize = TRUE, best = 0, worst = Inf,
+  properties = c("regr", "req.pred", "req.truth"),
+  name = "Root relative squared error",
+  note = "Defined as sqrt (sum_of_squared_errors / total_sum_of_squares). Undefined for single instances and when every truth value is identical. In this case the output will be NA.",
+  fun = function(task, model, pred, feats, extra.args) {
+    measureRRSE(pred$data$truth, pred$data$response)
+  }
+)
+
+#' @export measureRRSE
+#' @rdname measures
+#' @format none
+measureRRSE = function(truth, response){
+  tss = sum((truth-mean(truth))^2L)
+  if (tss == 0){
+    warning("RAE is undefined if all truth values are equal.")
+    return(NA)
+  }
+  sqrt(measureSSE(truth, response)/tss)
+}
+
+#' @export rae
+#' @rdname measures
+#' @format none
+rae = makeMeasure(id = "rae", minimize = TRUE, best = 0, worst = Inf,
+  properties = c("regr", "req.pred", "req.truth"),
+  name = "Relative absolute error",
+  note = "Defined as sum_of_absolute_errors / mean_absolute_deviation. Undefined for single instances and when every truth value is identical. In this case the output will be NA.",
+  fun = function(task, model, pred, feats, extra.args) {
+    measureRAE(pred$data$truth, pred$data$response)
+  }
+)
+
+#' @export measureRAE
+#' @rdname measures
+#' @format none
+measureRAE = function(truth, response){
+  meanad = sum(abs(truth-mean(truth)))
+  if (meanad == 0){
+    warning("RAE is undefined if all truth values are equal.")
+    return(NA)
+  }
+  return(measureSAE(truth, response)/meanad)
+}
+
+#' @export mape
+#' @rdname measures
+#' @format none
+mape = makeMeasure(id = "mape", minimize = TRUE, best = 0, worst = Inf,
+  properties = c("regr", "req.pred", "req.truth"),
+  name = "Mean absolute percentage error",
+  note = "Defined as the abs(truth_i - response_i)/truth_i. Won't work if any truth value is equal to zero. In this case the output will be NA.",
+  fun = function(task, model, pred, feats, extra.args) {
+    measureMAPE(pred$data$truth, pred$data$response)
+  }
+)
+
+#' @export measureMAPE
+#' @rdname measures
+#' @format none
+measureMAPE = function(truth, response){
+  if (any(truth == 0)){
+    warning("MAPE is undefined if any truth value is equal to 0.")
+    return(NA)
+  }
+  return(mean(abs((truth-response)/truth)))
+}
+
 ###############################################################################
 ### classif multi ###
 ###############################################################################

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -260,8 +260,8 @@ test_that("check measure calculations", {
   pred.regr.mape = pred.regr
   pred.regr.mape$data$truth = c(5, 10, 1, 5) #we change the 0 target because mape is undefined
   mape.perf = performance(pred.regr.mape, measures = mape, model = mod.regr)
-  mape.test = mean(abs((5-4)/5)+abs((10-11)/10)+abs((1-0)/1)+abs((5-4)/5))
-  expect_equal(mape.test, rae$fun(pred = pred.regr.mape))
+  mape.test = mean(c(abs((5-4)/5),abs((10-11)/10),abs((1-0)/1),abs((5-4)/5)))
+  expect_equal(mape.test, mape$fun(pred = pred.regr.mape))
   expect_equal(mape.test, as.numeric(mape.perf))
   expect_equal(1/4*(abs((4-5)/5)+abs((11-10)/10)+abs((0-2)/2)+abs((4-5)/5)), measureMAPE(c(5, 10, 2, 5),c(4, 11, 0, 4)))
   expect_warning(measureMAPE(0,0))

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -236,7 +236,38 @@ test_that("check measure calculations", {
   expvar.perf = performance(pred.regr, measures = expvar, model = mod.regr)
   expect_equal(expvar.test, expvar$fun(pred = pred.regr))
   expect_equal(expvar.test, as.numeric(expvar.perf))
-
+  # rrse
+  rrse.test = sqrt(sum((pred.art.regr - tar.regr)^2L) / sum((tar.regr - mean(tar.regr))^2L))
+  rrse.perf = performance(pred.regr, measures = rrse, model = mod.regr)
+  expect_equal(rrse.test, rrse$fun(pred = pred.regr))
+  expect_equal(rrse.test, as.numeric(rrse.perf))
+  expect_equal(sqrt((4-5)^2+(11-10)^2+(0-0)^2+(4-5)^2)/sqrt((5-5)^2+(10-5)^2+(0-5)^2+(5-5)^2), measureRRSE(c(5, 10, 0, 5),c(4, 11, 0, 4)))
+  expect_warning(measureRRSE(0,0))
+  expect_warning(measureRRSE(c(1,1,1,1),c(1,2,3,4)))
+  expect_silent(measureRRSE(c(1,1,1,0),c(2,2,2,2)))
+  # rae
+  rae.test = sum(abs(pred.art.regr - tar.regr)) / sum(abs(tar.regr - mean(tar.regr)))
+  rae.perf = performance(pred.regr, measures = rae, model = mod.regr)
+  expect_equal(rae.test, rae$fun(pred = pred.regr))
+  expect_equal(rae.test, as.numeric(rae.perf))
+  expect_equal((abs(4-5)+abs(11-10)+abs(0-0)+abs(4-5))/(abs(5-5)+abs(10-5)+abs(0-5)+abs(5-5)), measureRAE(c(5, 10, 0, 5),c(4, 11, 0, 4)))
+  expect_warning(measureRAE(0,0))
+  expect_warning(measureRAE(c(1,1,1,1),c(1,2,3,4)))
+  expect_silent(measureRAE(c(1,1,1,0),c(2,2,2,2)))
+  # mape
+  expect_equal(NA, mape$fun(pred = pred.regr))
+  expect_equal(NA, measureMAPE(c(5, 10, 0, 5),c(4, 11, 0, 4)))
+  mape.perf = performance(pred.regr.mape, measures = mape, model = mod.regr)
+  pred.regr.mape = pred.regr
+  pred.regr.mape$data$truth = c(5, 10, 1, 5) #we change the 0 target because mape is undefined
+  mape.test = mean(abs((5-4)/5)+abs((10-11)/10)+abs((1-0)/1)+abs((5-4)/5))
+  expect_equal(mape.test, rae$fun(pred = pred.regr.mape))
+  expect_equal(mape.test, as.numeric(mape.perf))
+  expect_equal(1/4*(abs((4-5)/5)+abs((11-10)/10)+abs((0-2)/2)+abs((4-5)/5)), measureMAPE(c(5, 10, 2, 5),c(4, 11, 0, 4)))
+  expect_warning(measureMAPE(0,0))
+  expect_warning(measureMAPE(c(1,1,1,0),c(2,2,2,2)))
+  expect_silent(measureMAPE(c(1,1,1,1),c(2,2,2,2)))
+  
   #test multiclass measures
 
   #mmce

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -257,9 +257,9 @@ test_that("check measure calculations", {
   # mape
   expect_equal(NA, mape$fun(pred = pred.regr))
   expect_equal(NA, measureMAPE(c(5, 10, 0, 5),c(4, 11, 0, 4)))
-  mape.perf = performance(pred.regr.mape, measures = mape, model = mod.regr)
   pred.regr.mape = pred.regr
   pred.regr.mape$data$truth = c(5, 10, 1, 5) #we change the 0 target because mape is undefined
+  mape.perf = performance(pred.regr.mape, measures = mape, model = mod.regr)
   mape.test = mean(abs((5-4)/5)+abs((10-11)/10)+abs((1-0)/1)+abs((5-4)/5))
   expect_equal(mape.test, rae$fun(pred = pred.regr.mape))
   expect_equal(mape.test, as.numeric(mape.perf))


### PR DESCRIPTION
Added the Root relative squared error measure and the Relative absolute error based on this answer http://stats.stackexchange.com/a/203187/60613.

These metrics are good to have in the package because they establish a baseline to compare results, i.e. if the relative error is above 1 you are doing worse than simply predicting the mean result.

- More measures can be added (e.g. Relative squared error)

- I could have used the already existing functions `measureSAE` and `measureSSE`, but I guess that wouldn't be optimal

- The measures won't work, for obvious reasons, with single instances (e.g. doing leave one out)