### PR TITLE
introduce Aggregation class properties and clean up ResampleResult printer

### DIFF
--- a/R/Aggregation.R
+++ b/R/Aggregation.R
@@ -12,6 +12,7 @@
 #' \describe{
 #' \item{id [\code{character(1)}]}{Name of the aggregation method.}
 #' \item{name [\code{character(1)}]}{Long name of the aggregation method.}
+#' \item{properties [\code{character}]}{Properties of the aggregation.}
 #' \item{fun [\code{function(task, perf.test, perf.train, measure, group, pred)}]}{Aggregation function.}
 #' }
 #' @name Aggregation
@@ -30,6 +31,12 @@ NULL
 #'   Name of the aggregation method (preferably the same name as the generated function).
 #' @param name [\code{character(1)}]\cr
 #'   Long name of the aggregation method. Default is \code{id}.
+#' @param properties [\code{character}]\cr
+#'   Set of aggregation properties.
+#'   \describe{
+#'     \item{req.train}{Is prediction on train sets required to calculate the aggregation?}
+#'     \item{req.test}{Is prediction on test sets required to calculate the aggregation?}
+#'   }
 #' @param fun [\code{function(task, perf.test, perf.train, measure, group, pred)}]\cr
 #'   Calculates the aggregated performance. In most cases you will only need the performances
 #'   \code{perf.test} and optionally \code{perf.train} on the test and training data sets.
@@ -52,12 +59,13 @@ NULL
 #' @examples
 #' # computes the interquartile range on all performance values
 #' test.iqr = makeAggregation(id = "test.iqr", name = "Test set interquartile range",
+#'   properties = "req.test",
 #'   fun = function (task, perf.test, perf.train, measure, group, pred) IQR(perf.test))
 #' @export
-makeAggregation = function(id, name = id, fun) {
+makeAggregation = function(id, name = id, properties, fun) {
   assertString(id)
   assertString(name)
-  setClasses(list(id = id, name = name, fun = fun), "Aggregation")
+  makeS3Obj("Aggregation", id = id, name = name, fun = fun, properties = properties)
 }
 
 #' @export

--- a/R/Aggregation.R
+++ b/R/Aggregation.R
@@ -34,8 +34,8 @@ NULL
 #' @param properties [\code{character}]\cr
 #'   Set of aggregation properties.
 #'   \describe{
-#'     \item{req.train}{Is prediction on train sets required to calculate the aggregation?}
-#'     \item{req.test}{Is prediction on test sets required to calculate the aggregation?}
+#'     \item{req.train}{Are prediction or train sets required to calculate the aggregation?}
+#'     \item{req.test}{Are prediction or test sets required to calculate the aggregation?}
 #'   }
 #' @param fun [\code{function(task, perf.test, perf.train, measure, group, pred)}]\cr
 #'   Calculates the aggregated performance. In most cases you will only need the performances

--- a/R/Measure_custom_resampled.R
+++ b/R/Measure_custom_resampled.R
@@ -37,20 +37,7 @@
 #'   Should the measure be minimized?
 #'   Default is \code{TRUE}.
 #' @param properties [\code{character}]\cr
-#'   Set of measure properties. Some standard property names include:
-#'   \describe{
-#'     \item{classif}{Is the measure applicable for classification?}
-#'     \item{classif.multi}{Is the measure applicable for multi-class classification?}
-#'     \item{regr}{Is the measure applicable for regression?}
-#'     \item{surv}{Is the measure applicable for survival?}
-#'     \item{costsens}{Is the measure applicable for cost-sensitive learning?}
-#'     \item{req.pred}{Is prediction object required in calculation? Usually the case.}
-#'     \item{req.truth}{Is truth column required in calculation? Usually the case.}
-#'     \item{req.task}{Is task object required in calculation? Usually not the case}
-#'     \item{req.model}{Is model object required in calculation? Usually not the case.}
-#'     \item{req.feats}{Are feature values required in calculation? Usually not the case.}
-#'     \item{req.prob}{Are predicted probabilites required in calculation? Usually not the case, example would be AUC.}
-#'   }
+#'   Set of measure properties. For a list of values see \code{\link{Measure}}.
 #'   Default is \code{character(0)}.
 #' @param best [\code{numeric(1)}]\cr
 #'   Best obtainable value for measure.
@@ -64,9 +51,9 @@
 #' @family performance
 #' @export
 makeCustomResampledMeasure = function(measure.id, aggregation.id, minimize = TRUE, properties = character(0L),
-                                      fun, extra.args = list(), best = NULL, worst = NULL,
-                                      measure.name = measure.id, aggregation.name = aggregation.id,
-                                      note = "") {
+  fun, extra.args = list(), best = NULL, worst = NULL, measure.name = measure.id,
+  aggregation.name = aggregation.id, note = "") {
+
   assertString(measure.id)
   assertString(aggregation.id)
   assertFlag(minimize)
@@ -84,6 +71,7 @@ makeCustomResampledMeasure = function(measure.id, aggregation.id, minimize = TRU
    best = best, worst = worst, name = measure.name, note = note)
   fun2 = function(task, perf.test, perf.train, measure, group, pred)
     fun(task, group, pred, extra.args)
-  aggr = makeAggregation(id = aggregation.id, name = aggregation.name, fun = fun2)
+  # we set the properties to "no requirements" here
+  aggr = makeAggregation(id = aggregation.id, name = aggregation.name, properties = character(0L), fun = fun2)
   setAggregation(custom, aggr)
 }

--- a/R/ResampleResult.R
+++ b/R/ResampleResult.R
@@ -46,8 +46,7 @@
 #' }
 #' }
 #' The print method of this object gives a short overview, including
-#' task and learner ids, aggregated measures as well as mean and standard
-#' deviation of the measures.
+#' task and learner ids, aggregated measures and runtime for the resampling.
 #' @family resample
 NULL
 
@@ -56,12 +55,7 @@ print.ResampleResult = function(x, ...) {
   cat("Resample Result\n")
   catf("Task: %s", x$task.id)
   catf("Learner: %s", x$learner.id)
-  m = x$measures.test[, -1L, drop = FALSE]
-  Map(function(name, x, aggr) {
-    catf("%s.aggr: %.2f", name, aggr)
-    catf("%s.mean: %.2f", name, mean(x, na.rm = TRUE))
-    catf("%s.sd: %.2f", name, sd(x, na.rm = TRUE))
-  }, name = colnames(m), x = m, aggr = x$aggr)
+  catf("Aggr perf: %s", perfsToString(x$aggr))
   catf("Runtime: %g", x$runtime)
   invisible(NULL)
 }

--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -36,6 +36,7 @@ NULL
 test.mean = makeAggregation(
   id = "test.mean",
   name = "Test mean",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) mean(perf.test)
 )
 
@@ -44,6 +45,7 @@ test.mean = makeAggregation(
 test.sd = makeAggregation(
   id = "test.sd",
   name = "Test sd",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) sd(perf.test)
 )
 
@@ -52,6 +54,7 @@ test.sd = makeAggregation(
 test.median = makeAggregation(
   id = "test.median",
   name = "Test median",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) median(perf.test)
 )
 
@@ -60,6 +63,7 @@ test.median = makeAggregation(
 test.min = makeAggregation(
   id = "test.min",
   name = "Test minimum",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) min(perf.test)
 )
 
@@ -68,6 +72,7 @@ test.min = makeAggregation(
 test.max = makeAggregation(
   id = "test.max",
   name = "Test maximum",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.test)
 )
 
@@ -76,6 +81,7 @@ test.max = makeAggregation(
 test.sum = makeAggregation(
   id = "test.sum",
   name = "Test sum",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) sum(perf.test)
 )
 
@@ -84,6 +90,7 @@ test.sum = makeAggregation(
 test.range = makeAggregation(
   id = "test.range",
   name = "Test range",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.test))
 )
 
@@ -92,6 +99,7 @@ test.range = makeAggregation(
 test.rmse = makeAggregation(
   id = "test.rmse",
   name = "Test RMSE",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) sqrt(mean(perf.test^2))
 )
 
@@ -100,6 +108,7 @@ test.rmse = makeAggregation(
 train.mean = makeAggregation(
   id = "train.mean",
   name = "Training mean",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) mean(perf.train)
 )
 
@@ -108,6 +117,7 @@ train.mean = makeAggregation(
 train.sd = makeAggregation(
   id = "train.sd",
   name = "Training sd",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) sd(perf.train)
 )
 
@@ -116,6 +126,7 @@ train.sd = makeAggregation(
 train.median = makeAggregation(
   id = "train.median",
   name = "Training median",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) median(perf.train)
 )
 
@@ -124,6 +135,7 @@ train.median = makeAggregation(
 train.min = makeAggregation(
   id = "train.min",
   name = "Training min",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) min(perf.train)
 )
 
@@ -132,6 +144,7 @@ train.min = makeAggregation(
 train.max = makeAggregation(
   id = "train.max",
   name = "Training max",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.train)
 )
 
@@ -140,6 +153,7 @@ train.max = makeAggregation(
 train.sum = makeAggregation(
   id = "train.sum",
   name = "Training sum",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) sum(perf.train)
 )
 
@@ -148,6 +162,7 @@ train.sum = makeAggregation(
 train.range = makeAggregation(
   id = "train.range",
   name = "Training range",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.train))
 )
 
@@ -156,6 +171,7 @@ train.range = makeAggregation(
 train.rmse = makeAggregation(
   id = "train.rmse",
   name = "Training RMSE",
+  properties = "req.train",
   fun = function(task, perf.test, perf.train, measure, group, pred) sqrt(mean(perf.train^2))
 )
 
@@ -164,6 +180,7 @@ train.rmse = makeAggregation(
 b632 = makeAggregation(
   id = "b632",
   name = ".632 Bootstrap",
+  properties = c("req.train", "req.test"),
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     mean(0.632*perf.test + 0.368*perf.train)
   }
@@ -176,6 +193,7 @@ b632 = makeAggregation(
 b632plus = makeAggregation(
   id = "b632plus",
   name = ".632 Bootstrap plus",
+  properties = c("req.train", "req.test"),
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     df = as.data.frame(pred)
     a = numeric(length(perf.test))
@@ -201,6 +219,7 @@ b632plus = makeAggregation(
 testgroup.mean = makeAggregation(
   id = "testgroup.mean",
   name = "Test group mean",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     mean(vnapply(split(perf.test, group), mean))
   }
@@ -211,6 +230,7 @@ testgroup.mean = makeAggregation(
 test.join = makeAggregation(
   id = "test.join",
   name = "Test join",
+  properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     df = as.data.frame(pred)
     f = if (length(group)) group[df$iter] else factor(rep(1L, nrow(df)))

--- a/R/checkAggrBeforeResample.R
+++ b/R/checkAggrBeforeResample.R
@@ -1,0 +1,25 @@
+# check whether rdesc$predict is set, so that the requiring properties of the measure are satisfied
+# called the beginning of resample
+checkAggrBeforeResample = function(measure, rdesc) {
+  a = measure$aggr
+  p = a$properties
+  pred = rdesc$predict
+  p.allowed = if (all(c("req.train", "req.test") %in% p)) {
+    "both"
+  } else if ("req.train" %in% p) {
+    c("train", "both")
+  } else if ("req.test" %in% p) {
+    c("test", "both")
+  } else {
+    c("train", "test", "both")
+  }
+  if (pred %nin% p.allowed)
+    stopf("Aggregation '%s' not compatible with resampling! You have to set arg 'predict' to %s in your resample object, instead it is '%s'!", a$id, stri_paste("'", p.allowed, "'", collapse = " or "), pred)
+}
+
+# map the checker over multiple measures
+checkAggrsBeforeResample = function(measures, rdesc) {
+  lapply(measures, checkAggrBeforeResample, rdesc = rdesc)
+}
+
+

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -16,8 +16,10 @@ measureAggrPrettyName = function(measure) {
   stri_paste(measure$name, measure$aggr$name, sep = ": ")
 }
 
-perfsToString = function(y) {
-  stri_paste(stri_paste(names(y), "=", formatC(y, digits = 3L), sep = ""), 
+# convert a named numvec of perf values (think 'aggr' from resample) into flat string
+# ala <name><sep><value>,...,<name><sep><value>
+perfsToString = function(y, sep = "=") {
+  stri_paste(stri_paste(names(y), "=", formatC(y, digits = 3L), sep = ""),
              collapse = ",", sep = " ")
 }
 

--- a/R/resample.R
+++ b/R/resample.R
@@ -92,6 +92,7 @@ resample = function(learner, task, resampling, measures, weights = NULL, models 
     stop(stri_paste("Size of data set:", n, "and resampling instance:", r, "differ!", sep = " "))
 
   checkLearnerBeforeTrain(task, learner, weights)
+  checkAggrsBeforeResample(measures, resampling$desc)
 
   rin = resampling
   more.args = list(learner = learner, task = task, rin = rin, weights = NULL,

--- a/tests/testthat/test_base_performance.R
+++ b/tests/testthat/test_base_performance.R
@@ -40,7 +40,7 @@ test_that("performance", {
 
   # custom measure
   mymeasure = makeCustomResampledMeasure(measure.id = "mym", aggregation.id = "train.mean",
-                                         properties = c("classif", "predtype.response"),
+    properties = c("classif", "predtype.response"),
     fun = function(task, group, pred, feats, extra.args) {
       mean(pred$data$truth != pred$data$response)
     })

--- a/tests/testthat/test_base_resample.R
+++ b/tests/testthat/test_base_resample.R
@@ -6,9 +6,13 @@ test_that("resample", {
   rin3 = makeResampleInstance(makeResampleDesc("Subsample", iters = 2), task = multiclass.task)
 
   lrn = makeLearner("classif.lda")
-  p1 = resample(lrn, multiclass.task, rin1)$pred
-  p2 = resample(lrn, multiclass.task, rin2)$pred
-  p3 = resample(lrn, multiclass.task, rin3)$pred
+  r1 = resample(lrn, multiclass.task, rin1)
+  r2 = resample(lrn, multiclass.task, rin2)
+  r3 = resample(lrn, multiclass.task, rin3)
+
+  p1 = r1$pred
+  p2 = r2$pred
+  p3 = r3$pred
 
   inds = Reduce(c, rin1$test.inds)
   y = getTaskTargets(multiclass.task)[inds]
@@ -22,6 +26,9 @@ test_that("resample", {
   y = getTaskTargets(multiclass.task)[inds]
   expect_equal(p3$data$id, inds)
   expect_equal(p3$data$truth, y)
+  # test printer
+  expect_output(print(r1), "Resample Result")
+
 
   cv.i = makeResampleInstance(makeResampleDesc("CV", iters = 3), binaryclass.task)
 
@@ -51,22 +58,21 @@ test_that("resample", {
 test_that("resampling, predicting train set works", {
   rdesc = makeResampleDesc("CV", iters = 2, predict = "train")
   lrn = makeLearner("classif.rpart")
-  r = resample(lrn, multiclass.task, rdesc)
-  expect_true(as.logical(is.na(r$aggr["mmce.test.mean"])))
+  expect_error(resample(lrn, multiclass.task, rdesc), "not compatible with resampling")
 
   rdesc = makeResampleDesc("CV", iters = 2, predict = "train")
   lrn = makeLearner("classif.rpart")
   m = setAggregation(mmce, train.mean)
   r = resample(lrn, multiclass.task, rdesc, measures = m)
-  expect_true(!as.logical(is.na(r$aggr["mmce.train.mean"])))
+  expect_false(is.na(r$aggr["mmce.train.mean"]))
 
   rdesc = makeResampleDesc("CV", iters = 2, predict = "both")
   lrn = makeLearner("classif.rpart")
   m1 = setAggregation(mmce, train.mean)
   m2 = setAggregation(mmce, test.mean)
   r = resample(lrn, multiclass.task, rdesc, measures = list(m1, m2))
-  expect_true(!as.logical(is.na(r$aggr["mmce.train.mean"])))
-  expect_true(!as.logical(is.na(r$aggr["mmce.test.mean"])))
+  expect_false(is.na(r$aggr["mmce.train.mean"]))
+  expect_false(is.na(r$aggr["mmce.test.mean"]))
 
 })
 


### PR DESCRIPTION
this addresses issue #1045 
it became a lot longer than i had hoped. 
summary of what i did:

1) Aggregation objects now have properties. they define whether they need the trains set evals, test set evals, or both. this allows to generate an informative error msg for the NA problem in the issue.

2) i removed the "mean" and "sd" display from the ResampleResult printer. this was kinda hacked in before, confusing as it used different aggregation functions, and also did not reliably work. 
it also nearly never provided more info but ate up extra lines in a useless manner.
i printed the aggreated measure performance in a standard way instead.

3) some tests
