### PR TITLE
add weight fun arg to generatePartialDependenceData and generateFunctionalANOVAData

### DIFF
--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -221,6 +221,19 @@ test_that("generatePartialDependenceData", {
   q = plotPartialDependence(dr, facet = "chas", facet.wrap.ncol = 2L,
     data = regr.df)
   testFacetting(q, ncol = 2L)
+
+  # with the joint distribution as the weight function generatePartialDependenceData
+  # should return NA for regions with zero probability
+  x = runif(10)
+  y = 2 * x
+  idx = x > .5
+  x[idx] = NA
+  test.task = makeRegrTask(data = data.frame(x = x[-idx], y = y[-idx]), target = "y")
+  fit = train("regr.rpart", test.task)
+  pd = generatePartialDependenceData(fit, test.task,
+    weight.fun = function(x, data) ifelse(x > .5, 0, 1),
+    fmin = list("x" = 0), fmax = list("x" = 1))
+  expect_that(all(is.na(pd$data[pd$data$x > .5, "y"])), is_true())
 })
 
 test_that("generateFeatureGrid", {


### PR DESCRIPTION
for use with methods to detect regions of extrapolation. their use here down weights predictions made at regions of low data density. this could be used with a density estimator, some sort of classifier (e.g., [Hooker 2004](http://dl.acm.org/citation.cfm?id=1014121)) or by using [data depth](https://www.jstor.org/stable/120138?seq=1#page_scan_tab_contents) which is what I've been testing this with.

this is particularly important with partial dependence since the algorithm assumes the features come from a product distribution (i.e., p(x_u, x_-u) = p(x_u)p(x_-u). since they usually don't functional behavior can be displayed at parts of the joint distribution with little or no density/mass. this means that the output reflects the learner's properties more than the data.

will add this to the tutorial and so on as well. i thought of integrating the extrapolation detection into mlr but as far as i know now this is the only use. i think i may write a package which has a bunch of methods for extrapolation detection in it and if we want to integrate that we can do so then.

