### PR TITLE
bug in weight.fun default for centered partial dependence

### DIFF
--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -262,7 +262,7 @@ generatePartialDependenceData = function(obj, input, features,
         out = parallelMap(doPartialDependenceIteration, i = seq_len(nrow(rng)), more.args = args)
         if (!is.null(center) & individual)
           centerpred = doPartialDependenceIteration(obj, data, center[, x, drop = FALSE],
-            x, fun, td, 1, bounds = bounds, weight.fun = function(x, data) 1)
+            x, fun, td, 1, bounds = bounds, weight.fun = function(x, data) rep(1, nrow(x)))
         else
           centerpred = NULL
       }
@@ -286,7 +286,7 @@ generatePartialDependenceData = function(obj, input, features,
       args$rng = rng
       out = parallelMap(doPartialDependenceIteration, i = seq_len(nrow(rng)), more.args = args)
       if (!is.null(center) & individual)
-        centerpred = as.data.frame(doPartialDependenceIteration(obj, data, center, features, fun, td, 1, bounds, weight.fun = function(x, data) 1))
+        centerpred = as.data.frame(doPartialDependenceIteration(obj, data, center, features, fun, td, 1, bounds, weight.fun = function(x, data) rep(1, nrow(x))))
       else
         centerpred = NULL
     }

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -238,6 +238,11 @@ test_that("generatePartialDependenceData", {
   # issue 55 in the tutorial
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width",
     center = list("Petal.Width" = min(multiclass.df$Petal.Width)), gridsize = gridsize)
+
+  # subsequent bug found in pr #1206
+  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width",
+    individual = TRUE,
+    center = list("Petal.Width" = min(multiclass.df$Petal.Width)), gridsize = gridsize)
 })
 
 test_that("generateFeatureGrid", {


### PR DESCRIPTION
the default weight.fun was inappropriately set to its older
nonvectorized identity weight function. bug was identified in pr #1206.