### PR TITLE
set default of shw.missing.values to TRUE

### DIFF
--- a/R/getHyperPars.R
+++ b/R/getHyperPars.R
@@ -27,7 +27,7 @@ getHyperPars.Learner = function(learner, for.fun = c("train", "predict", "both")
   pv[ns]
 }
 
-getHyperParsString = function(learner, show.missing.values = FALSE) {
+getHyperParsString = function(learner, show.missing.values = TRUE) {
   hps = getHyperPars(learner)
   ns = names(hps)
   pars = getParamSet(learner)$pars[ns]

--- a/R/getHyperPars.R
+++ b/R/getHyperPars.R
@@ -27,7 +27,7 @@ getHyperPars.Learner = function(learner, for.fun = c("train", "predict", "both")
   pv[ns]
 }
 
-getHyperParsString = function(learner, show.missing.values) {
+getHyperParsString = function(learner, show.missing.values = FALSE) {
   hps = getHyperPars(learner)
   ns = names(hps)
   pars = getParamSet(learner)$pars[ns]


### PR DESCRIPTION
This fixes #1212 


Same default as in ParamHelpers for `paramValueToString`

EDIT: After short discussion with @berndbischl we set the value to TRUE, but this shouldn't change anything.