### PR TITLE
Fix some warnings in base tests

### DIFF
--- a/tests/testthat/test_base_getParamSet.R
+++ b/tests/testthat/test_base_getParamSet.R
@@ -9,7 +9,7 @@ test_that("getParamSet", {
   ps = getParamSet(lrn)
   expect_true(all(c("method", "fw.method") %in% names(ps$pars)))
 
-  lrn = makeModelMultiplexer(list(setId(lrn, "x")))
+  lrn = makeModelMultiplexer(list(setLearnerId(lrn, "x")))
   ps = getParamSet(lrn)
   expect_true(all(c("x.method", "x.fw.method", "selected.learner") %in% names(ps$pars)))
 

--- a/tests/testthat/test_base_makeLearners.R
+++ b/tests/testthat/test_base_makeLearners.R
@@ -6,7 +6,7 @@ test_that("makeLearners", {
   lrns1 = setNames(lapply(cls1, makeLearner), cls1)
   ids = c("a", "b")
   lrns1 = setNames(lapply(cls1, makeLearner), cls1)
-  lrns2 = setNames(mapply(setId, lrns1, ids, SIMPLIFY = FALSE), ids)
+  lrns2 = setNames(mapply(setLearnerId, lrns1, ids, SIMPLIFY = FALSE), ids)
   lrns3 = lapply(lrns1, setPredictType, predict.type = "prob")
 
   res = makeLearners(cls1)

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -255,8 +255,12 @@ test_that("check measure calculations", {
   expect_warning(measureRAE(c(1,1,1,1),c(1,2,3,4)))
   expect_silent(measureRAE(c(1,1,1,0),c(2,2,2,2)))
   # mape
-  expect_equal(NA, mape$fun(pred = pred.regr))
-  expect_equal(NA, measureMAPE(c(5, 10, 0, 5),c(4, 11, 0, 4)))
+  suppressWarnings({
+    expect_equal(NA, mape$fun(pred = pred.regr))
+    expect_equal(NA, measureMAPE(c(5, 10, 0, 5),c(4, 11, 0, 4)))
+  })
+  expect_warning(mape$fun(pred = pred.regr), regexp = "MAPE is undefined if any truth value is equal to 0.")
+  expect_warning(measureMAPE(c(5, 10, 0, 5),c(4, 11, 0, 4)), regexp = "MAPE is undefined if any truth value is equal to 0.")
   pred.regr.mape = pred.regr
   pred.regr.mape$data$truth = c(5, 10, 1, 5) #we change the 0 target because mape is undefined
   mape.perf = performance(pred.regr.mape, measures = mape, model = mod.regr)


### PR DESCRIPTION
So there seem to occur some warnings in the base tests when running them locally


```
Warnings -----------------------------------------------------------------------
1. getParamSet (@test_base_getParamSet.R#12) - 'setId' is deprecated.
Use 'setLearnerId' instead.
See help("Deprecated")

2. makeLearners (@test_base_makeLearners.R#9) - 'function (learner, id) 
{
    .Deprecated("setLearnerId")
    learner = checkLearner(learner)
    assertString(id)
    learner$id = id
    return(learner)
}' is deprecated.
Use 'setLearnerId' instead.
See help("Deprecated")

3. makeLearners (@test_base_makeLearners.R#9) - 'function (learner, id) 
{
    .Deprecated("setLearnerId")
    learner = checkLearner(learner)
    assertString(id)
    learner$id = id
    return(learner)
}' is deprecated.
Use 'setLearnerId' instead.
See help("Deprecated")

4. check measure calculations (@test_base_measures.R#258) - MAPE is undefined if any truth value is equal to 0.

5. check measure calculations (@test_base_measures.R#259) - MAPE is undefined if any truth value is equal to 0.

6. measures quickcheck (@test_base_measures.R#659) - NAs produced by integer overflow
```

1 - 3 are just deprecated calls to `getId`

4 - 5 added supress warning test to check the actual value (`NA`) as well as an test for the warning message.

6 I have no idea why this is failing, seems to be consistently failing when running rcheck  but works when running the chunk of code by hand. 