### PR TITLE
Add support for visualizing tasks with 2 or more hyperparameters

### DIFF
--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -368,15 +368,15 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       d$iteration = 1:nrow(d)
     }
   }
-  print(d)
+
   # just x, y
   if ((length(x) == 1) && (length(y) == 1) && !(z.flag)){
-    if (hyperpars.effect.data$nested){
+    if (hyperpars.effect.data$nested && !partial.flag) {
       plt = ggplot(d, aes_string(x = x, y = y, color = "nested_cv_run"))
     } else {
       plt = ggplot(d, aes_string(x = x, y = y))
     }
-    if (na.flag){
+    if (na.flag && !partial.flag){
       plt = plt + geom_point(aes_string(shape = "learner_status",
         color = "learner_status")) +
         scale_shape_manual(values = c("Failure" = 24, "Success" = 0)) +
@@ -404,7 +404,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
         plt = ggplot(data = d, aes_string(x = x, y = y, fill = z, z = z)) +
           geom_tile()
       }
-      if ((na.flag || show.experiments) && !(show.interpolated)){
+      if ((na.flag || show.experiments) && !show.interpolated && !partial.flag){
         plt = plt + geom_point(data = d[d$learner_status %in% c("Success",
           "Failure"), ],
           aes_string(shape = "learner_status"),

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -23,14 +23,18 @@
 #'  Default is \code{FALSE}.
 #' @param partial.dep [\code{logical(1)}]\cr
 #'  Should partial dependence be generated based on converting to reg task? This
-#'  sets a flag so that we know to use partial dependence downstream.
+#'  sets a flag so that we know to use partial dependence downstream. This
+#'  should most likely be set to \code{TRUE} if 2 or more hyperparameters were
+#'  tuned simultaneously. Setting to \code{TRUE} will cause
+#'  \code{\link{plotHyperParsEffect}} to automatically plot partial dependence
+#'  when called downstream.
 #'  Default is \code{FALSE}.
 #'
 #' @return [\code{HyperParsEffectData}]
 #'  Object containing the hyperparameter effects dataframe, the tuning
 #'  performance measures used, the hyperparameters used, a flag for including
-#'  diagnostic info, a flag for whether nested cv was used, and the optimization
-#'  algorithm used.
+#'  diagnostic info, a flag for whether nested cv was used, a flag for whether
+#'  partial dependence should be generated, and the optimization algorithm used.
 #'
 #' @examples \dontrun{
 #' # 3-fold cross validation
@@ -137,7 +141,8 @@ print.HyperParsEffectData = function(x, ...) {
 #'  Result of \code{\link{generateHyperParsEffectData}}
 #' @param x [\code{character(1)}]\cr
 #'  Specify what should be plotted on the x axis. Must be a column from
-#'  \code{HyperParsEffectData$data}
+#'  \code{HyperParsEffectData$data}. For partial dependence, this is assumed to
+#'  be a hyperparameter.
 #' @param y [\code{character(1)}]\cr
 #'  Specify what should be plotted on the y axis. Must be a column from
 #'  \code{HyperParsEffectData$data}
@@ -153,7 +158,8 @@ print.HyperParsEffectData = function(x, ...) {
 #' @param loess.smooth [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will add loess smoothing line to plots where possible. Note that
 #'  this is probably only useful when \code{plot.type} is set to either
-#'  \dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
+#'  \dQuote{scatter} or \dQuote{line}. Must be a column from
+#'  \code{HyperParsEffectData$data}. Not used with partial dependence.
 #'  Default is \code{FALSE}.
 #' @param facet [\code{character(1)}]\cr
 #'  Specify what should be used as the facet axis for a particular geom. When
@@ -165,7 +171,8 @@ print.HyperParsEffectData = function(x, ...) {
 #'  If \code{TRUE}, will only plot the current global optima when setting
 #'  x = "iteration" and y as a performance measure from
 #'  \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the
-#'  performance of every iteration, even if it is not an improvement.
+#'  performance of every iteration, even if it is not an improvement. Not used
+#'  with partial dependence.
 #'  Default is \code{TRUE}.
 #' @param interpolate [\code{\link{Learner}} | \code{character(1)}]\cr
 #'  If not \code{NULL}, will interpolate non-complete grids in order to visualize a more
@@ -173,32 +180,37 @@ print.HyperParsEffectData = function(x, ...) {
 #'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
 #'  cases of irregular hyperparameter paths, you will most likely need to use
 #'  this to have a meaningful visualization. Accepts either a \link{Learner}
-#'  object or the learner as a string for interpolation.
+#'  object or the learner as a string for interpolation. Not used with partial
+#'  dependence.
 #'  Default is \code{NULL}.
 #' @param show.experiments [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will overlay the plot with points indicating where an experiment
 #'  ran. This is only useful when creating a heatmap or contour plot with
 #'  interpolation so that you can see which points were actually on the
 #'  original path. Note: if any learner crashes occurred within the path, this
-#'  will become \code{TRUE}.
+#'  will become \code{TRUE}. Not used with partial dependence.
 #'  Default is \code{FALSE}.
 #' @param show.interpolated [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will overlay the plot with points indicating where interpolation
 #'  ran. This is only useful when creating a heatmap or contour plot with
-#'  interpolation so that you can see which points were interpolated.
+#'  interpolation so that you can see which points were interpolated. Not used
+#'  with partial dependence.
 #'  Default is \code{FALSE}.
 #' @param nested.agg [\code{function}]\cr
 #'  The function used to aggregate nested cross validation runs when plotting 2
-#'  hyperpars simultaneously. This is only useful when nested cross validation
-#'  is used along with plotting a 2 hyperpars.
+#'  hyperparameters. This is also used for nested aggregation in partial
+#'  dependence.
 #'  Default is \code{mean}.
 #' @template ret_gg2
 #'
 #' @note Any NAs incurred from learning algorithm crashes will be indicated in
-#' the plot and the NA values will be replaced with the column min/max depending
-#' on the optimal values for the respective measure. Execution time will be
-#' replaced with the max. Interpolation by its nature will result in predicted
-#' values for the performance measure. Use interpolation with caution.
+#' the plot (except in the case of partial dependence) and the NA values will be
+#' replaced with the column min/max depending on the optimal values for the
+#' respective measure. Execution time will be replaced with the max.
+#' Interpolation by its nature will result in predicted values for the
+#' performance measure. Use interpolation with caution. If \dQuote{partial.dep}
+#' is set to \code{TRUE} in \code{\link{generateHyperParsEffectData}}, only
+#' partial dependence will be plotted.
 #'
 #' @export
 #'

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -208,8 +208,8 @@ print.HyperParsEffectData = function(x, ...) {
 #'  hyperparameters. This is also used for nested aggregation in partial
 #'  dependence.
 #'  Default is \code{mean}.
-#' @param partial.dep.fun [\code{\link{Learner}} | \code{character(1)}]\cr
-#'  The function used to learn partial dependence. Must be specified if
+#' @param partial.dep.learn [\code{\link{Learner}} | \code{character(1)}]\cr
+#'  The learner used to learn partial dependence. Must be specified if
 #'  \dQuote{partial.dep} is set to \code{TRUE} in
 #'  \code{\link{generateHyperParsEffectData}}. Accepts either a \link{Learner}
 #'  object or the learner as a string for learning partial dependence.
@@ -233,7 +233,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   z = NULL, plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
   pretty.names = TRUE, global.only = TRUE, interpolate = NULL,
   show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean,
-  partial.dep.fun = NULL) {
+  partial.dep.learn = NULL) {
 
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
@@ -254,11 +254,11 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   assertFlag(show.experiments)
   assertFunction(nested.agg)
   # assign learner for partial dep
-  assert(checkClass(partial.dep.fun, "Learner"), checkString(partial.dep.fun),
-    checkNull(partial.dep.fun))
-  if (checkClass(partial.dep.fun, "Learner") == TRUE ||
-      checkString(partial.dep.fun) == TRUE) {
-    lrn = checkLearnerRegr(partial.dep.fun)
+  assert(checkClass(partial.dep.learn, "Learner"), checkString(partial.dep.learn),
+    checkNull(partial.dep.learn))
+  if (checkClass(partial.dep.learn, "Learner") == TRUE ||
+      checkString(partial.dep.learn) == TRUE) {
+    lrn = checkLearnerRegr(partial.dep.learn)
   }
 
   if (length(x) > 1 || length(y) > 1 || length(z) > 1 || length(facet) > 1)
@@ -279,8 +279,8 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   heatcontour.flag = plot.type %in% c("heatmap", "contour")
   partial.flag = hyperpars.effect.data$partial
 
-  if (partial.flag && is.null(partial.dep.fun))
-    stopf("Partial dependence requested but partial.dep.fun not specified!")
+  if (partial.flag && is.null(partial.dep.learn))
+    stopf("Partial dependence requested but partial.dep.learn not specified!")
 
   # deal with NAs where optimizer failed
   if (na.flag){

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -5,7 +5,7 @@
 \title{Generate hyperparameter effect data.}
 \usage{
 generateHyperParsEffectData(tune.result, include.diagnostics = FALSE,
-  trafo = FALSE)
+  trafo = FALSE, partial.dep = FALSE)
 }
 \arguments{
 \item{tune.result}{[\code{\link{TuneResult}} | \code{\link{ResampleResult}}]\cr
@@ -24,6 +24,11 @@ Default is \code{FALSE}.}
 Should the units of the hyperparameter path be converted to the
 transformed scale? This is only useful when trafo was used to create the
 path.
+Default is \code{FALSE}.}
+
+\item{partial.dep}{[\code{logical(1)}]\cr
+Should partial dependence be generated based on converting to reg task? This
+sets a flag so that we know to use partial dependence downstream.
 Default is \code{FALSE}.}
 }
 \value{

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -28,15 +28,19 @@ Default is \code{FALSE}.}
 
 \item{partial.dep}{[\code{logical(1)}]\cr
 Should partial dependence be generated based on converting to reg task? This
-sets a flag so that we know to use partial dependence downstream.
+sets a flag so that we know to use partial dependence downstream. This
+should most likely be set to \code{TRUE} if 2 or more hyperparameters were
+tuned simultaneously. Setting to \code{TRUE} will cause
+\code{\link{plotHyperParsEffect}} to automatically plot partial dependence
+when called downstream.
 Default is \code{FALSE}.}
 }
 \value{
 [\code{HyperParsEffectData}]
  Object containing the hyperparameter effects dataframe, the tuning
  performance measures used, the hyperparameters used, a flag for including
- diagnostic info, a flag for whether nested cv was used, and the optimization
- algorithm used.
+ diagnostic info, a flag for whether nested cv was used, a flag for whether
+ partial dependence should be generated, and the optimization algorithm used.
 }
 \description{
 Generate cleaned hyperparameter effect data from a tuning result or from a

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -27,12 +27,13 @@ path.
 Default is \code{FALSE}.}
 
 \item{partial.dep}{[\code{logical(1)}]\cr
-Should partial dependence be generated based on converting to reg task? This
+Should partial dependence be requested based on converting to reg task? This
 sets a flag so that we know to use partial dependence downstream. This
 should most likely be set to \code{TRUE} if 2 or more hyperparameters were
-tuned simultaneously. Setting to \code{TRUE} will cause
-\code{\link{plotHyperParsEffect}} to automatically plot partial dependence
-when called downstream.
+tuned simultaneously. Partial dependence should always be requested when
+more than 2 hyperparameters were tuned simultaneously. Setting to
+\code{TRUE} will cause \code{\link{plotHyperParsEffect}} to automatically
+plot partial dependence when called downstream.
 Default is \code{FALSE}.}
 }
 \value{

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -15,7 +15,8 @@ Result of \code{\link{generateHyperParsEffectData}}}
 
 \item{x}{[\code{character(1)}]\cr
 Specify what should be plotted on the x axis. Must be a column from
-\code{HyperParsEffectData$data}}
+\code{HyperParsEffectData$data}. For partial dependence, this is assumed to
+be a hyperparameter.}
 
 \item{y}{[\code{character(1)}]\cr
 Specify what should be plotted on the y axis. Must be a column from
@@ -35,7 +36,8 @@ Default is \dQuote{scatter}.}
 \item{loess.smooth}{[\code{logical(1)}]\cr
 If \code{TRUE}, will add loess smoothing line to plots where possible. Note that
 this is probably only useful when \code{plot.type} is set to either
-\dQuote{scatter} or \dQuote{line}. Must be a column from \code{HyperParsEffectData$data}
+\dQuote{scatter} or \dQuote{line}. Must be a column from
+\code{HyperParsEffectData$data}. Not used with partial dependence.
 Default is \code{FALSE}.}
 
 \item{facet}{[\code{character(1)}]\cr
@@ -51,7 +53,8 @@ Whether to use the short name of the learner instead of its ID in labels. Defaul
 If \code{TRUE}, will only plot the current global optima when setting
 x = "iteration" and y as a performance measure from
 \code{HyperParsEffectData$measures}. Set this to FALSE to always plot the
-performance of every iteration, even if it is not an improvement.
+performance of every iteration, even if it is not an improvement. Not used
+with partial dependence.
 Default is \code{TRUE}.}
 
 \item{interpolate}{[\code{\link{Learner}} | \code{character(1)}]\cr
@@ -60,7 +63,8 @@ complete path. Only meaningful when attempting to plot a heatmap or contour.
 This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
 cases of irregular hyperparameter paths, you will most likely need to use
 this to have a meaningful visualization. Accepts either a \link{Learner}
-object or the learner as a string for interpolation.
+object or the learner as a string for interpolation. Not used with partial
+dependence.
 Default is \code{NULL}.}
 
 \item{show.experiments}{[\code{logical(1)}]\cr
@@ -68,19 +72,20 @@ If \code{TRUE}, will overlay the plot with points indicating where an experiment
 ran. This is only useful when creating a heatmap or contour plot with
 interpolation so that you can see which points were actually on the
 original path. Note: if any learner crashes occurred within the path, this
-will become \code{TRUE}.
+will become \code{TRUE}. Not used with partial dependence.
 Default is \code{FALSE}.}
 
 \item{show.interpolated}{[\code{logical(1)}]\cr
 If \code{TRUE}, will overlay the plot with points indicating where interpolation
 ran. This is only useful when creating a heatmap or contour plot with
-interpolation so that you can see which points were interpolated.
+interpolation so that you can see which points were interpolated. Not used
+with partial dependence.
 Default is \code{FALSE}.}
 
 \item{nested.agg}{[\code{function}]\cr
 The function used to aggregate nested cross validation runs when plotting 2
-hyperpars simultaneously. This is only useful when nested cross validation
-is used along with plotting a 2 hyperpars.
+hyperparameters. This is also used for nested aggregation in partial
+dependence.
 Default is \code{mean}.}
 }
 \value{
@@ -94,10 +99,13 @@ optimizer.
 }
 \note{
 Any NAs incurred from learning algorithm crashes will be indicated in
-the plot and the NA values will be replaced with the column min/max depending
-on the optimal values for the respective measure. Execution time will be
-replaced with the max. Interpolation by its nature will result in predicted
-values for the performance measure. Use interpolation with caution.
+the plot (except in the case of partial dependence) and the NA values will be
+replaced with the column min/max depending on the optimal values for the
+respective measure. Execution time will be replaced with the max.
+Interpolation by its nature will result in predicted values for the
+performance measure. Use interpolation with caution. If \dQuote{partial.dep}
+is set to \code{TRUE} in \code{\link{generateHyperParsEffectData}}, only
+partial dependence will be plotted.
 }
 \examples{
 # see generateHyperParsEffectData

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -8,7 +8,7 @@ plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
   pretty.names = TRUE, global.only = TRUE, interpolate = NULL,
   show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean,
-  partial.dep.fun = NULL)
+  partial.dep.learn = NULL)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -89,8 +89,8 @@ hyperparameters. This is also used for nested aggregation in partial
 dependence.
 Default is \code{mean}.}
 
-\item{partial.dep.fun}{[\code{\link{Learner}} | \code{character(1)}]\cr
-The function used to learn partial dependence. Must be specified if
+\item{partial.dep.learn}{[\code{\link{Learner}} | \code{character(1)}]\cr
+The learner used to learn partial dependence. Must be specified if
 \dQuote{partial.dep} is set to \code{TRUE} in
 \code{\link{generateHyperParsEffectData}}. Accepts either a \link{Learner}
 object or the learner as a string for learning partial dependence.

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -7,7 +7,8 @@
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
   pretty.names = TRUE, global.only = TRUE, interpolate = NULL,
-  show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean)
+  show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean,
+  partial.dep.fun = NULL)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -87,6 +88,13 @@ The function used to aggregate nested cross validation runs when plotting 2
 hyperparameters. This is also used for nested aggregation in partial
 dependence.
 Default is \code{mean}.}
+
+\item{partial.dep.fun}{[\code{\link{Learner}} | \code{character(1)}]\cr
+The function used to learn partial dependence. Must be specified if
+\dQuote{partial.dep} is set to \code{TRUE} in
+\code{\link{generateHyperParsEffectData}}. Accepts either a \link{Learner}
+object or the learner as a string for learning partial dependence.
+Default is \code{NULL}.}
 }
 \value{
 ggplot2 plot object.

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -284,7 +284,7 @@ test_that("2+ hyperparams", {
 
   # test single hyperparam creation
   plt = plotHyperParsEffect(data, x = "C", y = "acc.test.mean",
-    plot.type = "line", partial.dep.fun = "regr.randomForest")
+    plot.type = "line", partial.dep.learn = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -296,7 +296,7 @@ test_that("2+ hyperparams", {
 
   # test bivariate
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
-    plot.type = "heatmap", partial.dep.fun = "regr.randomForest")
+    plot.type = "heatmap", partial.dep.learn = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -321,7 +321,7 @@ test_that("2+ hyperparams", {
   res = resample(lrn, task = pid.task, resampling = cv2, extract = getTuneResult)
   data = generateHyperParsEffectData(res, partial.dep = TRUE)
   plt = plotHyperParsEffect(data, x = "C", y = "acc.test.mean",
-    plot.type = "line", partial.dep.fun = "regr.randomForest")
+    plot.type = "line", partial.dep.learn = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -342,7 +342,7 @@ test_that("2+ hyperparams", {
     resampling = rdesc, par.set = ps, show.info = F)
   data = generateHyperParsEffectData(res, partial.dep = TRUE)
   plt = plotHyperParsEffect(data, x = "C", y = "acc.test.mean",
-    plot.type = "line", partial.dep.fun = "regr.randomForest")
+    plot.type = "line", partial.dep.learn = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -284,7 +284,7 @@ test_that("2+ hyperparams", {
 
   # test single hyperparam creation
   plt = plotHyperParsEffect(data, x = "C", y = "acc.test.mean",
-    plot.type = "line")
+    plot.type = "line", partial.dep.fun = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -296,7 +296,7 @@ test_that("2+ hyperparams", {
 
   # test bivariate
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
-    plot.type = "heatmap")
+    plot.type = "heatmap", partial.dep.fun = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -321,7 +321,7 @@ test_that("2+ hyperparams", {
   res = resample(lrn, task = pid.task, resampling = cv2, extract = getTuneResult)
   data = generateHyperParsEffectData(res, partial.dep = TRUE)
   plt = plotHyperParsEffect(data, x = "C", y = "acc.test.mean",
-    plot.type = "line")
+    plot.type = "line", partial.dep.fun = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")
@@ -342,7 +342,7 @@ test_that("2+ hyperparams", {
     resampling = rdesc, par.set = ps, show.info = F)
   data = generateHyperParsEffectData(res, partial.dep = TRUE)
   plt = plotHyperParsEffect(data, x = "C", y = "acc.test.mean",
-    plot.type = "line")
+    plot.type = "line", partial.dep.fun = "regr.randomForest")
   print(plt)
   dir = tempdir()
   path = stri_paste(dir, "/test.svg")


### PR DESCRIPTION
This PR will add support for visualizing hyperparameter tuning when tuning 2 or more hyperparameters simultaneously.


Example usage tuning C, sigma, degree of SVM on `pid.task`:

```
ps = makeParamSet(
  makeNumericParam("C", lower = -5, upper = 5, trafo = function(x) 2^x),
  makeNumericParam("sigma", lower = -5, upper = 5, trafo = function(x) 2^x),
  makeDiscreteParam("degree", values = 2:5))
ctrl = makeTuneControlRandom(maxit = 100L)
rdesc = makeResampleDesc("Holdout", predict = "both")
learn = makeLearner("classif.ksvm", par.vals = list(kernel = "besseldot"))
res = tuneParams(learn, task = pid.task, control = ctrl, 
  measures = list(acc,setAggregation(acc, train.mean)), resampling = rdesc, 
  par.set = ps, show.info = F)
data = generateHyperParsEffectData(res, partial.dep = TRUE)
```

We can isolate just `C`:

```
plotHyperParsEffect(data, x = "C", y = "acc.test.mean", plot.type = "line", 
  partial.dep.learn = "regr.randomForest")
```

![image](https://cloud.githubusercontent.com/assets/4913951/18418857/36268628-781c-11e6-8d4c-9d921b0f2223.png)

We can also look at bivariate relationships, such as `C` and `sigma`:

```
plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean", 
  plot.type = "heat map", partial.dep.learn = "regr.randomForest")
```

![image](https://cloud.githubusercontent.com/assets/4913951/18418867/65a8aed0-781c-11e6-98cb-a8099b242a7e.png)

Note the scales in the plots are off due to #1232 