### PR TITLE
fix xgboost tests

### DIFF
--- a/tests/testthat/test_base_getHyperPars.R
+++ b/tests/testthat/test_base_getHyperPars.R
@@ -21,11 +21,4 @@ test_that("getHyperPars", {
 
   lrn = makeMultilabelBinaryRelevanceWrapper("classif.rpart")  
   expect_true(setequal(getHyperPars(lrn), list(xval = 0)))
-  
-  #Missing values should not be ommited and printed
-  lrn = makeLearner("classif.xgboost")
-  expect_true(setequal(getHyperPars(lrn), list(nrounds = 1, missing = NA)))
-  
-  expect_output(print(lrn), "missing=NA")
-  
 })

--- a/tests/testthat/test_classif_xgboost.R
+++ b/tests/testthat/test_classif_xgboost.R
@@ -6,7 +6,7 @@ test_that("classif_xgboost", {
   set.seed(getOption("mlr.debug.seed"))
   model = xgboost::xgboost(data = data.matrix(binaryclass.train[,1:60]),
     label = as.numeric(binaryclass.train[,61])-1,
-    nrounds = 20, objective = "binary:logistic", missing = NA_real_)
+    nrounds = 20, objective = "binary:logistic", missing = NULL)
   pred = xgboost::predict(model, data.matrix(binaryclass.test[,1:60]))
   pred = factor(as.numeric(pred>0.5), labels = binaryclass.class.levs)
 

--- a/tests/testthat/test_regr_xgboost.R
+++ b/tests/testthat/test_regr_xgboost.R
@@ -6,7 +6,7 @@ test_that("regr_xgboost", {
   set.seed(getOption("mlr.debug.seed"))
   model = xgboost::xgboost(data = data.matrix(regr.train[,1:13]),
     label = as.numeric(regr.train[,14]),
-    nrounds = 20, objective = "reg:linear", missing = NA_real_)
+    nrounds = 20, objective = "reg:linear", missing = NULL)
   pred = xgboost::predict(model, data.matrix(regr.test[,1:13]))
 
   set.seed(getOption("mlr.debug.seed"))


### PR DESCRIPTION
xgboost tests failed after latest change of default for `missing`. Removed the test as it seems unnecessary now.

@berndbischl ?!