### PR TITLE
remove weight.fun in place of expanded fun in generatePartialDependence

### DIFF
--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -57,14 +57,12 @@
 #'   a numeric matrix with the number of columns equal to the number of class levels of the target.
 #'   For classification with \code{predict.type = "response"} (the default) the function must accept
 #'   a character vector and output a numeric vector with length equal to the number of classes in the
-#'   target feature.
+#'   target feature. Two variables, \code{data} and \code{newdata} are made available to \code{fun} internally via a
+#'   wrapper. `data` is the training data from `input` and `newdata` contains a single point from the
+#'   prediction grid for \code{features} along with the training data for features not in \code{features}.
+#'   This allows the computation of weights based on comparisons of the prediction grid to the training data.
 #'   The default is the mean, unless \code{obj} is classification with \code{predict.type = "response"}
 #'   in which case the default is the proportion of observations predicted to be in each class.
-#' @param weight.fun [\code{function}]\cr
-#'   A function which takes a \code{data.frame} \code{x} and a \code{data.frame} \code{data}
-#'   (both of which are coerced to numeric matrices) and returns a non-negative
-#'   numeric weight. The number of columns in \code{x} must match the column dimension of \code{data}.
-#'   By default \code{weight.fun} returns a weight of 1.
 #' @param bounds [\code{numeric(2)}]\cr
 #'   The value (lower, upper) the estimated standard error is multiplied by to estimate the bound on a
 #'   confidence region for a partial dependence. Ignored if \code{predict.type != "se"} for the learner.
@@ -134,11 +132,40 @@
 #' fit = train(lrn, iris.task)
 #' pd = generatePartialDependenceData(fit, iris.task, "Petal.Width")
 #' plotPartialDependence(pd, data = getTaskData(iris.task))
+#'
+#' # simulated example with weights computed via the joint distribution
+#' # in practice empirical weights could be constructed by estimating the joint
+#' # density from the training data (the data arg to fun) and computing the probabilty
+#' # of the prediction grid under this estimated density (the newdata arg) or
+#' # by using something like data depth or outlier classification to weight the
+#' # unusualness of points in arg newdata.
+#' sigma = matrix(c(1, .5, .5, 1), 2, 2)
+#' C = chol(sigma)
+#' X = replicate(2, rnorm(100)) %*% C
+#' alpha = runif(2, -1, 1)
+#' y = X %*% alpha
+#' df = data.frame(y, X)
+#' tsk = makeRegrTask(data = df, target = "y")
+#' fit = train("regr.svm", tsk)
+#'
+#' w.fun = function(x, newdata) {
+#'  # compute multivariate normal density given sigma
+#'  sigma = matrix(c(1, .5, .5, 1), 2, 2)
+#'  dec = chol(sigma)
+#'  tmp = backsolve(dec, t(newdata), transpose = TRUE)
+#'  rss = colSums(tmp^2)
+#'  logretval = -sum(log(diag(dec))) - 0.5 * ncol(newdata) * log(2 * pi) - 0.5 * rss
+#'  w = exp(logretval)
+#'  # weight prediction grid given probability of grid points under the joint
+#'  # density
+#'  sum(w * x) / sum(w)
+#' }
+#'
+#' generatePartialDependenceData(fit, tsk, "X1", fun = w.fun)
 #' @export
 generatePartialDependenceData = function(obj, input, features,
   interaction = FALSE, derivative = FALSE, individual = FALSE, center = NULL,
-  fun = mean, weight.fun = function(x, data) rep(1, nrow(x)),
-  bounds = c(qnorm(.025), qnorm(.975)),
+  fun = mean, bounds = c(qnorm(.025), qnorm(.975)),
   resample = "none", fmin, fmax, gridsize = 10L, ...) {
 
   assertClass(obj, "WrappedModel")
@@ -183,18 +210,6 @@ generatePartialDependenceData = function(obj, input, features,
     center = as.data.frame(do.call("cbind", center))
   }
   assertFunction(fun)
-  test = fun(1:3)
-  if (!is.numeric(test))
-    stop("fun argument must return a numeric vector")
-  if (!(length(test) %in% c(1L, 3L)))
-    stop("function argument must return a numeric vector of length 1 or 3.")
-
-  assertFunction(weight.fun)
-  x = matrix(0, 2, 2)
-  test = as.matrix(replicate(2, rnorm(5)))
-  weights = weight.fun(x, test)
-  if (!is.numeric(weights) && length(weights) == 2L)
-    stop("Invalid weight.fun.")
 
   assertNumeric(bounds, len = 2L)
   assertNumber(bounds[1], upper = 0)
@@ -219,20 +234,6 @@ generatePartialDependenceData = function(obj, input, features,
   if (length(features) > 1L & interaction)
     rng = expand.grid(rng)
 
-  if (!individual) {
-    ## check that aggregation function returns input of valid length and type
-    ## if individual then function is not applied
-    test = fun(1:3)
-    if (!is.numeric(test))
-      stop("fun argument must return a numeric vector")
-    if (td$type == "classif" & obj$learner$predict.type == "response" & length(test) != 3L)
-      stop("If learner predict.type != prob, then the fun argument must return a numeric vector with length equal to the number of target class levels.")
-    if (td$type == "classif" & obj$learner$predict.type == "prob" & length(test) != 1L)
-      stop("function argument must return a numeric vector of length 1.")
-    if (td$type == "regr" & !(length(test) %in% c(1L, 3L)))
-      stop("function argument must return a numeric vector of length 1 or 3.")
-  }
-
   if (td$type == "regr")
     target = td$target
   else if (td$type == "classif") {
@@ -244,7 +245,7 @@ generatePartialDependenceData = function(obj, input, features,
     target = "Risk"
 
   args = list(obj = obj, data = data, fun = fun, td = td, individual = individual,
-    bounds = bounds, weight.fun = weight.fun, ...)
+    bounds = bounds, ...)
 
   if (length(features) > 1L & !interaction) {
     out = lapply(features, function(x) {
@@ -262,7 +263,7 @@ generatePartialDependenceData = function(obj, input, features,
         out = parallelMap(doPartialDependenceIteration, i = seq_len(nrow(rng)), more.args = args)
         if (!is.null(center) & individual)
           centerpred = doPartialDependenceIteration(obj, data, center[, x, drop = FALSE],
-            x, fun, td, 1, bounds = bounds, weight.fun = function(x, data) rep(1, nrow(x)))
+            x, fun, td, 1, bounds = bounds, ...)
         else
           centerpred = NULL
       }
@@ -286,7 +287,7 @@ generatePartialDependenceData = function(obj, input, features,
       args$rng = rng
       out = parallelMap(doPartialDependenceIteration, i = seq_len(nrow(rng)), more.args = args)
       if (!is.null(center) & individual)
-        centerpred = as.data.frame(doPartialDependenceIteration(obj, data, center, features, fun, td, 1, bounds, weight.fun = function(x, data) rep(1, nrow(x))))
+        centerpred = as.data.frame(doPartialDependenceIteration(obj, data, center, features, fun, td, 1, bounds))
       else
         centerpred = NULL
     }
@@ -334,12 +335,11 @@ generatePartialDependenceData = function(obj, input, features,
 #'   A function that accepts a numeric vector and returns either a single number
 #'   such as a measure of location such as the mean, or three numbers, which give a lower bound,
 #'   a measure of location, and an upper bound. Note if three numbers are returned they must be
-#'   in this order. The default is the mean.
-#' @param weight.fun [\code{function}]\cr
-#'   A function which takes a \code{data.frame} \code{x} and a \code{data.frame} \code{data}
-#'   (both of which are coerced to numeric matrices) and returns a non-negative
-#'   numeric weight. The number of columns in \code{x} must match the column dimension of \code{data}.
-#'   By default \code{weight.fun} returns a weight of 1.
+#'   in this order. Two variables, \code{data} and \code{newdata} are made available to \code{fun} internally via a
+#'   wrapper. `data` is the training data from `input` and `newdata` contains a single point from the
+#'   prediction grid for \code{features} along with the training data for features not in \code{features}.
+#'   This allows the computation of weights based on comparisons of the prediction grid to the training data.
+#'   The default is the mean.
 #' @param bounds [\code{numeric(2)}]\cr
 #'   The value (lower, upper) the estimated standard error is multiplied by to estimate the bound on a
 #'   confidence region for a partial dependence. Ignored if \code{predict.type != "se"} for the learner.
@@ -391,7 +391,6 @@ generatePartialDependenceData = function(obj, input, features,
 #' plotPartialDependence(fa)
 #' @export
 generateFunctionalANOVAData = function(obj, input, features, depth = 1L, fun = mean,
-  weight.fun = function(x, data) rep(1, nrow(x)),
   bounds = c(qnorm(.025), qnorm(.975)),
   resample = "none", fmin, fmax, gridsize = 10L, ...) {
 
@@ -429,20 +428,7 @@ generateFunctionalANOVAData = function(obj, input, features, depth = 1L, fun = m
   assertCount(gridsize, positive = TRUE)
   assertIntegerish(depth, lower = 1L, upper = length(features), len = 1L)
 
-  assertFunction(weight.fun)
-  x = matrix(0, 2, 2)
-  test = as.matrix(replicate(2, rnorm(5)))
-  weights = weight.fun(x, test)
-  if (!is.numeric(weights) && length(weights) == 2L)
-    stop("Invalid weight.fun.")
-
   assertFunction(fun)
-  test = fun(1:3)
-  if (!is.numeric(test))
-    stop("fun argument must return a numeric vector")
-  if (!(length(test) %in% c(1L, 3L)))
-    stop("function argument must return a numeric vector of length 1 or 3.")
-
   assertNumeric(bounds, len = 2L)
   assertNumber(bounds[1], upper = 0)
   assertNumber(bounds[2], lower = 0)
@@ -461,15 +447,17 @@ generateFunctionalANOVAData = function(obj, input, features, depth = 1L, fun = m
   target = td$target
 
   ## generate each effect
-  pd = lapply(U, function(u, args) {
+  args = list(obj = obj, data = data, fun = fun, td = td, bounds = bounds, ...)
+  pd = lapply(U, function(u) {
     args$features = u
     args$rng = fixed_grid[[stri_paste(u, collapse = ":")]]
     out = parallelMap(doPartialDependenceIteration, i = seq_len(nrow(args$rng)), more.args = args)
     doAggregatePartialDependence(out, td, target, u, args$rng)
-  }, args = list(obj = obj, data = data, fun = fun, td = td, bounds = bounds, weight.fun = weight.fun, ...))
+  })
   names(pd) = effects
 
-  if (length(test) == 3L | obj$learner$predict.type == "se")
+  if (all(c("upper", "lower") %in% colnames(pd[[1]])) |
+        obj$learner$predict.type == "se")
     target = c("upper", "lower", target)
 
   ## remove lower order effects
@@ -510,23 +498,31 @@ print.FunctionalANOVAData = function(x, ...) {
   printHead(x$data)
 }
 
-doPartialDerivativeIteration = function(x, obj, data, features, fun, td, individual, weight.fun, ...) {
+doPartialDerivativeIteration = function(x, obj, data, features, fun, td, individual, ...) {
   if (!individual) {
+    fun.wrapper = function(x, newdata, data, ...) {
+      args = formals(fun)
+      if (all(c("newdata", "data") %in% names(args))) {
+        fun(x, newdata = newdata, data = data, ...)
+      } else if ("newdata" %in% names(args)) {
+        fun(x, newdata = newdata, ...)
+      } else if ("data" %in% names(args)) {
+        fun(x, data = data, ...)
+      } else {
+        fun(x, ...)
+      }
+    }
     # construct function appropriate for numDeriv w/ aggregate predictions
     f = function(x, obj, data, features, fun, td, ...) {
       newdata = data
       newdata[features] = x
-      weights = do.call("weight.fun", list("x" = newdata[, obj$features, drop = FALSE],
-        "data" = data[, obj$features, drop = FALSE], ...))
-      assertNumeric(weights, lower = 0, finite = TRUE, all.missing = FALSE, len = nrow(newdata))
-      if (sum(weights) == 0) weights = rep(NA, length(weights))
       pred = do.call("predict", c(list("object" = obj, "newdata" = newdata), list(...)))
       if (obj$learner$predict.type == "response")
-        fun((getPredictionResponse(pred) * weights) / sum(weights))
+        fun.wrapper(getPredictionResponse(pred), ...)
       else if (length(obj$task.desc$class.levels) == 2L)
-        fun((getPredictionProbabilities(pred) * weights) / sum(weights))
+        fun.wrapper(getPredictionProbabilities(pred), ...)
       else
-        apply((getPredictionProbabilities(pred) * weights) / sum(weights), 2, fun)
+        apply(getPredictionProbabilities(pred), 2, fun.wrapper, ...)
     }
     if (obj$learner$predict.type == "response")
       numDeriv::grad(func = f, x = x, obj = obj, data = data, features = features, fun = fun, td = td)
@@ -536,15 +532,11 @@ doPartialDerivativeIteration = function(x, obj, data, features, fun, td, individ
     f = function(x, obj, data, features, fun, td, ...) {
       newdata = data
       newdata[features] = x
-      weights = do.call("weight.fun", list("x" = newdata[, obj$features, drop = FALSE],
-        "data" = data[, obj$features, drop = FALSE], ...))
-      assertNumeric(weights, lower = 0, finite = TRUE, all.missing = FALSE, len = nrow(newdata))
-      if (sum(weights) == 0) weights = rep(NA, length(weights))
       pred = do.call("predict", c(list("object" = obj, "newdata" = newdata), list(...)))
       if (obj$learner$predict.type == "response")
-        (getPredictionResponse(pred) * weights) / sum(weights)
+        getPredictionResponse(pred)
       else
-        (as.numeric(getPredictionProbabilities(pred)) * weights) / sum(weights)
+        getPredictionProbabilities(pred)
     }
     if (obj$learner$predict.type == "response")
       sapply(1:nrow(data), function(idx)
@@ -556,34 +548,33 @@ doPartialDerivativeIteration = function(x, obj, data, features, fun, td, individ
   }
 }
 
-doPartialDependenceIteration = function(obj, data, rng, features, fun, td, i, bounds,
-  weight.fun, individual = FALSE, ...) {
-
+doPartialDependenceIteration = function(obj, data, rng, features, fun, td, i, bounds, individual = FALSE, ...) {
   newdata = data
   newdata[features] = rng[i, ]
-  weights = do.call("weight.fun", list("x" = newdata[, obj$features, drop = FALSE],
-    "data" = data[, obj$features, drop = FALSE], ...))
-  assertNumeric(weights, lower = 0, finite = TRUE, all.missing = FALSE, len = nrow(newdata))
-  if (sum(weights) == 0) weights = rep(NA, length(weights))
+  fun.wrapper = function(x, newdata, data, ...) {
+    args = formals(fun)
+    if (all(c("newdata", "data") %in% names(args))) {
+      fun(x, newdata = newdata, data = data, ...)
+    } else if ("newdata" %in% names(args)) {
+      fun(x, newdata = newdata, ...)
+    } else if ("data" %in% names(args)) {
+      fun(x, data = data, ...)
+    } else {
+      fun(x, ...)
+    }
+  }
   pred = do.call("predict", c(list("object" = obj, "newdata" = newdata), list(...)))
   if (obj$learner$predict.type == "response") {
-    if (td$type == "classif") {
-      if (identical(functionBody(weight.fun), functionBody(function(x, data) rep(1, nrow(x)))))
-        fun(getPredictionResponse(pred))
-      else
-        stop('Classification with predict.type = "response" is incompatible with weights.')
-    } else {
-      fun((getPredictionResponse(pred) * weights) / sum(weights))
-    }
+    fun.wrapper(getPredictionResponse(pred), newdata, data, ...)
   } else if (length(obj$task.desc$class.levels) == 2L) {
-    fun((getPredictionProbabilities(pred) * weights) / sum(weights))
+    fun.wrapper(getPredictionProbabilities(pred), newdata, data, ...)
   } else if (obj$learner$predict.type == "se") {
     point = getPredictionResponse(pred)
     out = cbind(point + outer(getPredictionSE(pred), bounds), point)[, c(1, 3, 2)]
-    out = (out * weights) / sum(weights)
-    unname(apply(out, 2, fun))
+    unname(apply(out, 2, fun.wrapper, newdata = newdata, data = data, ...))
   } else {
-    apply((getPredictionProbabilities(pred) * weights) / sum(weights), 2, fun)
+    apply(getPredictionProbabilities(pred), 2, fun.wrapper, newdata = newdata,
+      data = data, ...)
   }
 }
 

--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -135,7 +135,7 @@
 #'
 #' # simulated example with weights computed via the joint distribution
 #' # in practice empirical weights could be constructed by estimating the joint
-#' # density from the training data (the data arg to fun) and computing the probabilty
+#' # density from the training data (the data arg to fun) and computing the probability
 #' # of the prediction grid under this estimated density (the newdata arg) or
 #' # by using something like data depth or outlier classification to weight the
 #' # unusualness of points in arg newdata.

--- a/tests/testthat/test_base_generateFeatureImportanceData.R
+++ b/tests/testthat/test_base_generateFeatureImportanceData.R
@@ -13,5 +13,4 @@ test_that("generateFeatureImportanceData", {
   
   # Test printer
   expect_output(print(classif.imp), regexp = "FeatureImportance:")
-  
 })

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -5,7 +5,6 @@ test_that("generateFunctionalANOVAData", {
 
   fr = train("regr.rpart", regr.task)
   dr1 = generateFunctionalANOVAData(fr, regr.task, c("lstat", "age"), 1L, mean, gridsize = gridsize)
-  
   plotPartialDependence(dr1)
   dir = tempdir()
   path = paste0(dir, "/test.svg")
@@ -60,6 +59,8 @@ test_that("generatePartialDependenceData", {
   expect_that(max(dr$data$lstat), equals(40.))
   expect_that(min(dr$data$lstat), equals(1.))
   expect_that(nrow(dr$data), equals(gridsize * nfeat))
+  expect_true(all(dr$data$medv >= min(regr.df$medv) | dr$data$medv <= max(regr.df$medv)))
+
   plotPartialDependence(dr, facet = "chas")
   dir = tempdir()
   path = paste0(dir, "/test.svg")
@@ -230,8 +231,17 @@ test_that("generatePartialDependenceData", {
   x[idx] = NA
   test.task = makeRegrTask(data = data.frame(x = x[-idx], y = y[-idx]), target = "y")
   fit = train("regr.rpart", test.task)
-  pd = generatePartialDependenceData(fit, test.task,
-    weight.fun = function(x, data) apply(x, 1, function(z) ifelse(z > .5, 0, 1)),
+
+  fun = function(x, newdata) {
+    w = ifelse(newdata$x > .5, 0, 1)
+    if (sum(w) == 0) {
+      NA
+    } else {
+      weighted.mean(x, w)
+    }
+  }
+  
+  pd = generatePartialDependenceData(fit, test.task, fun = fun,
     fmin = list("x" = 0), fmax = list("x" = 1), gridsize = gridsize)
   expect_that(all(is.na(pd$data[pd$data$x > .5, "y"])), is_true())
 


### PR DESCRIPTION
 - internal wrapper for fun arg to allow passing of internal
   newdata (prediction grid) and data (training data from input arg)
   which allows computation of weights in fun instead of via an extra
   step using another arg, weight.fun (now removed)

two issues related to this. first is how to document it. i added to the docs here but we don't have a dependency free way to show an example of it (a situation where the aggregation function would use the prediction grid and/or the training data). 

the second issue is writing a test that would have caught the bug. how to do this doesn't seem obvious. you could check to see if the predictions are within the range of the training data target but it would be easy to make this break without having any bugs in the code.