### PR TITLE
fix 958 classif.glmnet in multilabelBinaryRelevanceWrapper

### DIFF
--- a/R/MultilabelBinaryRelevanceWrapper.R
+++ b/R/MultilabelBinaryRelevanceWrapper.R
@@ -50,11 +50,11 @@ trainLearner.MultilabelBinaryRelevanceWrapper = function(.learner, .task, .subse
 }
 
 #' @export
-predictLearner.MultilabelBinaryRelevanceWrapper = function(.learner, .model, .newdata, ...) {
+predictLearner.MultilabelBinaryRelevanceWrapper = function(.learner, .model, .newdata, .subset = NULL, ...) {
   models = getLearnerModel(.model, more.unwrap = FALSE)
   f = if (.learner$predict.type == "response")
-    function(m) as.logical(getPredictionResponse(predict(m, newdata = .newdata, ...)))
+    function(m) as.logical(getPredictionResponse(predict(m, newdata = .newdata, subset = NULL,...)))
   else
-    function(m) getPredictionProbabilities(predict(m, newdata = .newdata, ...), cl = "TRUE")
+    function(m) getPredictionProbabilities(predict(m, newdata = .newdata, subset = NULL,...), cl = "TRUE")
   asMatrixCols(lapply(models, f))
 }

--- a/R/MultilabelBinaryRelevanceWrapper.R
+++ b/R/MultilabelBinaryRelevanceWrapper.R
@@ -53,8 +53,8 @@ trainLearner.MultilabelBinaryRelevanceWrapper = function(.learner, .task, .subse
 predictLearner.MultilabelBinaryRelevanceWrapper = function(.learner, .model, .newdata, .subset = NULL, ...) {
   models = getLearnerModel(.model, more.unwrap = FALSE)
   f = if (.learner$predict.type == "response")
-    function(m) as.logical(getPredictionResponse(predict(m, newdata = .newdata, subset = NULL,...)))
+    function(m) as.logical(getPredictionResponse(predict(m, newdata = .newdata, subset = .subset,...)))
   else
-    function(m) getPredictionProbabilities(predict(m, newdata = .newdata, subset = NULL,...), cl = "TRUE")
+    function(m) getPredictionProbabilities(predict(m, newdata = .newdata, subset = .subset,...), cl = "TRUE")
   asMatrixCols(lapply(models, f))
 }

--- a/R/predict.R
+++ b/R/predict.R
@@ -38,7 +38,7 @@
 #' p = predict(model, task = iris.task, subset = test.set)
 #' print(p)
 #' getPredictionProbabilities(p)
-predict.WrappedModel = function(object, task, newdata, subset, ...) {
+predict.WrappedModel = function(object, task, newdata, subset = NULL, ...) {
   if (!xor(missing(task), missing(newdata)))
     stop("Pass either a task object or a newdata data.frame to predict, but not both!")
   assertClass(object, classes = "WrappedModel")
@@ -58,7 +58,7 @@ predict.WrappedModel = function(object, task, newdata, subset, ...) {
     }
     size = nrow(newdata)
   }
-  if (missing(subset)) {
+  if (is.null(subset)) {
     subset = seq_len(size)
   } else {
     if (is.logical(subset))

--- a/tests/testthat/test_base_multilabel.R
+++ b/tests/testthat/test_base_multilabel.R
@@ -52,6 +52,15 @@ test_that("multilabel learning", {
   expect_true(!is.na(p))
 })
 
+test_that("MultilabelBinaryRelevanceWrapper with glmnet", {
+  # multilabelBinaryRelevanceWrapper was not working properly for classif.glmnet, we had a bug here
+  lrn = makeLearner("classif.glmnet", predict.type = "response")
+  lrn2 = makeMultilabelBinaryRelevanceWrapper(lrn)
+  mod = train(lrn2, multilabel.task)
+  pred = predict(mod, multilabel.task)
+  expect_error(pred, NA)
+})
+
 testMultilabelWrapper = function(fun, ...) {
   desc = fun("classif.rpart")$model.subclass[1]
   test_that(desc, {
@@ -91,7 +100,7 @@ testMultilabelWrapper = function(fun, ...) {
     expect_true(is.data.frame(p))
     p = getPredictionProbabilities(r$pred, getTaskClassLevels(multilabel.task))
     expect_true(is.data.frame(p))
-    
+
     lrn1 = makeLearner("classif.rpart")
     lrn2 = fun(lrn1, ...)
     lrn2 = setPredictType(lrn2, "prob")


### PR DESCRIPTION
fixed bug from issue #958.
set subset to NULL in predict function in order to prevent the parameter s of glmnet from getting partial matching problems.
