### PR TITLE
mini fix for Friedman tests (#1262)

### DIFF
--- a/R/friedmanPostHocTestBMR.R
+++ b/R/friedmanPostHocTestBMR.R
@@ -1,14 +1,15 @@
-
 #' @title Perform a posthoc Friedman-Nemenyi test.
 #'
 #' @description
 #' Performs a \code{\link[PMCMR]{posthoc.friedman.nemenyi.test}} for a
 #' \code{\link{BenchmarkResult}} and a selected measure.
-#' This means \code{all pairwise comparisons} of \code{learners} are performed.
+#' This means \emph{all pairwise comparisons} of \code{learners} are performed.
 #' The null hypothesis of the post hoc test is that each pair of learners is equal.
 #' If the null hypothesis of the included ad hoc \code{\link[stats]{friedman.test}}
-#' can be rejected a \code{pairwise.htest} is returned. If not, the function returns the
-#' corresponding \link[stats]{friedman.test}
+#' can be rejected an object of class \code{pairwise.htest} is returned. If not, the function returns the
+#' corresponding \link[stats]{friedman.test}.
+#' Note that benchmark results for at least two learners on at least two tasks
+#' are required.
 #'
 #' @template arg_bmr
 #' @template arg_measure
@@ -34,8 +35,10 @@ friedmanPostHocTestBMR = function(bmr, measure = NULL, p.value = 0.05, aggregati
   measure = checkBMRMeasure(measure, bmr)
   n.learners = length(bmr$learners)
   if (n.learners < 2)
-    message("Only one Learner to compare")
+    stop("Benchmark results for at least two learners are required")
   n.tasks = length(bmr$results)
+  if (n.tasks < 2)
+    stop("Benchmark results for at least two tasks are required")
   
   # aggregate over iterations
   if (aggregation == "mean") {

--- a/R/friedmanTestBMR.R
+++ b/R/friedmanTestBMR.R
@@ -2,8 +2,10 @@
 #'
 #' @description Performs a \code{\link[stats]{friedman.test}} for a selected measure.
 #' The null hypothesis is that apart from an effect of the different
-#' [\code{\link{Task}}], the location parameter (aggregated performance-measure)
+#' [\code{\link{Task}}], the location parameter (aggregated performance measure)
 #' is the same for each \code{\link{Learner}}.
+#' Note that benchmark results for at least two learners on at least two tasks
+#' are required.
 #'
 #' @template arg_bmr
 #' @template arg_measure
@@ -18,13 +20,19 @@ friedmanTestBMR = function(bmr, measure = NULL, aggregation = "default") {
   assertClass(bmr, "BenchmarkResult")
   measure = checkBMRMeasure(measure, bmr)
   assertChoice(aggregation, c("default", "mean"))
-  
+  n.learners = length(bmr$learners)
+  if (n.learners < 2)
+    stop("Benchmark results for at least two learners are required")
+  n.tasks = length(bmr$results)
+  if (n.tasks < 2)
+    stop("Benchmark results for at least two tasks are required")
+
   # aggregate mean or default over iterations
   if (aggregation == "mean") {
     df = as.data.frame(bmr)
     df = aggregate(df[[measure$id]],
-                   by = list(task.id = df$task.id, learner.id = df$learner.id),
-                   FUN = mean)
+      by = list(task.id = df$task.id, learner.id = df$learner.id),
+      FUN = mean)
     aggr.meas = "x"
   } else {
     aggr.meas = measureAggrName(measure)

--- a/tests/testthat/test_base_friedmanTestBMR.R
+++ b/tests/testthat/test_base_friedmanTestBMR.R
@@ -1,4 +1,4 @@
-context("test_friedmantTestBMR")
+context("test_friedmanTestBMR")
 
 test_that("test_friedmanTestBMR", {
   lrns = list(makeLearner("classif.nnet"), makeLearner("classif.rpart"))
@@ -19,7 +19,6 @@ test_that("test_friedmanTestBMR", {
   expect_is(r3, "htest")
   expect_false(r3$f.rejnull)
 
-
   # Case: Reject null
   # Make sure nnet is always worse then rpart. (add error)
   res$results$binary$classif.nnet$measures.test$acc = 1
@@ -31,4 +30,21 @@ test_that("test_friedmanTestBMR", {
   }
   expect_is(r4$crit.difference[[1]], "numeric")
   expect_gt(r4$crit.difference[[1]], 0L)
+})
+
+
+test_that("Friedman test on one learner / one task", {
+  lrns = list(makeLearner("classif.nnet"), makeLearner("classif.rpart"))
+  tasks = list(multiclass.task, binaryclass.task)
+  rdesc = makeResampleDesc("Holdout")
+
+  res = benchmark(lrns, tasks[[1]], rdesc)
+  expect_error(friedmanTestBMR(res), "at least two tasks")
+  expect_error(friedmanPostHocTestBMR(res), "at least two tasks")
+  expect_error(generateCritDifferencesData(res), "at least two tasks")
+
+  res = benchmark(lrns[[1]], tasks, rdesc)
+  expect_error(friedmanTestBMR(res), "at least two learners")
+  expect_error(friedmanPostHocTestBMR(res), "at least two learners")
+  expect_error(generateCritDifferencesData(res), "at least two learners")
 })


### PR DESCRIPTION
Added checks for the number of learners and tasks in a BenchmarkResult before doing the Friedman test + unit test. See #1262.

friedmanTestBMR and related functions require some more cleanup (see also #705). I will issue a separate PR for that.