### PR TITLE
Fixes plotHyperParsEffects for #1281

### DIFF
--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -186,8 +186,8 @@ print.HyperParsEffectData = function(x, ...) {
 #'  complete path. Only meaningful when attempting to plot a heatmap or contour.
 #'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
 #'  cases of irregular hyperparameter paths, you will most likely need to use
-#'  this to have a meaningful visualization. Accepts either a \link{Learner}
-#'  object or the learner as a string for interpolation. Not used with partial
+#'  this to have a meaningful visualization. Accepts either a regression \link{Learner}
+#'  object or the learner as a string for interpolation. This should not be used with partial
 #'  dependence.
 #'  Default is \code{NULL}.
 #' @param show.experiments [\code{logical(1)}]\cr
@@ -209,7 +209,7 @@ print.HyperParsEffectData = function(x, ...) {
 #'  dependence.
 #'  Default is \code{mean}.
 #' @param partial.dep.learn [\code{\link{Learner}} | \code{character(1)}]\cr
-#'  The learner used to learn partial dependence. Must be specified if
+#'  The regression learner used to learn partial dependence. Must be specified if
 #'  \dQuote{partial.dep} is set to \code{TRUE} in
 #'  \code{\link{generateHyperParsEffectData}}. Accepts either a \link{Learner}
 #'  object or the learner as a string for learning partial dependence.
@@ -260,7 +260,8 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       checkString(partial.dep.learn) == TRUE) {
     lrn = checkLearnerRegr(partial.dep.learn)
   }
-
+  if (!is.null(partial.dep.learn) && !is.null(interpolate))
+    stopf("partial.dep.learn and interpolate can't be simultaneously requested!")
   if (length(x) > 1 || length(y) > 1 || length(z) > 1 || length(facet) > 1)
     stopf("Greater than 1 length x, y, z or facet not yet supported")
 
@@ -316,7 +317,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
     }
     partial.task = makeRegrTask(id = "par_dep",
       data = d[, c(hypers, measures[1])], target = measures[1])
-    partial.fit = train("regr.randomForest", partial.task)
+    partial.fit = train(lrn, partial.task)
     if ((length(x) == 1) && (length(y) == 1) && !(z.flag)) {
       # we only care about each feature by itself for this case
       d = generatePartialDependenceData(partial.fit, partial.task, x)$data

--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -187,7 +187,7 @@ print.HyperParsEffectData = function(x, ...) {
 #'  This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
 #'  cases of irregular hyperparameter paths, you will most likely need to use
 #'  this to have a meaningful visualization. Accepts either a regression \link{Learner}
-#'  object or the learner as a string for interpolation. This should not be used with partial
+#'  object or the learner as a string for interpolation. This cannot be used with partial
 #'  dependence.
 #'  Default is \code{NULL}.
 #' @param show.experiments [\code{logical(1)}]\cr

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -63,8 +63,8 @@ If not \code{NULL}, will interpolate non-complete grids in order to visualize a 
 complete path. Only meaningful when attempting to plot a heatmap or contour.
 This will fill in \dQuote{empty} cells in the heatmap or contour plot. Note that
 cases of irregular hyperparameter paths, you will most likely need to use
-this to have a meaningful visualization. Accepts either a \link{Learner}
-object or the learner as a string for interpolation. Not used with partial
+this to have a meaningful visualization. Accepts either a regression \link{Learner}
+object or the learner as a string for interpolation. This should not be used with partial
 dependence.
 Default is \code{NULL}.}
 
@@ -90,7 +90,7 @@ dependence.
 Default is \code{mean}.}
 
 \item{partial.dep.learn}{[\code{\link{Learner}} | \code{character(1)}]\cr
-The learner used to learn partial dependence. Must be specified if
+The regression learner used to learn partial dependence. Must be specified if
 \dQuote{partial.dep} is set to \code{TRUE} in
 \code{\link{generateHyperParsEffectData}}. Accepts either a \link{Learner}
 object or the learner as a string for learning partial dependence.


### PR DESCRIPTION
See #1281

- [x] Correctly accepts any regression learner for partial dependence
- [x] Arg check when user incorrectly calls `interpolate` and `partial.dep.learn` simultaneously
- [x] Stronger language in docs for using regression