### PR TITLE
Fix partial dep range grid for integer features (#1287)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -45,13 +45,14 @@ generateFeatureGrid = function(features, data, resample, gridsize, fmin, fmax) {
         factor(rep(levels(data[[feature]]), length.out = cutoff),
                levels = levels(data[[feature]]), ordered = is.ordered(data[[feature]]))
       } else {
+        if (nunique <= 5L) {
+          warningf("Number of unique observations for %s is %i. Are you sure you have enough data?",
+            feature, nunique)
+        }
         if (resample != "none") {
           sort(sample(data[[feature]], cutoff, resample == "bootstrap"))
         } else {
-          if (is.integer(data[[feature]]))
-            sort(rep(fmin[[feature]]:fmax[[feature]], length.out = cutoff))
-          else
-            seq(fmin[[feature]], fmax[[feature]], length.out = cutoff)
+          seq(fmin[[feature]], fmax[[feature]], length.out = cutoff)
         }
       }
     }, simplify = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,7 +52,10 @@ generateFeatureGrid = function(features, data, resample, gridsize, fmin, fmax) {
         if (resample != "none") {
           sort(sample(data[[feature]], cutoff, resample == "bootstrap"))
         } else {
-          seq(fmin[[feature]], fmax[[feature]], length.out = cutoff)
+          if (is.integer(data[[feature]]))
+            seq.int(fmin[[feature]], fmax[[feature]], length.out = cutoff)
+          else
+            seq(fmin[[feature]], fmax[[feature]], length.out = cutoff)
         }
       }
     }, simplify = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,7 +53,7 @@ generateFeatureGrid = function(features, data, resample, gridsize, fmin, fmax) {
           sort(sample(data[[feature]], cutoff, resample == "bootstrap"))
         } else {
           if (is.integer(data[[feature]]))
-            seq.int(fmin[[feature]], fmax[[feature]], length.out = cutoff)
+            as.integer(seq.int(fmin[[feature]], fmax[[feature]], length.out = cutoff))
           else
             seq(fmin[[feature]], fmax[[feature]], length.out = cutoff)
         }


### PR DESCRIPTION
See #1287 

- [x] Integer features now correctly create a sequential scale from min to max in partial dependence
- [x] Warning if numerical feature has small num unique obs (I don't love this so lmk)