### PR TITLE
store task.desc instead only task.id in ResampleResult

### DIFF
--- a/R/ResampleResult_operators.R
+++ b/R/ResampleResult_operators.R
@@ -14,3 +14,17 @@ getRRPredictions = function(res) {
   else
     res$pred
 }
+
+#' @title Get task description from resample results.
+#'
+#' @description
+#' Get a summarizing task description.
+#'
+#' @param res [\code{ResampleResult}]\cr
+#'   The result of \code{\link{resample}}.
+#' @return [\code{TaskDesc}].
+#' @export
+#' @family resample
+getRRTaskDescription = function(res) {
+  res$task.desc
+}

--- a/R/resample.R
+++ b/R/resample.R
@@ -201,7 +201,7 @@ mergeResampleResult = function(learner, task, iter.results, measures, rin, model
 
   list(
     learner.id = learner$id,
-    task.id = getTaskId(task),
+    task.desc = getTaskDescription(task),
     measures.train = ms.train,
     measures.test = ms.test,
     aggr = aggr,

--- a/R/resample.R
+++ b/R/resample.R
@@ -201,6 +201,7 @@ mergeResampleResult = function(learner, task, iter.results, measures, rin, model
 
   list(
     learner.id = learner$id,
+    task.id = getTaskId(task),
     task.desc = getTaskDescription(task),
     measures.train = ms.train,
     measures.test = ms.test,

--- a/tests/testthat/test_base_resample_operators.R
+++ b/tests/testthat/test_base_resample_operators.R
@@ -1,0 +1,13 @@
+context("resample getter work")
+
+test_that("resample getter work", {
+  r1 = resample(makeLearner("classif.rpart"), binaryclass.task, cv2)
+  r2 = resample(makeLearner("classif.rpart"), binaryclass.task, cv2, keep.pred = FALSE)
+
+  # getRRPredictions
+  expect_equal(getRRPredictions(r1), r1$pred)
+  expect_error(getRRPredictions(r2), "keep.pred = FALSE")
+
+  # getRRTaskDescription
+  expect_equal(getRRTaskDescription(r1), getTaskDescription(binaryclass.task))
+})


### PR DESCRIPTION
This should be fast to review @larskotthoff . I outsourced this from PR #914 as this seems to be needed for several other issues.