### PR TITLE
reate a list of `Prediction` objects for each single resample iteration

### DIFF
--- a/R/ResampleResult_operators.R
+++ b/R/ResampleResult_operators.R
@@ -28,3 +28,62 @@ getRRPredictions = function(res) {
 getRRTaskDescription = function(res) {
   res$task.desc
 }
+
+#' @title Get list of predictions for train and test set of each single resample iteration.
+#'
+#' @description
+#' This function creates a list with two slots \code{train} and \code{test} where
+#' each slot is again a list of \code{\link{Prediction}} objects for each single
+#' resample iteration.
+#' In case that \code{predict = "train"} was used for the resample description
+#' (see \code{\link{makeResampleDesc}}), the slot \code{test} will be \code{NULL}
+#' and in case that \code{predict = "test"} was used, the slot \code{train} will be
+#' \code{NULL}.
+#'
+#' @param res [\code{ResampleResult}]\cr
+#'   The result of \code{\link{resample}} run with \code{keep.pred = TRUE}.
+#' @param ... [any]\cr
+#'   Further options passed to \code{\link{makePrediction}}.
+#' @return [list].
+#' @export
+#' @family resample
+getRRPredictionList = function(res, ...) {
+  assertClass(res, "ResampleResult")
+  # We need to force keep.pred = TRUE (will be checked in getRRPredictions)
+  pred = getRRPredictions(res)
+  predict.type = pred$predict.type
+  time = pred$time
+  task.desc = getRRTaskDescription(res)
+
+  # split by train and test set
+  set = levels(pred$data$set)
+
+  # get prediction objects for train and test set
+  prediction = lapply(set, function(s) {
+    # split by resample iterations
+    p.split = subset(pred$data, set == s)
+    p.split = split(p.split, as.factor(p.split$iter))
+    # create prediction object for each resample iteration
+    p.split = lapply(p.split, function (p) {
+      # get predictions based on predict.type
+      if (predict.type == "prob") {
+        y = p[,grepl("^prob[.]", colnames(p))]
+        # we need to remove the "prob." part in the colnames, otherwise
+        # makePrediction thinks that the factor starts with "prob."
+        colnames(y) =  gsub("^prob[.]", "", colnames(y))
+      } else {
+        y = p$response
+      }
+      makePrediction(task.desc, id = p$id,
+        truth = p$truth, y = y, row.names = p$id,
+        predict.type = predict.type, time = NA, ...)
+    })
+    # add time info afterwards
+    for(i in 1:length(p.split)) p.split[[i]]$time = time[i]
+    return(p.split)
+  })
+  ret = setNames(prediction, set)
+  if (is.null(ret$train)) ret = append(ret, list(train = NULL))
+  if (is.null(ret$test)) ret = append(ret, list(test = NULL))
+  return(ret[c("train", "test")])
+}

--- a/tests/testthat/test_base_resample_operators.R
+++ b/tests/testthat/test_base_resample_operators.R
@@ -1,8 +1,9 @@
 context("resample getter work")
 
 test_that("resample getter work", {
-  r1 = resample(makeLearner("classif.rpart"), binaryclass.task, cv2)
-  r2 = resample(makeLearner("classif.rpart"), binaryclass.task, cv2, keep.pred = FALSE)
+  lrn = makeLearner("classif.rpart")
+  r1 = resample(lrn, binaryclass.task, cv2)
+  r2 = resample(lrn, binaryclass.task, cv2, keep.pred = FALSE)
 
   # getRRPredictions
   expect_equal(getRRPredictions(r1), r1$pred)
@@ -10,4 +11,24 @@ test_that("resample getter work", {
 
   # getRRTaskDescription
   expect_equal(getRRTaskDescription(r1), getTaskDescription(binaryclass.task))
+
+  # getRRPredictionList
+  r1 = resample(lrn, binaryclass.task, makeResampleDesc("CV", iters = 2, predict = "test"))
+  r2 = resample(lrn, binaryclass.task, makeResampleDesc("CV", iters = 2, predict = "both"))
+  # FIXME: add check for "train" after https://github.com/mlr-org/mlr/issues/1284 has been fixed
+  #r3 = resample(lrn, binaryclass.task, makeResampleDesc("CV", iters = 2, predict = "train"), setAggregation(mmce, train.mean))
+
+  # check if structure is correct
+  expect_named(getRRPredictionList(r1), c("train", "test"))
+  expect_null(getRRPredictionList(r1)$train)
+  expect_equal(length(getRRPredictionList(r1)$test), 2)
+
+  expect_named(getRRPredictionList(r2), c("train", "test"))
+  expect_equal(length(getRRPredictionList(r2)$test), 2)
+  expect_equal(length(getRRPredictionList(r2)$train), 2)
+
+  # check if performance value is correct
+  expect_equal(r1$measures.test$mmce, unname(vnapply(getRRPredictionList(r1)$test, performance, mmce)))
+  expect_equal(r2$measures.train$mmce, unname(vnapply(getRRPredictionList(r2)$train, performance, mmce)))
+  expect_equal(r2$measures.test$mmce, unname(vnapply(getRRPredictionList(r2)$test, performance, mmce)))
 })


### PR DESCRIPTION
I outsourced this from PR #914 as this seems to be necessary also for other issues. This new function creates a list of `Prediction` objects for each single resample iteration of a `ResampleResult` object. 
Since mlr by default computes measures for each resample iteration separately and then aggregates the measures, we can use this function to simply add additonal measures to an already existing `ResampleResult` object (see also the `addMeasure` function from PR #914, which I will also outsource from PR #914 after this PR has been merged).
