### PR TITLE
Add new measures to existing ResampleResult

### DIFF
--- a/R/ResampleResult_operators.R
+++ b/R/ResampleResult_operators.R
@@ -129,7 +129,10 @@ addRRMeasure = function(res, measures) {
     aggr = vnapply(measures[measures.id %in% missing.measures], function(m) {
       m$aggr$fun(task = NULL,
         perf.test = res$measures.test[, m$id],
-        perf.train = res$measures.train[, m$id], measure = m)
+        perf.train = res$measures.train[, m$id],
+        measure = m,
+        pred = getRRPredictions(res),
+        group = res$pred$instance$group)
     })
     names(aggr) = vcapply(measures[measures.id %in% missing.measures], measureAggrName)
     res$aggr = c(res$aggr, aggr)

--- a/R/ResampleResult_operators.R
+++ b/R/ResampleResult_operators.R
@@ -87,3 +87,52 @@ getRRPredictionList = function(res, ...) {
   if (is.null(ret$test)) ret = append(ret, list(test = NULL))
   return(ret[c("train", "test")])
 }
+
+#' @title Compute new measures for existing ResampleResult
+#' @description
+#'  Adds new measures to an existing \code{ResampleResult}.
+#' @param res [\code{ResampleResult}]\cr
+#'   The result of \code{\link{resample}} run with \code{keep.pred = TRUE}.
+#' @template arg_measures
+#' @return [\code{\link{ResampleResult}}].
+#' @export
+#' @family resample
+addRRMeasure = function(res, measures) {
+  assertClass(res, "ResampleResult")
+  if (inherits(measures, "Measure")) measures = list(measures)
+
+  # check if measures are missing in ResampleResult object
+  measures.id = vcapply(measures, function(x) x$id)
+  missing.measures = setdiff(measures.id, colnames(res$measures.test))
+
+  # if there are missing measures
+  if (length(missing.measures) != 0) {
+    # get list of prediction objects per iteration from resample result
+    pred = getRRPredictionList(res)
+
+    # recompute missing performance for train and/or test set
+    set = names(pred)[!vlapply(pred, is.null)]
+    perf = setNames(lapply(set, function(s) {
+      as.data.frame(do.call("rbind", lapply(pred[[s]], function(p) {
+        ret = performance(p, measures)
+        matrix(ret, ncol = length(measures), dimnames = list(NULL, names(ret)))
+      })))
+    }), set)
+
+    # add missing measures to resample result
+    if (is.null(perf$train))
+      res$measures.train[, missing.measures] = NA else
+        res$measures.train = cbind(res$measures.train, perf$train[, missing.measures, drop = FALSE])
+    if (is.null(perf$test))
+      res$measures.test[, missing.measures] = NA else
+        res$measures.test = cbind(res$measures.test, perf$test[, missing.measures, drop = FALSE])
+    aggr = vnapply(measures[measures.id %in% missing.measures], function(m) {
+      m$aggr$fun(task = NULL,
+        perf.test = res$measures.test[, m$id],
+        perf.train = res$measures.train[, m$id], measure = m)
+    })
+    names(aggr) = vcapply(measures[measures.id %in% missing.measures], measureAggrName)
+    res$aggr = c(res$aggr, aggr)
+  }
+  return(res)
+}

--- a/tests/testthat/test_base_resample.R
+++ b/tests/testthat/test_base_resample.R
@@ -147,7 +147,6 @@ test_that("resample is extended by an additional measure", {
   # check if it works with different aggregation methods
   aggr = list(test.mean, test.median, test.sd, test.range, test.join)
   for (a in aggr) {
-    cat(".")
     for (p in predict) {
       rdesc = makeResampleDesc("CV", iter = 3, predict = p)
       measures = list(mmce, ber, auc, brier)

--- a/tests/testthat/test_base_resample.R
+++ b/tests/testthat/test_base_resample.R
@@ -144,20 +144,27 @@ test_that("resample is extended by an additional measure", {
   # check if it works with test, both
   # FIXME: add "train" after https://github.com/mlr-org/mlr/issues/1284 has been fixed
   predict = c("test", "both")
-  for (p in predict) {
-    rdesc = makeResampleDesc("CV", iter = 3, predict = p)
-    measures = list(mmce, ber, auc, brier)
-    #if (p == "train") measures = lapply(measures, setAggregation, train.mean)
-    # create ResampleResult with all measures
-    res.all = resample(lrn, binaryclass.task, rdesc, measures)
-    # create ResampleResult with one measure and add the other ones afterwards
-    res = resample(lrn, binaryclass.task, rdesc, measures[[1]])
-    res.add = addRRMeasure(res, measures[-1])
+  # check if it works with different aggregation methods
+  aggr = list(test.mean, test.median, test.sd, test.range, test.join)
+  for (a in aggr) {
+    cat(".")
+    for (p in predict) {
+      rdesc = makeResampleDesc("CV", iter = 3, predict = p)
+      measures = list(mmce, ber, auc, brier)
+      # set aggregation method
+      measures = lapply(measures, setAggregation, a)
+      #if (p == "train") measures = lapply(measures, setAggregation, train.mean)
+      # create ResampleResult with all measures
+      res.all = resample(lrn, binaryclass.task, rdesc, measures)
+      # create ResampleResult with one measure and add the other ones afterwards
+      res = resample(lrn, binaryclass.task, rdesc, measures[[1]])
+      res.add = addRRMeasure(res, measures[-1])
 
-    # check if both ResampleResult objects are equal
-    expect_equal(res.all$measures.train, res.add$measures.train)
-    expect_equal(res.all$measures.test, res.add$measures.test)
-    expect_equal(res.all$aggr, res.add$aggr)
+      # check if both ResampleResult objects are equal
+      expect_equal(res.all$measures.train, res.add$measures.train)
+      expect_equal(res.all$measures.test, res.add$measures.test)
+      expect_equal(res.all$aggr, res.add$aggr)
+    }
   }
 
   # keep.pred must be TRUE


### PR DESCRIPTION
I outsourced this from PR #914 because it is easier to review in an extra PR. 
We can use this function to simply add additonal measures to an already existing `ResampleResult` object. After this is merged, we can finally adapt PR #914 and hopefully also merge that PR.