### PR TITLE
fix multilabel unit tests

### DIFF
--- a/tests/run-multilabel.R
+++ b/tests/run-multilabel.R
@@ -1,0 +1,5 @@
+library(testthat)
+if (identical(Sys.getenv("TRAVIS"), "true") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true")) {
+  test_check("mlr", "_multilabel_")
+}
+

--- a/tests/testthat/helper_helpers.R
+++ b/tests/testthat/helper_helpers.R
@@ -98,7 +98,7 @@ testProb = function(t.name, df, target, train.inds, old.probs, parset = list()) 
   inds = train.inds
   train = df[inds,]
   test = df[-inds,]
-  
+
   if(length(target) == 1) {
     task = makeClassifTask(data = df, target = target)
   } else {

--- a/tests/testthat/test_multilabel_randomForestSRC.R
+++ b/tests/testthat/test_multilabel_randomForestSRC.R
@@ -2,30 +2,30 @@ context("multilabel_randomForestSRC")
 
 test_that("multilabel_randomForestSRC", {
   requirePackagesOrSkip("randomForestSRC", default.method = "load")
-  
+
   parset.list = list(
     list(),
     list(ntree = 100),
-    list(ntree = 250, mtry = 5L),
+    list(ntree = 250, mtry = 3),
     list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE)
   )
   old.predicts.list = list()
   old.probs.list = list()
-  
+
   for (i in 1:length(parset.list)) {
     parset = parset.list[[i]]
-    for(i in multilabel.target) {
-      multilabel.train[i] = factor(multilabel.train[[i]], levels = c("TRUE", "FALSE"))
-      multilabel.test[i] = factor(multilabel.test[[i]], levels = c("TRUE", "FALSE"))
+    for(j in multilabel.target) {
+      multilabel.train[j] = factor(multilabel.train[[j]], levels = c("TRUE", "FALSE"))
+      multilabel.test[j] = factor(multilabel.test[[j]], levels = c("TRUE", "FALSE"))
     }
     parset = c(parset, list(data = multilabel.train, formula = multilabel.formula.cbind, forest = TRUE))
     set.seed(getOption("mlr.debug.seed"))
     m = do.call(randomForestSRC::rfsrc, parset)
+    set.seed(getOption("mlr.debug.seed"))
     p = predict(m, newdata = multilabel.test, membership = FALSE, na.action = "na.impute")
-    old.predicts.list[[i]] = data.frame(sapply(p$classOutput, function(x) as.logical(x$class)))
-    old.probs.list[[i]] = data.frame(sapply(p$classOutput, function(x) x$predicted[, 1]))
+    old.predicts.list[[i]] = as.data.frame(lapply(p$classOutput, function(x) as.logical(x$class)))
+    old.probs.list[[i]] = as.data.frame(lapply(p$classOutput, function(x) x$predicted[, 1]))
   }
-  
   testSimpleParsets("multilabel.randomForestSRC", multilabel.df, multilabel.target, multilabel.train.inds, old.predicts.list, parset.list)
   testProbParsets ("multilabel.randomForestSRC", multilabel.df, multilabel.target, multilabel.train.inds, old.probs.list, parset.list)
 })


### PR DESCRIPTION
1) there was a trvial bug in file test_multilabel_randomForestSRC.R

2) worse: the multilabel unit tests were not even *run* on travis, so we did not see this. a "run" file was missing. i added that here now.
