### PR TITLE
convert newdata data.table to data.frame with warning in predict

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -52,7 +52,7 @@ predict.WrappedModel = function(object, task, newdata, subset, ...) {
     size = getTaskSize(task)
   } else {
     assertDataFrame(newdata, min.rows = 1L)
-    if (!("data.frame" %in% class(newdata))) {
+    if (class(newdata)[1] != "data.frame") {
       warningf("Provided data for prediction is not a pure data.frame but from class %s, hence it will be converted.",  class(newdata)[1])
       newdata = as.data.frame(newdata)
     }

--- a/R/predict.R
+++ b/R/predict.R
@@ -52,7 +52,7 @@ predict.WrappedModel = function(object, task, newdata, subset, ...) {
     size = getTaskSize(task)
   } else {
     assertDataFrame(newdata, min.rows = 1L)
-    if (class(newdata)[1] != "data.frame") {
+    if (!("data.frame" %in% class(newdata))) {
       warningf("Provided data for prediction is not a pure data.frame but from class %s, hence it will be converted.",  class(newdata)[1])
       newdata = as.data.frame(newdata)
     }

--- a/R/predict.R
+++ b/R/predict.R
@@ -52,6 +52,10 @@ predict.WrappedModel = function(object, task, newdata, subset, ...) {
     size = getTaskSize(task)
   } else {
     assertDataFrame(newdata, min.rows = 1L)
+    if (class(newdata)[1] != "data.frame") {
+      warningf("Provided data for prediction is not a pure data.frame but from class %s, hence it will be converted.",  class(newdata)[1])
+      newdata = as.data.frame(newdata)
+    }
     size = nrow(newdata)
   }
   if (missing(subset)) {

--- a/tests/testthat/test_base_predict.R
+++ b/tests/testthat/test_base_predict.R
@@ -137,3 +137,10 @@ test_that("predict doesn't warn if 'on.learner.error' is 'quiet'", {
   expect_true(inherits(mod, "FailureModel"))
   expect_warning(predict(mod, multiclass.task), NA)
 })
+
+test_that("predict works with data.table as newdata", {
+  lrn = makeLearner("classif.qda")
+  mod = train(lrn, iris.task)
+  expect_warning(predict(mod, newdata = data.table(iris)), regexp = "Provided data for prediction is not a pure data.frame but from class data.table, hence it will be converted.")
+})
+


### PR DESCRIPTION
Should fix #1306 

Base change so review thoroughly.

This is basically the same check we do for tasks. We could also create a helper function for that, especially when this is required at more points