### PR TITLE
Tiny improvments for ResamplePredition and an important question

### DIFF
--- a/R/ResamplePrediction.R
+++ b/R/ResamplePrediction.R
@@ -16,8 +16,8 @@ NULL
 
 
 makeResamplePrediction = function(instance, preds.test, preds.train) {
-  tenull = sapply(preds.test, is.null)
-  trnull = sapply(preds.train, is.null)
+  tenull = vapply(preds.test, is.null, FUN.VALUE = logical(1))
+  trnull = vapply(preds.train, is.null, FUN.VALUE = logical(1))
   if (any(tenull)) pr.te = preds.test[!tenull] else pr.te = preds.test
   if (any(trnull)) pr.tr = preds.train[!trnull] else pr.tr = preds.train
 
@@ -27,11 +27,11 @@ makeResamplePrediction = function(instance, preds.test, preds.train) {
   ))
 
   if (!any(tenull) && instance$desc$predict %in% c("test", "both")) {
-    p1 = preds.test[[1L]]
-    pall = preds.test
+    p1 = pr.te[[1L]]
+    pall = pr.te
   } else if (!any(trnull) && instance$desc$predict == "train") {
-    p1 = preds.train[[1L]]
-    pall = preds.train
+    p1 = pr.tr[[1L]]
+    pall = pr.tr
   }
   
   


### PR DESCRIPTION
After discussing issue #1284 and PR #1315 respectively on our last meeting, I did some beauty to ResamplePrediction:

- vapply instead of sapply
- changed the object passed to p1 (which is "safer")

There is one **major question** that arose regarding the ResamplePrediction function and 
depending on the answer some probably more changes need to be implemented.

Is it possible to make resampling, i.e. cross-validation, where the result of one of the iterations
is NULL? To demonstrate what we mean you find a small code snippet below:

````

lrn = makeLearner("classif.rpart", predict.type = "prob")
rdesc = makeResampleDesc("CV", iter = 4, predict = "train")
mmce.train = setAggregation(mmce, train.mean)
res = resample(lrn, binaryclass.task, rdesc, mmce.train)

head(res$pred$data)
# here every iteration has a result. Is it possible that one iteration has no result?

# Since I do not have a use case I will manipulate the results of doResampleIteration such
# that it shows what I mean
rin = makeResampleInstance(rdesc, task = binaryclass.task)

extract = function(model) {}
more.args = list(learner = lrn, task = binaryclass.task, rin = rin, weights = NULL,
  measures = list(mmce), model = FALSE, extract = extract, show.info = getMlrOption("show.info"))

library(parallelMap)
parallelLibrary("mlr", master = FALSE, level = "mlr.resample", show.info = FALSE)
exportMlrOptions(level = "mlr.resample")
iter.results = parallelMap(doResampleIteration, seq_len(rin$desc$iters), level = "mlr.resample", more.args = more.args)

preds.test = extractSubList(iter.results, "pred.test", simplify = FALSE)
preds.train = extractSubList(iter.results, "pred.train", simplify = FALSE)
head(preds.train, n = 2L)
preds.train[1] <- list(NULL)
head(preds.train, n = 2L)

````

Is there any use case you can think about where this might happen?
Thank you!

