### PR TITLE
Fixes pretty.names argument for benchmark plots. Addresses #1299

### DIFF
--- a/R/plotBMRBoxplots.R
+++ b/R/plotBMRBoxplots.R
@@ -33,7 +33,13 @@ plotBMRBoxplots = function(bmr, measure = NULL, style = "box", order.lrns = NULL
   df = orderBMRTasks(bmr, df, order.tsks)
 
   if (pretty.names) {
-    levels(df$learner.id) = getBMRLearnerShortNames(bmr)
+    learner.short.names = getBMRLearnerShortNames(bmr)
+    if (!is.null(order.lrns)) {
+      learner.ids = getBMRLearnerIds(bmr)
+      names(learner.short.names) = learner.ids
+      learner.short.names = learner.short.names[order.lrns]
+    }
+    levels(df$learner.id) = learner.short.names
   }
 
   p = ggplot(df, aes_string("learner.id", measure$id))

--- a/R/plotBMRRanksAsBarChart.R
+++ b/R/plotBMRRanksAsBarChart.R
@@ -34,20 +34,28 @@ plotBMRRanksAsBarChart = function(bmr, measure = NULL, ties.method = "average", 
   assertClass(bmr, "BenchmarkResult")
   measure = checkBMRMeasure(measure, bmr)
   assertChoice(pos, c("tile", "stack", "dodge"))
-
   df = as.data.frame(convertBMRToRankMatrix(bmr, measure, ties.method = ties.method, aggregation = aggregation))
-  df$learner.id = as.factor(rownames(df))
-  if (pretty.names) {
-    levels(df$learner.id) = getBMRLearnerShortNames(bmr)
-  }
+  df$learner.id = factor(rownames(df))
+
   setDT(df)
   df = melt(df, id.vars = "learner.id")
   setnames(df, c("variable", "value"), c("task.id", "rank"))
   df = orderBMRLrns(bmr, df, order.lrns)
   df = orderBMRTasks(bmr, df, order.tsks)
+  if (pretty.names) {
+    learner.ids = getBMRLearnerIds(bmr)
+    learner.short.names = getBMRLearnerShortNames(bmr)
+    names(learner.short.names) = learner.ids
+    if (is.null(order.lrns)) {
+      learner.short.names = learner.short.names[sort(learner.ids)]
+    } else {
+      learner.short.names = learner.short.names[order.lrns]
+    }
+    levels(df$learner.id) = learner.short.names
+  }
+  df$rank = as.factor(df$rank)
   setDF(df)
 
-  df = as.data.frame(sapply(df, as.factor))
   if (pos == "tile") {
     p = ggplot(df, aes_string("rank", "task.id", fill = "learner.id"))
     p = p + geom_tile()
@@ -57,8 +65,6 @@ plotBMRRanksAsBarChart = function(bmr, measure = NULL, ties.method = "average", 
     p = p + geom_bar(position = pos)
     p = p + ylab(NULL)
   }
-  
-  # p = p + scale_fill_discrete(labels = lev)
 
   return(p)
 }

--- a/R/plotBMRSummary.R
+++ b/R/plotBMRSummary.R
@@ -50,7 +50,7 @@ plotBMRSummary = function(bmr, measure = NULL, trafo = "none", order.tsks = NULL
   df = orderBMRTasks(bmr, df, order.tsks)
 
   if (pretty.names) {
-    df$learners.id = getBMRLearnerShortNames(bmr)
+    levels(df$learner.id) = getBMRLearnerShortNames(bmr)
   }
 
   p = ggplot(df, aes_string(x = meas.name, y = "task.id", col = "learner.id"))

--- a/tests/testthat/helper_helpers.R
+++ b/tests/testthat/helper_helpers.R
@@ -242,9 +242,13 @@ testFacetting = function(obj, nrow = NULL, ncol = NULL) {
 #   expect_true(all(qc$pass), info = "Some Quickcheck tests failed.")
 # }
 
-testDocForStrings = function(doc, x, grid.size = 1L) {
+testDocForStrings = function(doc, x, grid.size = 1L, ordered = FALSE) {
   text.paths = paste("/svg:svg//svg:text[text()[contains(., '",
     x, "')]]", sep = "")
   nodes = XML::getNodeSet(doc, text.paths, ns.svg)
   expect_equal(length(nodes), length(x) * grid.size)
+  if (ordered) {
+    node.strings = vcapply(nodes, XML::getChildrenStrings)
+    expect_equal(node.strings[seq_along(x)], x)
+  }
 }

--- a/tests/testthat/helper_helpers.R
+++ b/tests/testthat/helper_helpers.R
@@ -248,3 +248,10 @@ testDocForStrings = function(doc, x, grid.size = 1L) {
   nodes = XML::getNodeSet(doc, text.paths, ns.svg)
   expect_equal(length(nodes), length(x) * grid.size)
 }
+
+testDocForStrings = function(doc, x, grid.size = 1L) {
+  text.paths = paste("/svg:svg//svg:text[text()[contains(., '",
+    x, "')]]", sep = "")
+  nodes = XML::getNodeSet(doc, text.paths, ns.svg)
+  expect_equal(length(nodes), length(x) * grid.size)
+}

--- a/tests/testthat/helper_helpers.R
+++ b/tests/testthat/helper_helpers.R
@@ -248,10 +248,3 @@ testDocForStrings = function(doc, x, grid.size = 1L) {
   nodes = XML::getNodeSet(doc, text.paths, ns.svg)
   expect_equal(length(nodes), length(x) * grid.size)
 }
-
-testDocForStrings = function(doc, x, grid.size = 1L) {
-  text.paths = paste("/svg:svg//svg:text[text()[contains(., '",
-    x, "')]]", sep = "")
-  nodes = XML::getNodeSet(doc, text.paths, ns.svg)
-  expect_equal(length(nodes), length(x) * grid.size)
-}

--- a/tests/testthat/test_base_plotBMRBoxplots.R
+++ b/tests/testthat/test_base_plotBMRBoxplots.R
@@ -37,6 +37,16 @@ test_that("BenchmarkResult", {
   doc = XML::xmlParse(path)
   testDocForStrings(doc, getBMRLearnerIds(res), grid.size = 2L)
   testDocForStrings(doc, getBMRMeasureIds(res)[[1L]])
+
+  # test pretty.names in conjunction with order.lrns
+  new.order = c("classif.rpart", "classif.nnet")
+  plotBMRBoxplots(res, pretty.names = TRUE, order.lrns = new.order)
+  dir = tempdir()
+  path = paste0(dir, "/test.svg")
+  ggsave(path)
+  doc = XML::xmlParse(path)
+  testDocForStrings(doc, getBMRLearnerShortNames(res)[2:1],
+    grid.size = 2L, ordered = TRUE)
 })
 
 test_that("BenchmarkResult allows spaces", {

--- a/tests/testthat/test_base_plotBMRRanksAsBarChart.R
+++ b/tests/testthat/test_base_plotBMRRanksAsBarChart.R
@@ -1,6 +1,6 @@
-context("plotRankMatrixAsBar")
+context("plotBMRRanksAsBarChart")
 
-test_that("RankMatrix", {
+test_that("plotBMRRanksAsBarChart", {
   lrns = list(makeLearner("classif.nnet"), makeLearner("classif.rpart"))
   tasks = list(multiclass.task, binaryclass.task)
   rdesc = makeResampleDesc("CV", iters = 2L)

--- a/tests/testthat/test_base_plotBMRRanksAsBarChart.R
+++ b/tests/testthat/test_base_plotBMRRanksAsBarChart.R
@@ -26,4 +26,14 @@ test_that("plotBMRRanksAsBarChart", {
   ggsave(path)
   doc = XML::xmlParse(path)
   testDocForStrings(doc, getBMRLearnerIds(res))
+
+  # test pretty.names in conjunction with order.lrns
+  new.order = c("classif.rpart", "classif.nnet")
+  plotBMRRanksAsBarChart(res, pretty.names = TRUE, order.lrns = new.order)
+  dir = tempdir()
+  path = paste0(dir, "/test.svg")
+  ggsave(path)
+  doc = XML::xmlParse(path)
+  testDocForStrings(doc, getBMRLearnerShortNames(res)[2:1], ordered = TRUE)
+
 })


### PR DESCRIPTION
This should fix the issue we had with level reordering when the pretty.names argument was used
(specifically when used together with order.lrns)

Side question:
Why don't we have the order.lrns argument for plotBMRSummary? It would have the same effect as
in plotBMRRanksAsBarCharts. E.g: Only change ordering of legend labels.
Should I go ahead and add it? Maybe in a different PR though I guess.