### PR TITLE
check for sampled training task in resampling (fixes #1357)

### DIFF
--- a/R/DownsampleWrapper.R
+++ b/R/DownsampleWrapper.R
@@ -45,5 +45,6 @@ trainLearner.DownsampleWrapper = function(.learner, .task, .subset, .weights = N
   .task = subsetTask(.task, .subset)
   .task = downsample(.task, perc = dw.perc, stratify = dw.stratify)
   m = train(.learner$next.learner, .task, weights = .task$weights)
+  m$train.task = .task
   makeChainModel(next.model = m, cl = "DownsampleModel")
 }

--- a/R/OverUndersampleWrapper.R
+++ b/R/OverUndersampleWrapper.R
@@ -75,6 +75,7 @@ trainLearner.UndersampleWrapper = function(.learner, .task, .subset, .weights = 
   .task = subsetTask(.task, .subset)
   .task = undersample(.task, rate = usw.rate, cl = usw.cl)
   m = train(.learner$next.learner, .task, weights = .weights)
+  m$train.task = .task
   makeChainModel(next.model = m, cl = "UndersampleModel")
 }
 
@@ -83,6 +84,7 @@ trainLearner.OversampleWrapper = function(.learner, .task, .subset, .weights = N
   .task = subsetTask(.task, .subset)
   .task = oversample(.task, rate = osw.rate, cl = osw.cl)
   m = train(.learner$next.learner, .task, weights = .weights)
+  m$train.task = .task
   makeChainModel(next.model = m, cl = "OversampleModel")
 }
 

--- a/R/generateLearningCurve.R
+++ b/R/generateLearningCurve.R
@@ -58,11 +58,9 @@ generateLearningCurveData = function(learners, task, resampling = NULL,
   else
     assert(checkClass(resampling, "ResampleDesc"), checkClass(resampling, "ResampleInstance"))
 
-  perc.ids = seq_along(percs)
-
   # create downsampled versions for all learners
   lrnds1 = lapply(learners, function(lrn) {
-    lapply(perc.ids, function(p.id) {
+    lapply(seq_along(percs), function(p.id) {
       perc = percs[p.id]
       dsw = makeDownsampleWrapper(learner = lrn, dw.perc = perc, dw.stratify = stratify)
       list(

--- a/R/resample.R
+++ b/R/resample.R
@@ -132,8 +132,16 @@ doResampleIteration = function(learner, task, rin, i, measures, weights, model, 
   pred.train = NULL
   pred.test = NULL
   pp = rin$desc$predict
+  train.task = task
   if (pp == "train") {
-    pred.train = predict(m, task, subset = train.i)
+    if (!is.null(m$learner.model$next.model)) {
+      if (!is.null(m$learner.model$next.model$train.task)) {
+        # the learner was wrapped in a sampling wrapper
+        train.task = m$learner.model$next.model$train.task
+        train.i = m$learner.model$next.model$subset
+      }
+    }
+    pred.train = predict(m, train.task, subset = train.i)
     if (!is.na(pred.train$error)) err.msgs[2L] = pred.train$error
     ms.train = performance(task = task, model = m, pred = pred.train, measures = measures)
     names(ms.train) = vcapply(measures, measureAggrName)
@@ -143,10 +151,18 @@ doResampleIteration = function(learner, task, rin, i, measures, weights, model, 
     ms.test = performance(task = task, model = m, pred = pred.test, measures = measures)
     names(ms.test) = vcapply(measures, measureAggrName)
   } else { # "both"
-    pred.train = predict(m, task, subset = train.i)
+    if (!is.null(m$learner.model$next.model)) {
+      if (!is.null(m$learner.model$next.model$train.task)) {
+        # the learner was wrapped in a sampling wrapper
+        train.task = m$learner.model$next.model$train.task
+        train.i = m$learner.model$next.model$subset
+      }
+    }
+    pred.train = predict(m, train.task, subset = train.i)
     if (!is.na(pred.train$error)) err.msgs[2L] = pred.train$error
     ms.train = performance(task = task, model = m, pred = pred.train, measures = measures)
     names(ms.train) = vcapply(measures, measureAggrName)
+
     pred.test = predict(m, task, subset = test.i)
     if (!is.na(pred.test$error)) err.msgs[2L] = paste(err.msgs[2L], pred.test$error)
     ms.test = performance(task = task, model = m, pred = pred.test, measures = measures)

--- a/R/resample.R
+++ b/R/resample.R
@@ -134,12 +134,11 @@ doResampleIteration = function(learner, task, rin, i, measures, weights, model, 
   pp = rin$desc$predict
   train.task = task
   if (pp == "train") {
-    if (!is.null(m$learner.model$next.model)) {
-      if (!is.null(m$learner.model$next.model$train.task)) {
-        # the learner was wrapped in a sampling wrapper
-        train.task = m$learner.model$next.model$train.task
-        train.i = m$learner.model$next.model$subset
-      }
+    lm = getLearnerModel(m)
+    if ("BaseWrapper" %in% class(learner) && !is.null(lm$train.task)) {
+      # the learner was wrapped in a sampling wrapper
+      train.task = lm$train.task
+      train.i = lm$subset
     }
     pred.train = predict(m, train.task, subset = train.i)
     if (!is.na(pred.train$error)) err.msgs[2L] = pred.train$error
@@ -151,12 +150,11 @@ doResampleIteration = function(learner, task, rin, i, measures, weights, model, 
     ms.test = performance(task = task, model = m, pred = pred.test, measures = measures)
     names(ms.test) = vcapply(measures, measureAggrName)
   } else { # "both"
-    if (!is.null(m$learner.model$next.model)) {
-      if (!is.null(m$learner.model$next.model$train.task)) {
-        # the learner was wrapped in a sampling wrapper
-        train.task = m$learner.model$next.model$train.task
-        train.i = m$learner.model$next.model$subset
-      }
+    lm = getLearnerModel(m)
+    if ("BaseWrapper" %in% class(learner) && !is.null(lm$train.task)) {
+      # the learner was wrapped in a sampling wrapper
+      train.task = lm$train.task
+      train.i = lm$subset
     }
     pred.train = predict(m, train.task, subset = train.i)
     if (!is.na(pred.train$error)) err.msgs[2L] = pred.train$error

--- a/tests/testthat/test_base_downsample.R
+++ b/tests/testthat/test_base_downsample.R
@@ -62,4 +62,17 @@ test_that("downsample wrapper works with weights, we had issue #838",  {
   expect_true(length(u) == 5 && all(u %in% 1:10))
 })
 
+test_that("training performance works as expected (#1357)", {
+  num = makeMeasure(id = "num", minimize = FALSE,
+    properties = c("classif", "classif.multi", "req.pred", "req.truth"),
+    name = "Number",
+    fun = function(task, model, pred, feats, extra.args) {
+      length(pred$data$response)
+    }
+  )
 
+  rdesc = makeResampleDesc("Holdout", predict = "both")
+  lrn = makeDownsampleWrapper("classif.rpart", dw.perc = 0.1)
+  r = resample(lrn, multiclass.task, rdesc, measures = list(setAggregation(num, train.mean)))
+  expect_lte(r$measures.train$num, getTaskSize(multiclass.task) * 0.1)
+})


### PR DESCRIPTION
Turns out that this affected all wrappers that change the training task. I've fixed this in resampling, but I'm not sure if this needs to be addressed elsewhere.

@berndbischl @mllg 