### PR TITLE
Fix problem with integer overflow in measure mcc

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -701,7 +701,7 @@ measureWKAPPA = function(truth, response) {
   expected.mat = rowsum %*% t(colsum) 
 
   # get weights
-  class.values = as.numeric(levels(truth))
+  class.values = seq_along(levels(truth)) - 1L
   weights = outer(class.values, class.values, FUN = function(x, y) (x - y)^2)
   
   # calculate weighted kappa

--- a/R/measures.R
+++ b/R/measures.R
@@ -1041,10 +1041,10 @@ mcc = makeMeasure(id = "mcc", minimize = FALSE,
 #' @rdname measures
 #' @format none
 measureMCC = function(truth, response, negative, positive) {
-  tn = measureTN(truth, response, negative)
-  tp = measureTP(truth, response, positive)
-  fn = measureFN(truth, response, negative)
-  fp = measureFP(truth, response, positive)
+  tn = as.numeric(measureTN(truth, response, negative))
+  tp = as.numeric(measureTP(truth, response, positive))
+  fn = as.numeric(measureFN(truth, response, negative))
+  fp = as.numeric(measureFP(truth, response, positive))
   (tp * tn - fp * fn) /
     sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
 }

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -431,6 +431,11 @@ test_that("check measure calculations", {
   wkappa.perf = performance(pred.classif, measures = wkappa, model = mod.classif)
   expect_equal(measureWKAPPA(tar.classif, pred.art.classif), wkappa.test)
   expect_equal(measureWKAPPA(tar.classif, pred.art.classif), as.numeric(wkappa.perf))
+  tar.classif2 = tar.classif
+  pred.art.classif2 = pred.art.classif
+  levels(tar.classif2) = as.numeric(levels(tar.classif))^2
+  levels(pred.art.classif2) = as.numeric(levels(pred.art.classif))^2
+  expect_equal(measureWKAPPA(tar.classif2, pred.art.classif2), wkappa.test)
 
   #test binaryclass measures
 

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -51,6 +51,13 @@ test_that("measures", {
   expect_is(perf, "numeric")
 })
 
+test_that("classif measures do not produce integer overflow", {
+  tsk = oversample(subsetTask(pid.task), 1000)
+  lrn = makeLearner("classif.rpart", predict.type = "prob")
+  ms = listMeasures("classif", create = TRUE)
+  r = holdout(lrn, tsk, measures = ms, show.info = FALSE)
+  expect_numeric(r$aggr, any.missing = FALSE)
+})
 
 test_that("measures with same id still work", {
   m1 = mmce


### PR DESCRIPTION
Fixes the following problem:
```
holdout('classif.logreg', oversample(pid.task, 5), measures = mcc)
````

```
[Resample] holdout iter 1: mcc.test.mean=  NA
[Resample] Aggr. Result: mcc.test.mean=  NA
Resample Result
Task: PimaIndiansDiabetes-example
Learner: classif.logreg
Aggr perf: mcc.test.mean=  NA
Runtime: 0.0150108
Warning message:
In (tp + fp) * (tp + fn) * (tn + fp) * (tn + fn) :
  NAs produced by integer overflow
```