### PR TITLE
Allow Rfast filters to deal with missing data

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -508,7 +508,7 @@ makeFilter(
         an[i, ] <- Rfast::anovas(X[j, i, drop = FALSE], y[j]) 
       }
     }
-    setNames(y[, "stat"], getTaskFeatureNames(task))
+    setNames(an[, "F value"], getTaskFeatureNames(task))
   }
 )
 

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -285,7 +285,7 @@ makeFilter(
     d = getTaskData(task, target.extra = TRUE)
     y = Rfast::correls(d$target, d$data, type = "pearson")
     for (i in which(is.na(y[, "correlation"]))) {
-      y[i, "correlation"] <- cor(d$target, d$data[,i], use = "complete.obs")
+      y[i, "correlation"] = cor(d$target, d$data[,i], use = "complete.obs")
     }
     setNames(abs(y[, "correlation"]), getTaskFeatureNames(task))
   }
@@ -306,7 +306,7 @@ makeFilter(
     d = getTaskData(task, target.extra = TRUE)
     y = Rfast::correls(d$target, d$data, type = "spearman")
     for (i in which(is.na(y[, "correlation"]))) {
-      y[i, "correlation"] <- cor(d$target, d$data[,i], use = "complete.obs", method = "spearman")
+      y[i, "correlation"] = cor(d$target, d$data[,i], use = "complete.obs", method = "spearman")
     }
     setNames(abs(y[, "correlation"]), getTaskFeatureNames(task))
   }
@@ -505,7 +505,7 @@ makeFilter(
     for (i in which(is.na(an[, "F value"]))) {
       j = !is.na(X[,i])
       if (any(j)) {
-        an[i, ] <- Rfast::anovas(X[j, i, drop = FALSE], y[j]) 
+        an[i, ] = Rfast::anovas(X[j, i, drop = FALSE], y[j]) 
       }
     }
     setNames(an[, "F value"], getTaskFeatureNames(task))

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -284,6 +284,9 @@ makeFilter(
   fun = function(task, nselect, ...) {
     d = getTaskData(task, target.extra = TRUE)
     y = Rfast::correls(d$target, d$data, type = "pearson")
+    for (i in which(is.na(y[, "correlation"]))) {
+      y[i, "correlation"] <- cor(d$target, d$data[,i], use = "complete.obs")
+    }
     setNames(abs(y[, "correlation"]), getTaskFeatureNames(task))
   }
 )
@@ -302,6 +305,9 @@ makeFilter(
   fun = function(task, nselect, ...) {
     d = getTaskData(task, target.extra = TRUE)
     y = Rfast::correls(d$target, d$data, type = "spearman")
+    for (i in which(is.na(y[, "correlation"]))) {
+      y[i, "correlation"] <- cor(d$target, d$data[,i], use = "complete.obs", method = "spearman")
+    }
     setNames(abs(y[, "correlation"]), getTaskFeatureNames(task))
   }
 )
@@ -493,7 +499,15 @@ makeFilter(
   supported.features = c("numerics"),
   fun = function(task, nselect, ...) {
     d = getTaskData(task, target.extra = TRUE)
-    y = Rfast::ftests(as.matrix(d$data), as.numeric(d$target))
+    y = as.integer(d$target)
+    X = as.matrix(d$data)
+    an = Rfast::anovas(X, y)
+    for (i in which(is.na(an[, "F value"]))) {
+      j = !is.na(X[,i])
+      if (any(j)) {
+        an[i, ] <- Rfast::anovas(X[j, i, drop = FALSE], y[j]) 
+      }
+    }
     setNames(y[, "stat"], getTaskFeatureNames(task))
   }
 )

--- a/tests/testthat/test_featsel_filters.R
+++ b/tests/testthat/test_featsel_filters.R
@@ -45,5 +45,21 @@ test_that("filterFeatures", {
     more.args = list("rf.min.depth" = c(method = "vh", conservative = "low"))))
   expect_class(fv, classes = "FilterValues")
   expect_numeric(fv$data[, 3L], any.missing = FALSE, all.missing = FALSE, len = getTaskNFeats(multiclass.task))
+      
+  # extra tests for filters based on functions of the Rfast package, including
+  # whether they use pairwise complete observations
+  y = 1:10
+  x = data.frame(x1 = c(1:6, 1:3, NA), x2 = c(1, 1:8, 1))
+  tsk = makeRegrTask(data = cbind(y, x), target = "y")
+  expect_equal(as.vector(cor(y, x, use = "pairwise.complete.obs")),
+    generateFilterValuesData(tsk, "linear.correlation")$data$linear.correlation)
+
+  expect_equal(as.vector(cor(y, x, use = "pairwise.complete.obs", method = "spearman")),
+     generateFilterValuesData(tsk, "rank.correlation")$data$rank.correlation)
+
+  y = rep(letters[1:2], 5L)
+  tsk = makeClassifTask(data = cbind(y, x), target = "y")
+  expect_equal(as.vector(sapply(x, function(i) summary(aov(i ~ y))[[1]][1, "F value"])),
+    generateFilterValuesData(tsk, "anova.test")$data$anova.test)
 })
 


### PR DESCRIPTION
This should restore the behavior of the previous implementation with FSelector functions.