### PR TITLE
fix 1355, smote with integers

### DIFF
--- a/R/smote.R
+++ b/R/smote.R
@@ -76,6 +76,8 @@ smote = function(task, rate, nn = 5L, standardize = TRUE, alt.logic = FALSE) {
     }
   }
   x.min.matrix = as.matrix(x.min.matrix)
+  # ensure that x.min.matrix is numeric and not integer since c_smote requires a real valued matrix
+  storage.mode(x.min.matrix) = "numeric"
 
   if (alt.logic == TRUE) {
     n.xmin = dim(x.min.matrix)[1]

--- a/tests/testthat/test_base_imbal_smote.R
+++ b/tests/testthat/test_base_imbal_smote.R
@@ -69,3 +69,12 @@ test_that("smote wrapper",  {
   lrn4 = makeSMOTEWrapper(lrn1, sw.nn = 100)
   expect_error(resample(lrn4, binaryclass.task, rdesc), "when the minimal class has size")
 })
+
+test_that("smote works with only integer features", {
+  dat = getTaskData(pid.task)
+  i = sapply(dat, is.numeric)
+  dat[,i] = lapply(dat[,i], as.integer)
+  tsk = makeClassifTask(data = dat, target = "diabetes")
+  task2 = smote(tsk, 2)
+  expect_equal(getTaskSize(task2), 1036)
+})


### PR DESCRIPTION
Fixes #1355

Problem is that if all variables in a task are integer, `x.min.matrix` will become an integer matrix but `c_smote` expects a double matrix.