### PR TITLE
#1403 remove pretty.names

### DIFF
--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -45,7 +45,8 @@
 #' res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc,
 #' par.set = ps, control = ctrl)
 #' data = generateHyperParsEffectData(res)
-#' plotHyperParsEffect(data, x = "C", y = "mmce.test.mean")
+#' plt = plotHyperParsEffect(data, x = "C", y = "mmce.test.mean")
+#' plt + ylab("Misclassification Error")
 #'
 #' # nested cross validation
 #' ps = makeParamSet(makeDiscreteParam("C", values = 2^(-4:4)))
@@ -173,7 +174,6 @@ print.HyperParsEffectData = function(x, ...) {
 #'  using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 #'  for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 #'  Default is \code{NULL}.
-#' @template arg_prettynames
 #' @param global.only [\code{logical(1)}]\cr
 #'  If \code{TRUE}, will only plot the current global optima when setting
 #'  x = "iteration" and y as a performance measure from
@@ -225,15 +225,17 @@ print.HyperParsEffectData = function(x, ...) {
 #' is set to \code{TRUE} in \code{\link{generateHyperParsEffectData}}, only
 #' partial dependence will be plotted.
 #'
+#' Since a ggplot2 plot object is returned, the user can change the axis labels
+#' and other aspects of the plot using the appropriate ggplot2 syntax.
+#'
 #' @export
 #'
 #' @examples
 #' # see generateHyperParsEffectData
 plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   z = NULL, plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = NULL,
-  show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean,
-  partial.dep.learn = NULL) {
+  global.only = TRUE, interpolate = NULL, show.experiments = FALSE,
+  show.interpolated = FALSE, nested.agg = mean, partial.dep.learn = NULL) {
 
   assertClass(hyperpars.effect.data, classes = "HyperParsEffectData")
   assertChoice(x, choices = names(hyperpars.effect.data$data))
@@ -242,7 +244,6 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
   assertChoice(plot.type, choices = c("scatter", "line", "heatmap", "contour"))
   assertFlag(loess.smooth)
   assertSubset(facet, choices = names(hyperpars.effect.data$data))
-  assertFlag(pretty.names)
   assertFlag(global.only)
   assert(checkClass(interpolate, "Learner"), checkString(interpolate),
          checkNull(interpolate))
@@ -467,21 +468,6 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
       if (plot.type == "line")
         plt = plt + geom_line()
     }
-  }
-
-  # pretty name changing
-  if (pretty.names) {
-    if (x %in% hyperpars.effect.data$measures)
-      plt = plt +
-        xlab(eval(as.name(stri_split_fixed(x, ".test.mean")[[1]][1]))$name)
-    if (y %in% hyperpars.effect.data$measures)
-      plt = plt +
-        ylab(eval(as.name(stri_split_fixed(y, ".test.mean")[[1]][1]))$name)
-    if (!is.null(z))
-      if (z %in% hyperpars.effect.data$measures)
-        plt = plt +
-          labs(fill = eval(as.name(stri_split_fixed(z,
-            ".test.mean")[[1]][1]))$name)
   }
   return(plt)
 }

--- a/man/generateHyperParsEffectData.Rd
+++ b/man/generateHyperParsEffectData.Rd
@@ -58,7 +58,8 @@ rdesc = makeResampleDesc("CV", iters = 3L)
 res = tuneParams("classif.ksvm", task = pid.task, resampling = rdesc,
 par.set = ps, control = ctrl)
 data = generateHyperParsEffectData(res)
-plotHyperParsEffect(data, x = "C", y = "mmce.test.mean")
+plt = plotHyperParsEffect(data, x = "C", y = "mmce.test.mean")
+plt + ylab("Misclassification Error")
 
 # nested cross validation
 ps = makeParamSet(makeDiscreteParam("C", values = 2^(-4:4)))

--- a/man/plotHyperParsEffect.Rd
+++ b/man/plotHyperParsEffect.Rd
@@ -6,9 +6,8 @@
 \usage{
 plotHyperParsEffect(hyperpars.effect.data, x = NULL, y = NULL, z = NULL,
   plot.type = "scatter", loess.smooth = FALSE, facet = NULL,
-  pretty.names = TRUE, global.only = TRUE, interpolate = NULL,
-  show.experiments = FALSE, show.interpolated = FALSE, nested.agg = mean,
-  partial.dep.learn = NULL)
+  global.only = TRUE, interpolate = NULL, show.experiments = FALSE,
+  show.interpolated = FALSE, nested.agg = mean, partial.dep.learn = NULL)
 }
 \arguments{
 \item{hyperpars.effect.data}{[\code{HyperParsEffectData}]\cr
@@ -46,9 +45,6 @@ Specify what should be used as the facet axis for a particular geom. When
 using nested cross validation, set this to \dQuote{nested_cv_run} to obtain a facet
 for each outer loop. Must be a column from \code{HyperParsEffectData$data}
 Default is \code{NULL}.}
-
-\item{pretty.names}{[\code{logical{1}}]\cr
-Whether to use the short name of the learner instead of its ID in labels. Defaults to \code{TRUE}.}
 
 \item{global.only}{[\code{logical(1)}]\cr
 If \code{TRUE}, will only plot the current global optima when setting
@@ -114,6 +110,9 @@ Interpolation by its nature will result in predicted values for the
 performance measure. Use interpolation with caution. If \dQuote{partial.dep}
 is set to \code{TRUE} in \code{\link{generateHyperParsEffectData}}, only
 partial dependence will be plotted.
+
+Since a ggplot2 plot object is returned, the user can change the axis labels
+and other aspects of the plot using the appropriate ggplot2 syntax.
 }
 \examples{
 # see generateHyperParsEffectData

--- a/tests/testthat/test_base_generateHyperParsEffect.R
+++ b/tests/testthat/test_base_generateHyperParsEffect.R
@@ -51,7 +51,7 @@ test_that("1 numeric hyperparam", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     c("GeomPoint", "GeomLine"))
   expect_equal(plt$labels$x, "iteration")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # FIXME: make sure plot looks as expected
 })
@@ -80,7 +80,7 @@ test_that("1 discrete hyperparam", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     "GeomPoint")
   expect_equal(plt$labels$x, "kernel")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # FIXME: make sure plot looks as expected
 })
@@ -109,7 +109,7 @@ test_that("1 numeric hyperparam with optimizer failure", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     "GeomPoint")
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # FIXME: make sure plot looks as expected
 })
@@ -140,7 +140,7 @@ test_that("1 numeric hyperparam with nested cv", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     "GeomPoint")
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Mean misclassification error")
+  expect_equal(plt$labels$y, "mmce.test.mean")
 
   # FIXME: make sure plot looks as expected
 })
@@ -168,7 +168,7 @@ test_that("2 hyperparams", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     c("GeomLine", "GeomPoint"))
   expect_equal(plt$labels$x, "iteration")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # test heatcontour creation with interpolation
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
@@ -182,7 +182,7 @@ test_that("2 hyperparams", {
     c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
-  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$fill, "acc.test.mean")
   expect_equal(plt$labels$shape, "learner_status")
 
   # learner crash
@@ -205,7 +205,7 @@ test_that("2 hyperparams", {
     c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
-  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$fill, "acc.test.mean")
   expect_equal(plt$labels$shape, "learner_status")
 
   # FIXME: make sure plots looks as expected
@@ -238,7 +238,7 @@ test_that("2 hyperparams nested", {
     c("GeomPoint", "GeomRaster", "GeomContour"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
-  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$fill, "acc.test.mean")
   expect_equal(plt$labels$shape, "learner_status")
 
   # learner crashes
@@ -262,7 +262,7 @@ test_that("2 hyperparams nested", {
     c("GeomPoint", "GeomRaster"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
-  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$fill, "acc.test.mean")
   expect_equal(plt$labels$shape, "learner_status")
 })
 
@@ -291,7 +291,7 @@ test_that("2+ hyperparams", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     c("GeomLine", "GeomPoint"))
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # test bivariate
   plt = plotHyperParsEffect(data, x = "C", y = "sigma", z = "acc.test.mean",
@@ -303,7 +303,7 @@ test_that("2+ hyperparams", {
   expect_equal(class(plt$layers[[1]]$geom)[1], c("GeomTile"))
   expect_equal(plt$labels$x, "C")
   expect_equal(plt$labels$y, "sigma")
-  expect_equal(plt$labels$fill, "Accuracy")
+  expect_equal(plt$labels$fill, "acc.test.mean")
 
 
   # simple example with nested cv
@@ -328,7 +328,7 @@ test_that("2+ hyperparams", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     c("GeomLine", "GeomPoint"))
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # learner crash with imputation works
   ps = makeParamSet(
@@ -349,7 +349,7 @@ test_that("2+ hyperparams", {
   expect_set_equal(sapply(plt$layers, function(x) class(x$geom)[1]),
     c("GeomLine", "GeomPoint"))
   expect_equal(plt$labels$x, "C")
-  expect_equal(plt$labels$y, "Accuracy")
+  expect_equal(plt$labels$y, "acc.test.mean")
 
   # FIXME: make sure plots looks as expected
 })


### PR DESCRIPTION
Per discussion in #1403 this removes `pretty.names` argument from `plotHyperParsEffect`. This reduces API complexity for something should probably be edited by the user anyway. I added a note in the documentation to remind users.

This should be ready when green.