### PR TITLE
closes #1401 fixed colnames of createDummyFeatures

### DIFF
--- a/R/createDummyFeatures.R
+++ b/R/createDummyFeatures.R
@@ -45,9 +45,7 @@ createDummyFeatures.data.frame = function(obj, target = character(0L), method = 
   dummies = as.data.frame(lapply(obj[work.cols], createDummyFeatures, method = method))
 
   if (length(dummies) != 0) {
-    if (method == "1-of-n") {
-      colnames(dummies) = stri_paste(prefix, levels(dfcol), sep = ".")
-    } else {
+    if (ncol(dummies) == 1L) {
       colnames(dummies) = stri_paste(prefix, tail(levels(dfcol), -1), sep = ".")
     }
     cbind(dropNamed(obj, work.cols), dummies)
@@ -71,11 +69,11 @@ createDummyFeatures.factor = function(obj, target = character(0L), method = "1-o
   if (method == "1-of-n") {
     form = stri_paste("~", colname, "-1")
     res = model.matrix(as.formula(form), data = dcol)
-    colnames(res) = levels(obj)
+    colnames(res) = levels(as.factor(obj))
   } else {
     form = stri_paste("~", colname, "-1")
     res = model.matrix(as.formula(form), data = dcol)[, -1, drop = FALSE]
-    colnames(res) = tail(levels(obj), -1)
+    colnames(res) = tail(levels(as.factor(obj)), -1)
   }
   as.data.frame(res)
 }

--- a/tests/testthat/test_base_createDummyFeatures.R
+++ b/tests/testthat/test_base_createDummyFeatures.R
@@ -10,7 +10,7 @@ test_that("createDummyFeatures", {
   expect_equal(colnames(df.d), c("a", "b", "c.B"))
   df$b = as.factor(df$b)
   df.bc = createDummyFeatures(df)
-  expect_equal(colnames(df.bc), c("a", "b.a", "b.b", "b.b", "b.b", "b.b", "c.A", "c.B"))
+  expect_equal(colnames(df.bc), c("a", "b.a", "b.b", "b.c", "b.d", "b.e", "c.A", "c.B"))
 
   dummy.task = createDummyFeatures(iris.task)
   expect_equal(dummy.task, iris.task)

--- a/tests/testthat/test_base_createDummyFeatures.R
+++ b/tests/testthat/test_base_createDummyFeatures.R
@@ -8,6 +8,9 @@ test_that("createDummyFeatures", {
   expect_equal(colnames(df.d), c("a", "b", "c.A", "c.B"))
   df.d = createDummyFeatures(df, method = "reference")
   expect_equal(colnames(df.d), c("a", "b", "c.B"))
+  df$b = as.factor(df$b)
+  df.bc = createDummyFeatures(df)
+  expect_equal(colnames(df.bc), c("a", "b.a", "b.b", "b.b", "b.b", "b.b", "c.A", "c.B"))
 
   dummy.task = createDummyFeatures(iris.task)
   expect_equal(dummy.task, iris.task)


### PR DESCRIPTION
I fixed the colnames bug of createDummyFeatures and added a unit test to check for it.
The bug reported produced NAs as colnames:
```
createDummyFeatures(expand.grid(x1 = letters[1:2], x2 = letters[3:4]))
  NA NA NA NA
1  1  0  1  0
2  0  1  1  0
3  1  0  0  1
4  0  1  0  1
```

now we have it correctly:

```
createDummyFeatures(expand.grid(x1 = letters[1:2], x2 = letters[3:4]))
  x1.a x1.b x2.c x2.d
1    1    0    1    0
2    0    1    1    0
3    1    0    0    1
4    0    1    0    1
```