### PR TITLE
Small improvement/fix for plotResiduals

### DIFF
--- a/R/plotResiduals.R
+++ b/R/plotResiduals.R
@@ -90,7 +90,12 @@ makeResidualPlot = function(df, type = "scatterplot", loess.smooth = TRUE,
     p = p + ggtitle("True value vs. fitted value")
   } else {
     df$residuals = as.numeric(df$truth) - as.numeric(df$response)
-    p = ggplot(df, aes_string("residuals")) + geom_histogram()
+    p = ggplot(df, aes_string("residuals"))
+    if (task.type == "classif") {
+      p = p + geom_bar()
+    } else {
+      p = p + geom_histogram()
+    }
     p = p + ggtitle("Histogram of residuals")
   }
 

--- a/R/plotResiduals.R
+++ b/R/plotResiduals.R
@@ -7,7 +7,8 @@
 #' @param obj [\code{\link{Prediction}} | \code{\link{BenchmarkResult}}]\cr
 #'   Input data.
 #' @param type Type of plot. Can be \dQuote{scatterplot}, the default. Or
-#'   \dQuote{hist}, for a histogram of the residuals.
+#'   \dQuote{hist}, for a histogram, or in case of classification problems
+#'   a barplot, displaying the residuals.
 #' @param loess.smooth [\code{logical(1)}]\cr
 #'   Should a loess smoother be added to the plot? Defaults to \code{TRUE}.
 #'   Only applicable for regression tasks and if \code{type} is set to \code{scatterplot}.

--- a/tests/testthat/test_base_plotResiduals.R
+++ b/tests/testthat/test_base_plotResiduals.R
@@ -54,7 +54,8 @@ test_that("plotResiduals with BenchmarkResult", {
   path = paste0(dir, "/test.svg")
   ggsave(path)
   doc = XML::xmlParse(path)
-  expect_equal(length(XML::getNodeSet(doc, black.bar.xpath, ns.svg)), grid.size * 30L)
+  # barplot now. We can't test for exact number of bars anymore
+  expect_true(length(XML::getNodeSet(doc, black.bar.xpath, ns.svg)) > 0L)
   
   # check pretty names
   testDocForStrings(doc, getBMRLearnerShortNames(bmr), grid.size = 2L)


### PR DESCRIPTION
When analyzing residuals of a classification problem with ``type = "hist"`` a barplot is now plotted instead of a histogram, which is more formally correct and nicer to look at.