### PR TITLE
closes #1421, colnames for more than one binary variable using method = "reference"

### DIFF
--- a/R/createDummyFeatures.R
+++ b/R/createDummyFeatures.R
@@ -44,6 +44,11 @@ createDummyFeatures.data.frame = function(obj, target = character(0L), method = 
 
   dummies = as.data.frame(lapply(obj[work.cols], createDummyFeatures, method = method))
 
+  if (method == "reference" && length(work.cols) == length(dummies)) {
+    colnames(dummies) = Map(function(col, pre) {
+      stri_paste(pre, tail(levels(col), -1), sep = ".")}, obj[work.cols], prefix)
+  }
+
   if (length(dummies) != 0) {
     if (ncol(dummies) == 1L) {
       colnames(dummies) = stri_paste(prefix, tail(levels(dfcol), -1), sep = ".")

--- a/tests/testthat/test_base_createDummyFeatures.R
+++ b/tests/testthat/test_base_createDummyFeatures.R
@@ -11,6 +11,8 @@ test_that("createDummyFeatures", {
   df$b = as.factor(df$b)
   df.bc = createDummyFeatures(df)
   expect_equal(colnames(df.bc), c("a", "b.a", "b.b", "b.c", "b.d", "b.e", "c.A", "c.B"))
+  grid = createDummyFeatures(expand.grid(x1 = letters[1:2], x2 = letters[3:4]), method = "reference")
+  expect_equal(colnames(grid), c("x1.b", "x2.d"))
 
   dummy.task = createDummyFeatures(iris.task)
   expect_equal(dummy.task, iris.task)


### PR DESCRIPTION
I fixed issuer #1421 and added a unit test.