### PR TITLE
fixes classif.binomial (Learner bug list)

### DIFF
--- a/R/RLearner_classif_binomial.R
+++ b/R/RLearner_classif_binomial.R
@@ -6,12 +6,12 @@ makeRLearner.classif.binomial = function() {
     par.set = makeParamSet(
       makeDiscreteLearnerParam("link", values = c("logit", "probit", "cloglog", "cauchit", "log"),
         default = "logit"),
-      makeLogicalLearnerParam("model", default = TRUE, tunable = FALSE)
+      makeLogicalLearnerParam("model", default = FALSE, tunable = FALSE)
     ),
     properties = c("twoclass", "numerics", "factors", "prob", "weights"),
     name = "Binomial Regression",
     short.name = "binomial",
-    note = "Delegates to `glm` with freely choosable binomial link function via learner parameter `link`."
+    note = "Delegates to `glm` with freely choosable binomial link function via learner parameter `link`. Against the original default in the stats package, model is set to FALSE, due to memory reasons."
   )
 }
 

--- a/R/RLearner_classif_binomial.R
+++ b/R/RLearner_classif_binomial.R
@@ -18,7 +18,7 @@ makeRLearner.classif.binomial = function() {
 #' @export
 trainLearner.classif.binomial = function(.learner, .task, .subset, .weights = NULL, link = "logit", ...) {
   f = getTaskFormula(.task)
-  stats::glm(f, data = getTaskData(.task, .subset), model = FALSE, family = binomial(link = link), weights = .weights, ...)
+  stats::glm(f, data = getTaskData(.task, .subset), family = binomial(link = link), weights = .weights, ...)
 }
 
 #' @export

--- a/R/RLearner_classif_binomial.R
+++ b/R/RLearner_classif_binomial.R
@@ -11,7 +11,7 @@ makeRLearner.classif.binomial = function() {
     properties = c("twoclass", "numerics", "factors", "prob", "weights"),
     name = "Binomial Regression",
     short.name = "binomial",
-    note = "Delegates to `glm` with freely choosable binomial link function via learner parameter `link`. Against the original default in the stats package, model is set to FALSE, due to memory reasons."
+    note = "Delegates to `glm` with freely choosable binomial link function via learner parameter `link`. The default for 'model' in the original learner is FALSE, due to memory reasons."
   )
 }
 


### PR DESCRIPTION
Maria was suggesting for add the model par to the train function signature in #1370. However, I was wondering why we set model = FALSE hardcoded inside the glm function call within the train function in the first place, since it's first - against the default value, and second - would make the param obsolete at all or did I get anything wrong here?
However I removed it and it works fine now as far as I can see.