### PR TITLE
Kendalls tau and spearmans rho as ranking based regression measures

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -402,7 +402,7 @@ tau = makeMeasure(id = "tau", minimize = FALSE, best = 1, worst = -1,
   }
 )
 
-#' @export measureTAU
+#' @export measureTau
 #' @rdname measures
 #' @format none
 measureTau = function(truth, response) {
@@ -422,7 +422,7 @@ rho = makeMeasure(id = "rho", minimize = FALSE, best = 1, worst = -1,
   }
 )
 
-#' @export measureRHO
+#' @export measureRho
 #' @rdname measures
 #' @format none
 measureRho = function(truth, response) {

--- a/R/measures.R
+++ b/R/measures.R
@@ -398,14 +398,14 @@ tau = makeMeasure(id = "tau", minimize = FALSE, best = 1, worst = -1,
   note = "Defined as: Kendall's tau correlation between truth and response. Only looks at the order.
   See Rosset et al.: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.95.1398&rep=rep1&type=pdf.",
   fun = function(task, model, pred, feats, extra.args) {
-    measureTAU(pred$data$truth, pred$data$response)
+    measureTau(pred$data$truth, pred$data$response)
   }
 )
 
 #' @export measureTAU
 #' @rdname measures
 #' @format none
-measureTAU = function(truth, response) {
+measureTau = function(truth, response) {
   cor(truth, response, use = "na.or.complete", method = "kendall")
 }
 
@@ -418,14 +418,14 @@ rho = makeMeasure(id = "rho", minimize = FALSE, best = 1, worst = -1,
   note = "Defined as: Spearman's rho correlation between truth and response. Only looks at the order. 
   See Rosset et al.: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.95.1398&rep=rep1&type=pdf.",
   fun = function(task, model, pred, feats, extra.args) {
-    measureRHO(pred$data$truth, pred$data$response)
+    measureRho(pred$data$truth, pred$data$response)
   }
 )
 
 #' @export measureRHO
 #' @rdname measures
 #' @format none
-measureRHO = function(truth, response) {
+measureRho = function(truth, response) {
   cor(truth, response, use = "na.or.complete", method = "spearman")
 }
 

--- a/R/measures.R
+++ b/R/measures.R
@@ -389,6 +389,46 @@ rmsle = makeMeasure(id = "rmsle", minimize = TRUE, best = 0, worst = Inf,
   }
 )
 
+#' @export tau
+#' @rdname measures
+#' @format none
+tau = makeMeasure(id = "tau", minimize = FALSE, best = 1, worst = -1,
+  properties = c("regr", "req.pred", "req.truth"),
+  name = "Kendall's tau",
+  note = "Defined as: Kendall's tau correlation between truth and response. Only looks at the order.
+  See Rosset et al.: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.95.1398&rep=rep1&type=pdf.",
+  fun = function(task, model, pred, feats, extra.args) {
+    measureTAU(pred$data$truth, pred$data$response)
+  }
+)
+
+#' @export measureTAU
+#' @rdname measures
+#' @format none
+measureTAU = function(truth, response) {
+  cor(truth, response, use = "na.or.complete", method = "kendall")
+}
+
+#' @export rho
+#' @rdname measures
+#' @format none
+rho = makeMeasure(id = "rho", minimize = FALSE, best = 1, worst = -1,
+  properties = c("regr", "req.pred", "req.truth"),
+  name = "Spearman's rho",
+  note = "Defined as: Spearman's rho correlation between truth and response. Only looks at the order. 
+  See Rosset et al.: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.95.1398&rep=rep1&type=pdf.",
+  fun = function(task, model, pred, feats, extra.args) {
+    measureRHO(pred$data$truth, pred$data$response)
+  }
+)
+
+#' @export measureRHO
+#' @rdname measures
+#' @format none
+measureRHO = function(truth, response) {
+  cor(truth, response, use = "na.or.complete", method = "spearman")
+}
+
 ###############################################################################
 ### classif multi ###
 ###############################################################################

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -294,6 +294,16 @@ test_that("check measure calculations", {
   rmsle.perf = performance(pred.regr, measures = rmsle, model = mod.regr)
   expect_equal(rmsle.test, rmsle$fun(pred = pred.regr))
   expect_equal(rmsle.test, as.numeric(rmsle.perf))
+  #tau
+  tau.test = 1
+  tau.perf = performance(pred.regr, measures = tau, model = mod.regr)
+  expect_equal(tau.test, tau$fun(pred = pred.regr))
+  expect_equal(tau.test, as.numeric(tau.perf))
+  #rho
+  rho.test = 1
+  rho.perf = performance(pred.regr, measures = rho, model = mod.regr)
+  expect_equal(rho.test, rho$fun(pred = pred.regr))
+  expect_equal(rho.test, as.numeric(rho.perf))
 
   #test multiclass measures
 


### PR DESCRIPTION
If one is mainly interested, if the order of the predicted values is correct one can use Kendalls tau and Spearmans rho as ranking based regression measures, see [Rosset et al.](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.95.1398&rep=rep1&type=pdf)

This is something similar to the AUC (I originally searched something like AUC for regression).

This can be especially interesting when you want to look if your trained model orders the observations correctly although e.g. mse is quite bad, because of outliers or wrong scale, that could be potentially solved by transforming the values before or after your training process. 
So this could be interesting as extra measure to e.g. the mse (which is strongly connected to pearson's correlation coefficient).

Implementation details:
- `use = "na.or.complete"`ensures, that something is calculated even if there are NA, if n-1 have at least one NA, it returns NA.
- The test is a bit trivial, but testing this is maybe trivial, too. ;)
- There is also a rescaled variant between 0 and 1, but I would prefer this

There are also some visual tools, see the paper for more information.