### PR TITLE
New parameter 'method' for classif.plsdaCaret. This fixes #1544

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 * getOOBPreds: get out-of-bag predictions from trained models for learners that store them -- these learners have the new "oobpreds" property
 * listTaskTypes, listLearnerProperties
 
+## learners - general
+* classif.plsdaCaret: added parameter "method".
+
+
 ## learners - removed
 * {classif,regr}.avNNet: no longer necessary, mlr contains a bagging wrapper
 

--- a/R/RLearner_classif_plsdaCaret.R
+++ b/R/RLearner_classif_plsdaCaret.R
@@ -4,7 +4,9 @@ makeRLearner.classif.plsdaCaret = function() {
     package = "caret",
     par.set = makeParamSet(
       makeIntegerLearnerParam(id = "ncomp", default = 2, lower = 1),
-      makeDiscreteLearnerParam(id = "probMethod", values = c("softmax", "Bayes"), default = "softmax")
+      makeDiscreteLearnerParam(id = "probMethod", values = c("softmax", "Bayes"), default = "softmax"),
+      makeDiscreteLearnerParam(id = "method", default = "kernelpls",
+                               values = c("kernelpls", "widekernelpls", "simpls", "oscorespls"))
     ),
     properties = c("numerics", "prob", "twoclass"),
     name = "Partial Least Squares (PLS) Discriminant Analysis",
@@ -15,7 +17,7 @@ makeRLearner.classif.plsdaCaret = function() {
 #' @export
 trainLearner.classif.plsdaCaret = function(.learner, .task, .subset, .weights, ...) {
   d = getTaskData(.task, .subset, target.extra = TRUE)
-  caret::plsda(d$data, d$target, method = "oscorespls", ...)
+  caret::plsda(d$data, d$target, ...)
 }
 
 #' @export

--- a/tests/testthat/test_classif_plsdaCaret.R
+++ b/tests/testthat/test_classif_plsdaCaret.R
@@ -5,7 +5,8 @@ test_that("classif_plsdaCaret", {
   parset.list = list(
     list(),
     list(ncomp = 4),
-    list(probMethod = "Bayes")
+    list(probMethod = "Bayes"),
+    list(method = "oscorespls")
   )
 
   old.predicts.list = list()


### PR DESCRIPTION
Make the `method` parameter and use the package's default of `kernelpls`. See #1544 