### PR TITLE
Closes #1473. Simpler feature filter for base tests

### DIFF
--- a/tests/testthat/test_base_generateFilterValuesData.R
+++ b/tests/testthat/test_base_generateFilterValuesData.R
@@ -6,41 +6,41 @@ context("filterFeatures")
 
 test_that("filterFeatures", {
   ns = getTaskFeatureNames(binaryclass.task)
-  f = filterFeatures(binaryclass.task, method = "anova.test", select = "threshold", threshold = -Inf)
+  f = filterFeatures(binaryclass.task, method = "variance", select = "threshold", threshold = -Inf)
   expect_equal(f, binaryclass.task)
 
-  feat.imp.old = suppressWarnings(getFilterValues(binaryclass.task))
+  feat.imp.old = suppressWarnings(generateFilterValuesData(binaryclass.task))
   expect_data_frame(feat.imp.old$data, types = c("character", "numeric"), nrow = length(ns), ncols = 3,
     col.names = "named")
   expect_equal(ns, feat.imp.old$data$name)
 
-  feat.imp.new = generateFilterValuesData(binaryclass.task)
+  feat.imp.new = suppressWarnings(generateFilterValuesData(binaryclass.task))
   expect_data_frame(feat.imp.new$data, types = c("character", "numeric"), nrow = length(ns), ncols = 3,
     col.names = "named")
   expect_equal(names(feat.imp.new$data), c("name", "type", "randomForestSRC.rfsrc"))
   expect_equal(ns, feat.imp.new$data$name)
 
-  feat.imp.old = suppressWarnings(getFilterValues(binaryclass.task, method = "anova.test"))
+  feat.imp.old = suppressWarnings(generateFilterValuesData(binaryclass.task, method = "variance"))
   expect_data_frame(feat.imp.old$data, types = c("character", "numeric"), nrow = length(ns), ncols = 3,
     col.names = "named")
   expect_equal(ns, feat.imp.old$data$name)
-  f = filterFeatures(binaryclass.task, method = "anova.test", abs = 5L)
+  f = filterFeatures(binaryclass.task, method = "variance", abs = 5L)
   expect_true(setequal(getTaskFeatureNames(f), head(sortByCol(feat.imp.old$data, "val", asc = FALSE), 5L)$name))
-  # now check that we get the same result by operating on getFilterValues
-  feat.imp.old = suppressWarnings(getFilterValues(binaryclass.task, method = "anova.test"))
+  # now check that we get the same result by operating on generateFilterValuesData
+  feat.imp.old = suppressWarnings(generateFilterValuesData(binaryclass.task, method = "variance"))
   ff = filterFeatures(binaryclass.task, fval = feat.imp.old, abs = 5L)
   expect_equal(f, ff)
 
-  feat.imp.new = generateFilterValuesData(binaryclass.task, method = "anova.test")
+  feat.imp.new = generateFilterValuesData(binaryclass.task, method = "variance")
   expect_data_frame(feat.imp.new$data, types = c("character", "numeric"), nrow = length(ns), ncols = 3,
     col.names = "named")
-  expect_equal(names(feat.imp.new$data), c("name", "type", "anova.test"))
+  expect_equal(names(feat.imp.new$data), c("name", "type", "variance"))
   expect_equal(ns, feat.imp.new$data$name)
-  f = filterFeatures(binaryclass.task, method = "anova.test", abs = 5L)
+  f = filterFeatures(binaryclass.task, method = "variance", abs = 5L)
   expect_true(setequal(getTaskFeatureNames(f),
-      head(sortByCol(feat.imp.new$data, "anova.test", asc = FALSE), 5L)$name))
+      head(sortByCol(feat.imp.new$data, "variance", asc = FALSE), 5L)$name))
   # now check that we get the same result by operating on generateFilterValuesData
-  feat.imp.new = generateFilterValuesData(binaryclass.task, method = "anova.test")
+  feat.imp.new = generateFilterValuesData(binaryclass.task, method = "variance")
   ff = filterFeatures(binaryclass.task, fval = feat.imp.new, abs = 5L)
   expect_equal(f, ff)
 
@@ -60,7 +60,7 @@ test_that("filterFeatures", {
 })
 
 test_that("plotFilterValues", {
-  fv = generateFilterValuesData(binaryclass.task, method = "anova.test")
+  fv = generateFilterValuesData(binaryclass.task, method = "variance")
   plotFilterValues(fv)
   dir = tempdir()
   path = paste0(dir, "/test.svg")
@@ -69,7 +69,7 @@ test_that("plotFilterValues", {
   expect_that(length(XML::getNodeSet(doc, black.bar.xpath, ns.svg)), equals(20))
   ## plotFilterValuesGGVIS(fv)
 
-  fv2 = generateFilterValuesData(binaryclass.task, method = c("anova.test", "randomForestSRC.rfsrc"))
+  fv2 = generateFilterValuesData(binaryclass.task, method = c("variance", "randomForestSRC.rfsrc"))
   plotFilterValues(fv2)
   ggsave(path)
   doc = XML::xmlParse(path)
@@ -100,7 +100,7 @@ test_that("args are passed down to filter methods", { # we had an issue here, se
   f1 = generateFilterValuesData(task, method = "variance", na.rm = FALSE)
   f2 = generateFilterValuesData(task, method = "variance", na.rm = TRUE)
   f3 = generateFilterValuesData(task, method = "variance", more.args = list(variance = list(na.rm = TRUE)))
-  f4 = generateFilterValuesData(task, method = c("anova.test", "variance"), more.args = list(variance = list(na.rm = TRUE)))
+  f4 = generateFilterValuesData(task, method = c("variance", "variance"), more.args = list(variance = list(na.rm = TRUE)))
 
   expect_true(is.na(f1$data$variance[1L]))
   expect_false(is.na(f2$data$variance[1L]))
@@ -109,7 +109,7 @@ test_that("args are passed down to filter methods", { # we had an issue here, se
 })
 
 test_that("errors for unsupported task and feature types", {
-  expect_error(generateFilterValuesData(multiclass.task, method = c("mrmr", "anova.test", "linear.correlation")), "Filter(s) 'mrmr', 'linear.correlation' not compatible with task of type 'classif'", fixed = TRUE)
+  expect_error(generateFilterValuesData(multiclass.task, method = c("mrmr", "variance", "linear.correlation")), "Filter(s) 'mrmr', 'linear.correlation' not compatible with task of type 'classif'", fixed = TRUE)
   expect_error(generateFilterValuesData(regr.task, method = c("mrmr", "carscore")), "Filter(s) 'mrmr', 'carscore' not compatible with features of type 'factors', and 'factors' respectively", fixed = TRUE)
   expect_error(generateFilterValuesData(regr.task, method = "carscore"), "Filter(s) 'carscore' not compatible with features of type 'factors' respectively", fixed = TRUE)
 })

--- a/tests/testthat/test_base_generateFilterValuesData.R
+++ b/tests/testthat/test_base_generateFilterValuesData.R
@@ -25,7 +25,7 @@ test_that("filterFeatures", {
     col.names = "named")
   expect_equal(ns, feat.imp.old$data$name)
   f = filterFeatures(binaryclass.task, method = "variance", abs = 5L)
-  expect_true(setequal(getTaskFeatureNames(f), head(sortByCol(feat.imp.old$data, "val", asc = FALSE), 5L)$name))
+  expect_true(setequal(getTaskFeatureNames(f), head(sortByCol(feat.imp.old$data, "variance", asc = FALSE), 5L)$name))
   # now check that we get the same result by operating on generateFilterValuesData
   feat.imp.old = suppressWarnings(generateFilterValuesData(binaryclass.task, method = "variance"))
   ff = filterFeatures(binaryclass.task, fval = feat.imp.old, abs = 5L)

--- a/tests/testthat/test_base_generateFilterValuesData.R
+++ b/tests/testthat/test_base_generateFilterValuesData.R
@@ -100,7 +100,7 @@ test_that("args are passed down to filter methods", { # we had an issue here, se
   f1 = generateFilterValuesData(task, method = "variance", na.rm = FALSE)
   f2 = generateFilterValuesData(task, method = "variance", na.rm = TRUE)
   f3 = generateFilterValuesData(task, method = "variance", more.args = list(variance = list(na.rm = TRUE)))
-  f4 = generateFilterValuesData(task, method = c("variance", "variance"), more.args = list(variance = list(na.rm = TRUE)))
+  f4 = generateFilterValuesData(task, method = c("univariate.model.score", "variance"), more.args = list(variance = list(na.rm = TRUE)))
 
   expect_true(is.na(f1$data$variance[1L]))
   expect_false(is.na(f2$data$variance[1L]))


### PR DESCRIPTION
See #1473 
RFast feature filters were replaced by the simpler variance-filter in our base tests.
I also replaced the deprecated `getFilterValues` by `generateFilterValuesData`, where needed.