### PR TITLE
get, has and list measure Properties

### DIFF
--- a/R/Measure.R
+++ b/R/Measure.R
@@ -36,6 +36,7 @@
 #'     \item{multilabel}{Is the measure applicable for multilabel classification?}
 #'     \item{regr}{Is the measure applicable for regression?}
 #'     \item{surv}{Is the measure applicable for survival?}
+#'     \item{cluster}{Is the measure applicable for cluster?}
 #'     \item{costsens}{Is the measure applicable for cost-sensitive learning?}
 #'     \item{req.pred}{Is prediction object required in calculation? Usually the case.}
 #'     \item{req.truth}{Is truth column required in calculation? Usually the case.}

--- a/R/Measure_properties.R
+++ b/R/Measure_properties.R
@@ -1,0 +1,43 @@
+#' @title Query properties of measures.
+#'
+#' @description
+#' Properties can be accessed with \code{getMeasureProperties(measure)}, which returns a
+#' character vector.
+#'
+#' The measure properties are defined in \code{\link{Measure}}
+#' @template arg_measure
+#' @param props [\code{character}]\cr
+#'   Vector of properties to query.
+#' @return \code{getMeasureProperties} returns a character vector with measure properties.
+#'  \code{hasMeasureProperties} returns a logical vector of the same length as \code{props}.
+#' @name MeasureProperties
+#' @rdname MeasureProperties
+#' @aliases getMeasureProperties hasMeasureProperties
+NULL
+
+#' @rdname MeasureProperties
+#' @export
+getMeasureProperties = function(measure) {
+  assertClass(measure, classes = "Measure")
+  measure$properties
+}
+
+#' @rdname MeasureProperties
+#' @export
+hasMeasureProperties = function(measure, props) {
+  assertClass(measure, classes = "Measure")
+  assertSubset(props, listMeasureProperties())
+  props %in% getMeasureProperties(measure)
+}
+
+#' @title List the supported measure properties.
+#'
+#' @description
+#'   This is useful for determining which measure properties are available.
+#'
+#' @return [\code{character}].
+#'
+#' @export
+listMeasureProperties = function() {
+  mlr$measure.properties
+}

--- a/R/Measure_properties.R
+++ b/R/Measure_properties.R
@@ -33,7 +33,7 @@ hasMeasureProperties = function(measure, props) {
 #' @title List the supported measure properties.
 #'
 #' @description
-#'   This is useful for determining which measure properties are available.
+#' This is useful for determining which measure properties are available.
 #'
 #' @return [\code{character}].
 #'

--- a/R/listMeasures.R
+++ b/R/listMeasures.R
@@ -18,7 +18,7 @@
 listMeasures = function(obj, properties = character(0L), create = FALSE) {
   if (!missing(obj))
     assert(checkCharacter(obj), checkClass(obj, "Task"))
-  assertCharacter(properties, any.missing = FALSE)
+  assertSubset(properties, listMeasureProperties())
   assertFlag(create)
   UseMethod("listMeasures")
 }
@@ -49,7 +49,7 @@ listMeasures.Task = function(obj, properties = character(0L), create = FALSE) {
 
 listMeasures2 = function(properties = character(0L), create = FALSE) {
   ee = as.environment("package:mlr")
-  res = Filter(function(x) inherits(x, "Measure") && all(properties %in% x$properties), as.list(ee))
+  res = Filter(function(x) inherits(x, "Measure") && all(properties %in% getMeasureProperties(x)), as.list(ee))
   if (create)
     res
   else

--- a/R/performance.R
+++ b/R/performance.R
@@ -44,7 +44,7 @@ performance = function(pred, measures, task = NULL, model = NULL, feats = NULL) 
 
 doPerformanceIteration = function(measure, pred = NULL, task = NULL, model = NULL, td = NULL, feats = NULL) {
   m = measure
-  props = m$properties
+  props = getMeasureProperties(m)
   if ("req.pred" %in% props) {
     if (is.null(pred))
       stopf("You need to pass pred for measure %s!", m$id)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,3 +29,6 @@ mlr$learner.properties = list(
   costsens   = c("numerics", "factors", "ordered", "missings", "weights", "prob", "twoclass", "multiclass")
 )
 mlr$learner.properties$any = unique(unlist(mlr$learner.properties))
+
+### Measure properties
+mlr$measure.properties = c("classif", "classif.multi", "multilabel", "regr", "surv", "cluster" ,"costsens", "req.pred", "req.truth", "req.task", "req.feat", "req.prob")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -31,4 +31,4 @@ mlr$learner.properties = list(
 mlr$learner.properties$any = unique(unlist(mlr$learner.properties))
 
 ### Measure properties
-mlr$measure.properties = c("classif", "classif.multi", "multilabel", "regr", "surv", "cluster" ,"costsens", "req.pred", "req.truth", "req.task", "req.feat", "req.prob")
+mlr$measure.properties = c("classif", "classif.multi", "multilabel", "regr", "surv", "cluster" ,"costsens", "req.pred", "req.truth", "req.task", "req.feats", "req.model", "req.prob")

--- a/tests/testthat/test_base_PreprocWrapperCaret.R
+++ b/tests/testthat/test_base_PreprocWrapperCaret.R
@@ -1,32 +1,30 @@
 context("PreprocWrapperCaret")
 
-# FIXME: the whole file needs to be enabled again, see issue #746
+test_that("basic PreprocWrapperCaret works", {
+  lrn1 = makeLearner("classif.rpart")
+  lrn2 = makePreprocWrapperCaret(lrn1)
+  m = train(lrn2, multiclass.task, subset = multiclass.train.inds)
+  p = predict(m, subsetTask(multiclass.task, subset = multiclass.test.inds))
+  perf = performance(p, mmce)
+  expect_true(perf < 0.1)
 
-# test_that("basic PreprocWrapperCaret works", {
-#   lrn1 = makeLearner("classif.rpart")
-#   lrn2 = makePreprocWrapperCaret(lrn1)
-#   m = train(lrn2, multiclass.task, subset = multiclass.train.inds)
-#   p = predict(m, subsetTask(multiclass.task, subset = multiclass.test.inds))
-#   perf = performance(p, mmce)
-#   expect_true(perf < 0.1)
+  lrn3 = makePreprocWrapperCaret(lrn1, ppc.BoxCox = TRUE, ppc.YeoJohnson = FALSE, ppc.pca = TRUE, ppc.pcaComp = 2, ppc.scale = TRUE, ppc.center = TRUE)
+  m = train(lrn3, multiclass.task, subset = multiclass.train.inds)
+  ctrl = m$learner.model$control
+  p = predict(m, subsetTask(multiclass.task, subset = multiclass.test.inds))
+  perf2 = performance(p, mmce)
+  expect_true(perf2 > perf)
 
-#   lrn3 = makePreprocWrapperCaret(lrn1, ppc.BoxCox = TRUE, ppc.YeoJohnson = FALSE, ppc.pca = TRUE, ppc.pcaComp = 2, ppc.scale = TRUE, ppc.center = TRUE)
-#   m = train(lrn3, multiclass.task, subset = multiclass.train.inds)
-#   ctrl = m$learner.model$control
-#   p = predict(m, subsetTask(multiclass.task, subset = multiclass.test.inds))
-#   perf2 = performance(p, mmce)
-#   expect_true(perf2 > perf)
+  mod = caret::preProcess(x = multiclass.df[multiclass.train.inds,1:4], method = c("BoxCox", "pca", "scale", "center"), pcaComp = 2)
+  mod$method = mod$method[order(names(mod$method))]
+  ctrl$method = ctrl$method[order(names(ctrl$method))]
+  mod$call = NULL
+  ctrl$call = NULL
+  expect_equal(mod, ctrl)
+})
 
-#   mod = caret::preProcess(x = multiclass.df[multiclass.train.inds,1:4], method = c("BoxCox", "pca", "scale", "center"), pcaComp = 2)
-#   mod$method = mod$method[order(names(mod$method))]
-#   ctrl$method = ctrl$method[order(names(ctrl$method))]
-#   mod$call = NULL
-#   ctrl$call = NULL
-#   expect_equal(mod, ctrl)
-# })
-
-# test_that("PreprocWrapperCaret supports missing values", {
-#   lrn1 = makeLearner("classif.svm")
-#   lrn2 = makePreprocWrapperCaret(lrn1, ppc.knnImpute = TRUE)
-#   expect_true(hasLearnerProperties(lrn2, props = "missings"))
-# })
+test_that("PreprocWrapperCaret supports missing values", {
+  lrn1 = makeLearner("classif.svm")
+  lrn2 = makePreprocWrapperCaret(lrn1, ppc.knnImpute = TRUE)
+  expect_true(hasLearnerProperties(lrn2, props = "missings"))
+})

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -789,11 +789,17 @@ test_that("getDefaultMeasure", {
 test_that("measure properties", {
   #hasMeasureProps yields correct properties
   expect_true(all(vlapply(listMeasures(create = TRUE),
-    function(m) all(hasMeasureProperties(m, m$properties)))))
+    function(m) {
+      res = hasMeasureProperties(m, m$properties)
+      all(res) & length(res) > 0
+      })))
   props = listMeasureProperties()
   #all props exist in mlr$measure.properties
   expect_true(all(vlapply(listMeasures(create = TRUE),
-    function(m) all(getMeasureProperties(m) %in% props))))
+    function(m) {
+      res = all(getMeasureProperties(m) %in% props)
+      all(res) & length(res) > 0
+    })))
 })
 
 test_that("measures quickcheck", {

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -786,6 +786,16 @@ test_that("getDefaultMeasure", {
   expect_equal(mmce, getDefaultMeasure("classif"))
 })
 
+test_that("measure properties", {
+  #hasMeasureProps yields correct properties
+  expect_true(all(vlapply(listMeasures(create = TRUE),
+    function(m) all(hasMeasureProperties(m, m$properties)))))
+  props = listMeasureProperties()
+  #all props exist in mlr$measure.properties
+  expect_true(all(vlapply(listMeasures(create = TRUE),
+    function(m) all(getMeasureProperties(m) %in% props))))
+})
+
 test_that("measures quickcheck", {
   skip_on_cran()
   options(warn = 2)


### PR DESCRIPTION
Fixes #1508.

I don't think splitting measure properties by task type makes much sense as only `req.prob` is not possible for all task types.

Also `cluster` property was missing in the description of Measure

