### PR TITLE
Seperate task help pages, closes #1565

### DIFF
--- a/R/ClassifTask.R
+++ b/R/ClassifTask.R
@@ -1,5 +1,7 @@
+#' @title Create a classification task.
+#' @inherit Task description params return
+#' @seealso \code{\link{Task}}
 #' @export
-#' @rdname Task
 makeClassifTask = function(id = deparse(substitute(data)), data, target, weights = NULL, blocking = NULL, positive = NA_character_, fixup.data = "warn", check.data = TRUE) {
   assertString(id)
   assertDataFrame(data)

--- a/R/ClusterTask.R
+++ b/R/ClusterTask.R
@@ -1,4 +1,6 @@
-#' @rdname Task
+#' @title Create a cluster task.
+#' @inherit Task description params return
+#' @seealso \code{\link{Task}}
 #' @export
 makeClusterTask = function(id = deparse(substitute(data)), data, weights = NULL, blocking = NULL, fixup.data = "warn", check.data = TRUE) {
   assertString(id)

--- a/R/CostSensTask.R
+++ b/R/CostSensTask.R
@@ -1,6 +1,8 @@
-#' @export
-#' @rdname Task
+#' @title Create a cost-sensitive classification task.
+#' @inherit Task description params return
+#' @seealso \code{\link{Task}}
 #' @family costsens
+#' @export
 makeCostSensTask = function(id = deparse(substitute(data)), data, costs, blocking = NULL, fixup.data = "warn", check.data = TRUE) {
   assertString(id)
   assertDataFrame(data)

--- a/R/MultilabelTask.R
+++ b/R/MultilabelTask.R
@@ -1,5 +1,11 @@
+#' @title Create a multilabel task.
+#' @inherit Task description params return
+#' @section Note:
+#' For multilabel classification we assume that the presence of labels is encoded via logical
+#' columns in \code{data}. The name of the column specifies the name of the label. \code{target}
+#' is then a char vector that points to these columns.
+#' @seealso \code{\link{Task}}
 #' @export
-#' @rdname Task
 makeMultilabelTask = function(id = deparse(substitute(data)), data, target, weights = NULL,
   blocking = NULL, positive = NA_character_, fixup.data = "warn", check.data = TRUE) {
   assertString(id)

--- a/R/RegrTask.R
+++ b/R/RegrTask.R
@@ -1,5 +1,7 @@
+#' @title Create a regression task.
+#' @inherit Task description params return
+#' @seealso \code{\link{Task}}
 #' @export
-#' @rdname Task
 makeRegrTask = function(id = deparse(substitute(data)), data, target, weights = NULL, blocking = NULL, fixup.data = "warn", check.data = TRUE) {
   assertString(id)
   assertDataFrame(data)

--- a/R/SurvTask.R
+++ b/R/SurvTask.R
@@ -1,9 +1,6 @@
-#' @rdname Task
-#' @param censoring [\code{character(1)}]\cr
-#'  Censoring type. Allowed choices are \dQuote{rcens} for right censored data (default),
-#'  \dQuote{lcens} for left censored and \dQuote{icens} for interval censored data using
-#'  the \dQuote{interval2} format.
-#'  See \code{\link[survival]{Surv}} for details.
+#' @title Create a survival task.
+#' @inherit Task description params return
+#' @seealso \code{\link{Task}}
 #' @export
 makeSurvTask = function(id = deparse(substitute(data)), data, target, censoring = "rcens", weights = NULL, blocking = NULL, fixup.data = "warn", check.data = TRUE) {
   assertString(id)

--- a/R/Task.R
+++ b/R/Task.R
@@ -6,26 +6,6 @@
 #' the type of the task.
 #' It also contains a description object detailing further aspects of the data.
 #'
-#' Useful operators are: \code{\link{getTaskFormula}},
-#' \code{\link{getTaskFeatureNames}},
-#' \code{\link{getTaskData}},
-#' \code{\link{getTaskTargets}}, and
-#' \code{\link{subsetTask}}.
-#'
-#' Object members:
-#' \describe{
-#' \item{env [\code{environment}]}{Environment where data for the task are stored.
-#'   Use \code{\link{getTaskData}} in order to access it.}
-#' \item{weights [\code{numeric}]}{See argument. \code{NULL} if not present.}
-#' \item{blocking [\code{factor}]}{See argument. \code{NULL} if not present.}
-#' \item{task.desc [\code{\link{TaskDesc}}]}{Encapsulates further information about the task.}
-#' }
-#'
-#' Notes:
-#' For multilabel classification we assume that the presence of labels is encoded via logical
-#' columns in \code{data}. The name of the column specifies the name of the label. \code{target}
-#' is then a char vector that points to these columns.
-#'
 #' @param id [\code{character(1)}]\cr
 #'   Id string for object.
 #'   Default is the name of the R variable passed to \code{data}.
@@ -70,10 +50,27 @@
 #'   Should sanity of data be checked initially at task creation?
 #'   You should have good reasons to turn this off (one might be speed).
 #'   Default is \code{TRUE}.
+#' @param censoring [\code{character(1)}]\cr
+#'  Censoring type. Allowed choices are \dQuote{rcens} for right censored data (default),
+#'  \dQuote{lcens} for left censored and \dQuote{icens} for interval censored data using
+#'  the \dQuote{interval2} format.
+#'  See \code{\link[survival]{Surv}} for details.
 #' @return [\code{\link{Task}}].
+#' @section Object members:
+#' \describe{
+#' \item{env [\code{environment}]}{Environment where data for the task are stored.
+#'   Use \code{\link{getTaskData}} in order to access it.}
+#' \item{weights [\code{numeric}]}{See argument. \code{NULL} if not present.}
+#' \item{blocking [\code{factor}]}{See argument. \code{NULL} if not present.}
+#' \item{task.desc [\code{\link{TaskDesc}}]}{Encapsulates further information about the task.}
+#' }
+#' @section Useful operators:
+#' \code{\link{getTaskFormula}},
+#' \code{\link{getTaskFeatureNames}},
+#' \code{\link{getTaskData}},
+#' \code{\link{getTaskTargets}}, and
+#' \code{\link{subsetTask}}.
 #' @name Task
-#' @rdname Task
-#' @aliases ClassifTask RegrTask SurvTask CostSensTask ClusterTask MultilabelTask
 #' @examples
 #' if (requireNamespace("mlbench")) {
 #'   library(mlbench)

--- a/R/Task_operators.R
+++ b/R/Task_operators.R
@@ -357,7 +357,7 @@ recodeSurvivalTimes = function(y, from, to) {
 #'
 #' Retuns \dQuote{NULL} if the task is not of type \dQuote{costsens}.
 #'
-#' @param task [\code{\link{CostSensTask}}]\cr
+#' @param task [\code{\link{makeCostSensTask}}]\cr
 #'   The task.
 #' @template arg_subset
 #' @return [\code{matrix} | \code{NULL}].

--- a/R/estimateResidualVariance.R
+++ b/R/estimateResidualVariance.R
@@ -6,7 +6,7 @@
 #'
 #' @param x [\code{\link{Learner}} or \code{\link{WrappedModel}}]\cr
 #'   Learner or wrapped model.
-#' @param task [\code{\link{RegrTask}}]\cr
+#' @param task [\code{\link{makeRegrTask}}]\cr
 #'   Regression task.
 #'   If missing, \code{data} and \code{target} must be supplied.
 #' @param data [\code{data.frame}]\cr


### PR DESCRIPTION
I separated the help pages for the different task types as specified in #1565 
Task specific information for the survival and the multilabel tasks are now in their specific help pages.
Also I moved some stuff from the description into their own section, so this only shows up on the
"main" task help page.