### PR TITLE
Small hyperparameter naming fixes

### DIFF
--- a/R/RLearner_classif_cvglmnet.R
+++ b/R/RLearner_classif_cvglmnet.R
@@ -7,7 +7,6 @@ makeRLearner.classif.cvglmnet = function() {
       makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1),
       makeIntegerLearnerParam(id = "nfolds", default = 10L, lower = 3L),
       makeDiscreteLearnerParam(id = "type.measure", values = c("deviance", "class", "auc", "mse", "mae"), default = "deviance"),
-      makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
       makeDiscreteLearnerParam(id = "s", values = c("lambda.1se", "lambda.min"), default = "lambda.1se", when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),
       makeNumericLearnerParam(id = "lambda.min.ratio", lower = 0, upper = 1),

--- a/R/RLearner_classif_multinom.R
+++ b/R/RLearner_classif_multinom.R
@@ -12,9 +12,8 @@ makeRLearner.classif.multinom = function() {
       makeNumericLearnerParam(id = "rang", default = 0.7),
       makeNumericLearnerParam(id = "decay", default = 0),
       makeLogicalLearnerParam(id = "trace", default = TRUE, tunable = FALSE),
-      ## FIXME_PK: Why are abstol and reltol written with 2 "l"?
-      makeNumericLearnerParam(id = "abstoll", default = 1.0e-4),
-      makeNumericLearnerParam(id = "reltoll", default = 1.0e-8)
+      makeNumericLearnerParam(id = "abstol", default = 1.0e-4),
+      makeNumericLearnerParam(id = "reltol", default = 1.0e-8)
     ),
     properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights"),
     name = "Multinomial Regression",

--- a/R/RLearner_classif_nnet.R
+++ b/R/RLearner_classif_nnet.R
@@ -18,9 +18,8 @@ makeRLearner.classif.nnet = function() {
       makeLogicalLearnerParam(id = "Hess", default = FALSE),
       makeLogicalLearnerParam(id = "trace", default = TRUE, tunable = FALSE),
       makeIntegerLearnerParam(id = "MaxNWts", default = 1000L, lower = 1L),
-      ## FIXME_PK: Why are abstol and reltol written with 2 "l"?
-      makeNumericLearnerParam(id = "abstoll", default = 1.0e-4),
-      makeNumericLearnerParam(id = "reltoll", default = 1.0e-8)
+      makeNumericLearnerParam(id = "abstol", default = 1.0e-4),
+      makeNumericLearnerParam(id = "reltol", default = 1.0e-8)
     ),
     par.vals = list(size = 3L),
     properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights"),

--- a/R/RLearner_classif_rda.R
+++ b/R/RLearner_classif_rda.R
@@ -16,10 +16,8 @@ makeRLearner.classif.rda = function() {
       makeNumericLearnerParam(id = "zero.temp", default = 0.01, lower = 0, requires = quote(simAnn==TRUE || schedule==1)),
       makeNumericLearnerParam(id = "alpha", default = 2, lower = 1, requires = quote(simAnn==TRUE || schedule==2)),
       makeIntegerLearnerParam(id = "K", default = 100L, lower = 1L, requires = quote(simAnn==TRUE || schedule==2)),
-      makeDiscreteLearnerParam(id = "kernel", default = "triangular",
-        values = list("rectangular", "triangular", "epanechnikov", "biweight", "triweight", "cos", "inv", "gaussian")),
       makeLogicalLearnerParam(id = "trafo", default = TRUE),
-      makeLogicalLearnerParam(id = "SimAnn", default = FALSE),
+      makeLogicalLearnerParam(id = "simAnn", default = FALSE),
       makeLogicalLearnerParam(id = "estimate.error", default = TRUE)
     ),
     par.vals = list(estimate.error = FALSE),

--- a/R/RLearner_regr_cvglmnet.R
+++ b/R/RLearner_regr_cvglmnet.R
@@ -8,7 +8,6 @@ makeRLearner.regr.cvglmnet = function() {
       makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1),
       makeIntegerLearnerParam(id = "nfolds", default = 10L, lower = 3L),
       makeDiscreteLearnerParam(id = "type.measure", values = c("mse", "mae"), default = "mse"),
-      makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
       makeDiscreteLearnerParam(id = "s", values = c("lambda.1se", "lambda.min"), default = "lambda.1se", when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),
       makeNumericLearnerParam(id = "lambda.min.ratio", lower = 0, upper = 1),

--- a/R/RLearner_regr_nnet.R
+++ b/R/RLearner_regr_nnet.R
@@ -17,9 +17,8 @@ makeRLearner.regr.nnet = function() {
       makeLogicalLearnerParam(id = "Hess", default = FALSE),
       makeLogicalLearnerParam(id = "trace", default = TRUE, tunable = FALSE),
       makeIntegerLearnerParam(id = "MaxNWts", default = 1000L, lower = 1L),
-      # FIXME_PK: Why are abstoll and reltoll written with 2 "l"?
-      makeNumericLearnerParam(id = "abstoll", default = 1.0e-4),
-      makeNumericLearnerParam(id = "reltoll", default = 1.0e-8)
+      makeNumericLearnerParam(id = "abstol", default = 1.0e-4),
+      makeNumericLearnerParam(id = "reltol", default = 1.0e-8)
     ),
     par.vals = list(size = 3L),
     properties = c("numerics", "factors", "weights"),

--- a/R/RLearner_surv_cvglmnet.R
+++ b/R/RLearner_surv_cvglmnet.R
@@ -7,7 +7,6 @@ makeRLearner.surv.cvglmnet = function() {
       makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1),
       makeIntegerLearnerParam(id = "nfolds", default = 10L, lower = 3L),
       makeDiscreteLearnerParam(id = "type.measure", values = c("deviance"), default = "deviance"),
-      makeLogicalLearnerParam(id = "exact", default = FALSE, when = "predict"),
       makeLogicalLearnerParam(id = "grouped", default = TRUE),
       makeDiscreteLearnerParam(id = "s", values = c("lambda.1se", "lambda.min"), default = "lambda.1se", when = "predict"),
       makeIntegerLearnerParam(id = "nlambda", default = 100L, lower = 1L),


### PR DESCRIPTION
Fixes #1663
Fixes #1664
Fixes #1665
Fixes #1666

Found these while doing the `learnerParamHelp` PR.