### PR TITLE
ignore xgboost.model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ inst/doc/
 ehthumbs.db
 Icon?
 Thumbs.db
+*xgboost.model


### PR DESCRIPTION
Since with some update of xgboost it is always creating these files on disk.

(happens when running tests etc.)