### PR TITLE
fix getLearnerModel for nested preproc wrapper

### DIFF
--- a/R/ChainModel.R
+++ b/R/ChainModel.R
@@ -10,7 +10,7 @@ getLearnerModel.BaseWrapperModel = function(model, more.unwrap = FALSE) {
   if (inherits(model$learner.model, "NoFeaturesModel"))
     return(model$learner.model)
   if (more.unwrap)
-    model$learner.model$next.model$learner.model
+    getLearnerModel(model$learner.model$next.model, more.unwrap = TRUE)
   else
     model$learner.model$next.model
 }
@@ -19,5 +19,3 @@ getLearnerModel.BaseWrapperModel = function(model, more.unwrap = FALSE) {
 print.ChainModel = function(x, ...) {
   print(x$next.model)
 }
-
-

--- a/tests/testthat/test_base_PreprocWrapper.R
+++ b/tests/testthat/test_base_PreprocWrapper.R
@@ -29,3 +29,12 @@ test_that("PreprocWrapper", {
   capture.output(print(m))
   expect_true(setequal(getHyperPars(m$learner), list(xval = 0, minsplit = 10, x = 1, y = 2)))
 })
+
+test_that("getLearnerModel on nested PreprocWrapper", {
+  lrn = makeLearner("classif.rpart")
+  lrn = makeDummyFeaturesWrapper(lrn)
+  lrn = makeImputeWrapper(lrn, classes = list(numeric = imputeMax(5), factor = imputeConstant("NA")))
+  m = train(lrn, binaryclass.task)
+  expect_is(getLearnerModel(m), "PreprocModel")
+  expect_is(getLearnerModel(m, TRUE), "rpart")
+})


### PR DESCRIPTION
`getLearnerModel(..., more.unwrap = TRUE)` did not give the underlying R model, only the next learner.
`getLeafModel()` should in principle do this, but (a) is not exported and (b) also fails for nested chain models