### PR TITLE
Add rng as parameter to the generatePartialDependence function

### DIFF
--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -232,7 +232,7 @@ generatePartialDependenceData = function(obj, input, features,
     stop("fmax must be a named list with an NA or value corresponding to each feature.")
   assertCount(gridsize, positive = TRUE)
 
-  if (!is.null(rng))
+  if (is.null(rng))
     rng = generateFeatureGrid(features, data, resample, gridsize, fmin, fmax)
   if (length(features) > 1L & interaction)
     rng = expand.grid(rng)

--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -168,7 +168,7 @@
 generatePartialDependenceData = function(obj, input, features,
   interaction = FALSE, derivative = FALSE, individual = FALSE, center = NULL,
   fun = mean, bounds = c(qnorm(.025), qnorm(.975)),
-  resample = "none", fmin, fmax, gridsize = 10L, rng = NULL, ...) {
+  resample = "none", fmin, fmax, gridsize = 10L, range = NULL, ...) {
 
   assertClass(obj, "WrappedModel")
   if (obj$learner$predict.type == "se" & individual)
@@ -232,8 +232,10 @@ generatePartialDependenceData = function(obj, input, features,
     stop("fmax must be a named list with an NA or value corresponding to each feature.")
   assertCount(gridsize, positive = TRUE)
 
-  if (is.null(rng))
+  if (is.null(range))
     rng = generateFeatureGrid(features, data, resample, gridsize, fmin, fmax)
+  else
+    rng = range
   if (length(features) > 1L & interaction)
     rng = expand.grid(rng)
 

--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -91,7 +91,7 @@
 #'   If \code{resample = "bootstrap"} or \code{resample = "subsample"} then this defines
 #'   the number of (possibly non-unique) values resampled. If \code{resample = NULL} it defines the
 #'   length of the evenly spaced grid created.
-#' @param rng [\code{list}]\cr
+#' @param range [\code{list}]\cr
 #'   The range of values of the feature you would want the partial plots on - passed as a numeric list
 #' @param ... additional arguments to be passed to \code{\link{predict}}.
 #' @return [\code{PartialDependenceData}]. A named list, which contains the partial dependence,

--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -91,6 +91,8 @@
 #'   If \code{resample = "bootstrap"} or \code{resample = "subsample"} then this defines
 #'   the number of (possibly non-unique) values resampled. If \code{resample = NULL} it defines the
 #'   length of the evenly spaced grid created.
+#' @param rng [\code{numeric}]\cr
+#'   The range of values of the feature you would want the partial plots on - passed as a numeric list
 #' @param ... additional arguments to be passed to \code{\link{predict}}.
 #' @return [\code{PartialDependenceData}]. A named list, which contains the partial dependence,
 #'   input data, target, features, task description, and other arguments controlling the type of
@@ -166,7 +168,7 @@
 generatePartialDependenceData = function(obj, input, features,
   interaction = FALSE, derivative = FALSE, individual = FALSE, center = NULL,
   fun = mean, bounds = c(qnorm(.025), qnorm(.975)),
-  resample = "none", fmin, fmax, gridsize = 10L, ...) {
+  resample = "none", fmin, fmax, gridsize = 10L, rng = NULL, ...) {
 
   assertClass(obj, "WrappedModel")
   if (obj$learner$predict.type == "se" & individual)
@@ -230,7 +232,8 @@ generatePartialDependenceData = function(obj, input, features,
     stop("fmax must be a named list with an NA or value corresponding to each feature.")
   assertCount(gridsize, positive = TRUE)
 
-  rng = generateFeatureGrid(features, data, resample, gridsize, fmin, fmax)
+  if (missing(rng))
+    rng = generateFeatureGrid(features, data, resample, gridsize, fmin, fmax)
   if (length(features) > 1L & interaction)
     rng = expand.grid(rng)
 

--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -91,7 +91,7 @@
 #'   If \code{resample = "bootstrap"} or \code{resample = "subsample"} then this defines
 #'   the number of (possibly non-unique) values resampled. If \code{resample = NULL} it defines the
 #'   length of the evenly spaced grid created.
-#' @param rng [\code{numeric}]\cr
+#' @param rng [\code{list}]\cr
 #'   The range of values of the feature you would want the partial plots on - passed as a numeric list
 #' @param ... additional arguments to be passed to \code{\link{predict}}.
 #' @return [\code{PartialDependenceData}]. A named list, which contains the partial dependence,
@@ -232,7 +232,7 @@ generatePartialDependenceData = function(obj, input, features,
     stop("fmax must be a named list with an NA or value corresponding to each feature.")
   assertCount(gridsize, positive = TRUE)
 
-  if (missing(rng))
+  if (!is.null(rng))
     rng = generateFeatureGrid(features, data, resample, gridsize, fmin, fmax)
   if (length(features) > 1L & interaction)
     rng = expand.grid(rng)

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -266,8 +266,8 @@ test_that("generatePartialDependenceData", {
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
 	
   # test rng as paratmeter
-  petal.width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 16))
-  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal.width)
+  petal.width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 0.1))
+  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", range = petal.width)
   expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal.width)))
 })
 

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -268,7 +268,7 @@ test_that("generatePartialDependenceData", {
   # test rng as paratmeter
   petal_width <- c(seq(0.1,0.6,6),seq(1,2.5,16))
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal_width)
-  expect_that(pd$data$Petal.Width,equals(petal_width))
+  expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class))*length(petal_width)))
                                      
 })
 

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -269,7 +269,6 @@ test_that("generatePartialDependenceData", {
   petal.width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 16))
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal.width)
   expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal.width)))
-                                     
 })
 
 test_that("generateFeatureGrid", {

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -268,7 +268,7 @@ test_that("generatePartialDependenceData", {
   # test rng as paratmeter
   petal_width <- c(seq(0.1,0.6,6),seq(1,2.5,16))
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal_width)
-  expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class))*length(petal_width)))
+  expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal_width)))
                                      
 })
 

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -266,9 +266,9 @@ test_that("generatePartialDependenceData", {
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
 	
   # test rng as paratmeter
-  petal_width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 16))
-  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal_width)
-  expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal_width)))
+  petal.width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 16))
+  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal.width)
+  expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal.width)))
                                      
 })
 

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -266,7 +266,7 @@ test_that("generatePartialDependenceData", {
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
 	
   # test rng as paratmeter
-  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", c(0.1,0.2,0.3,0.4,0.5,0.6,1,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2,2.1,2.2,2.3,2.4,2.5))
+  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = c(seq(0.1,0.6,6),seq(1,2.5,16))
 })
 
 test_that("generateFeatureGrid", {

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -264,11 +264,11 @@ test_that("generatePartialDependenceData", {
   # issue 63 in the tutorial
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width",
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
-	
+
   # test rng as paratmeter
   petal.width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 0.1))
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", range = petal.width)
-  expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal.width)))
+  expect_that(length(pd$data$Petal.Width), equals(length(unique(pd$data$Class)) * length(petal.width)))
 })
 
 test_that("generateFeatureGrid", {

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -264,6 +264,9 @@ test_that("generatePartialDependenceData", {
   # issue 63 in the tutorial
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width",
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
+	
+  # test rng as paratmeter
+  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", c(0.1,0.2,0.3,0.4,0.5,0.6,1,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2,2.1,2.2,2.3,2.4,2.5))
 })
 
 test_that("generateFeatureGrid", {

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -266,7 +266,10 @@ test_that("generatePartialDependenceData", {
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
 	
   # test rng as paratmeter
-  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = c(seq(0.1,0.6,6),seq(1,2.5,16))
+  petal_width <- c(seq(0.1,0.6,6),seq(1,2.5,16))
+  pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal_width)
+  expect_that(pd$data$Petal.Width,equals(petal_width))
+                                     
 })
 
 test_that("generateFeatureGrid", {

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -266,7 +266,7 @@ test_that("generatePartialDependenceData", {
     individual = TRUE, derivative = TRUE, gridsize = gridsize)
 	
   # test rng as paratmeter
-  petal_width <- c(seq(0.1,0.6,6),seq(1,2.5,16))
+  petal_width = c(seq(0.1, 0.6, 0.1), seq(1, 2.5, 16))
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width", rng = petal_width)
   expect_that(length(pd$data$Petal.Width),equals(length(unique(pd$data$Class)) * length(petal_width)))
                                      


### PR DESCRIPTION
partialdependeance creates its own range of values based on the minimum and maximum values of a features in the train data. For instance in the iris data, the petal width is automatically divided into 6 buckets 0.1000000,0.3666667,0.6333333,0.9000000,1.1666667,1.4333333. But the user cannot specify if they want to get the output in buckets such as 0.1,0.2,0.5,0.8,1.0,1.2, 1.5. I am just passing the 'rng' as a parameter for the user to be able to provide these values. If the parameter is not provided, it will give the default values as above.