### PR TITLE
nnet: MaxNWts is not tunable

### DIFF
--- a/R/RLearner_classif_nnet.R
+++ b/R/RLearner_classif_nnet.R
@@ -17,7 +17,7 @@ makeRLearner.classif.nnet = function() {
       makeNumericLearnerParam(id = "decay", default = 0),
       makeLogicalLearnerParam(id = "Hess", default = FALSE),
       makeLogicalLearnerParam(id = "trace", default = TRUE, tunable = FALSE),
-      makeIntegerLearnerParam(id = "MaxNWts", default = 1000L, lower = 1L),
+      makeIntegerLearnerParam(id = "MaxNWts", default = 1000L, lower = 1L, tunable = FALSE),
       makeNumericLearnerParam(id = "abstol", default = 1.0e-4),
       makeNumericLearnerParam(id = "reltol", default = 1.0e-8)
     ),

--- a/R/RLearner_regr_nnet.R
+++ b/R/RLearner_regr_nnet.R
@@ -16,7 +16,7 @@ makeRLearner.regr.nnet = function() {
       makeNumericLearnerParam(id = "decay", default = 0, lower = 0),
       makeLogicalLearnerParam(id = "Hess", default = FALSE),
       makeLogicalLearnerParam(id = "trace", default = TRUE, tunable = FALSE),
-      makeIntegerLearnerParam(id = "MaxNWts", default = 1000L, lower = 1L),
+      makeIntegerLearnerParam(id = "MaxNWts", default = 1000L, lower = 1L, tunable = FALSE),
       makeNumericLearnerParam(id = "abstol", default = 1.0e-4),
       makeNumericLearnerParam(id = "reltol", default = 1.0e-8)
     ),


### PR DESCRIPTION
According to the manual: 

>The maximum allowable number of weights. There is no intrinsic limit in the code, but increasing MaxNWts will probably allow fits that are very slow and time-consuming.