### PR TITLE
Fix 1857 fixup.data

### DIFF
--- a/R/ClusterTask.R
+++ b/R/ClusterTask.R
@@ -6,7 +6,7 @@ makeClusterTask = function(id = deparse(substitute(data)), data, weights = NULL,
   assertChoice(fixup.data, choices = c("no", "quiet", "warn"))
   assertFlag(check.data)
 
-  task = makeUnsupervisedTask("cluster", data, weights, blocking)
+  task = makeUnsupervisedTask("cluster", data, weights, blocking, fixup.data, check.data)
   task$task.desc = makeClusterTaskDesc(id, data, weights, blocking)
   addClasses(task, "ClusterTask")
 }

--- a/R/MultilabelTask.R
+++ b/R/MultilabelTask.R
@@ -8,7 +8,7 @@ makeMultilabelTask = function(id = deparse(substitute(data)), data, target, weig
   assertChoice(fixup.data, choices = c("no", "quiet", "warn"))
   assertFlag(check.data)
 
-  task = makeSupervisedTask("multilabel", data, target, weights, blocking)
+  task = makeSupervisedTask("multilabel", data, target, weights, blocking, fixup.data, check.data)
   # currently we dont do any fixup here
   if (check.data) {
     for (cn in target)

--- a/R/SupervisedTask.R
+++ b/R/SupervisedTask.R
@@ -1,4 +1,4 @@
-makeSupervisedTask = function(type, data, target, weights = NULL, blocking = NULL, fixup.data = "warn", check.data = TRUE) {
+makeSupervisedTask = function(type, data, target, weights, blocking, fixup.data, check.data) {
   task = makeTask(type = type, data = data, weights = weights, blocking = blocking, fixup.data = fixup.data, check.data = check.data)
 
   if (check.data) {

--- a/R/UnsupervisedTask.R
+++ b/R/UnsupervisedTask.R
@@ -1,4 +1,4 @@
-makeUnsupervisedTask = function(type, data, weights = NULL, blocking = NULL, fixup.data = "warn", check.data = TRUE) {
+makeUnsupervisedTask = function(type, data, weights, blocking, fixup.data, check.data) {
   task = makeTask(type, data, weights, blocking, fixup.data = fixup.data, check.data = check.data)
   # we can't use getTaskData to access the tasks's data here because we then
   # want to access the description object which is not existing yet

--- a/tests/testthat/test_base_SupervisedTask.R
+++ b/tests/testthat/test_base_SupervisedTask.R
@@ -56,6 +56,12 @@ test_that("SupervisedTask dropping of levels works", {
     "Empty factor levels")
   e = getTaskData(task)
   expect_true(setequal(levels(e$Species), levs1))
+
+  expect_warning(makeMultilabelTask("multilabel", multilabel.df[1:10, ], target = c("y1", "y2"), fixup.data = "warn"),
+    "Empty factor levels")
+
+  expect_warning(makeMultilabelTask("multilabel", multilabel.df[1:10, ], target = c("y1", "y2"), fixup.data = "quiet"), NA)
+
 })
 
 test_that("SupervisedTask does not drop positive class", {

--- a/tests/testthat/test_base_UnsupervisedTask.R
+++ b/tests/testthat/test_base_UnsupervisedTask.R
@@ -25,4 +25,11 @@ test_that("UnsupervisedTask", {
   expect_true(getTaskDesc(ct1)$has.blocking)
   ct2 = subsetTask(ct1)
   expect_true(getTaskDesc(ct2)$has.blocking)
+
+  # check 'fixup data' works
+
+  expect_warning(makeClusterTask("cluster", iris[1:10, ], fixup.data = "warn"), "Empty factor levels")
+
+  expect_warning(makeClusterTask("cluster", iris[1:10, ], fixup.data = "quiet"), NA)
+
 })


### PR DESCRIPTION
This fixes #1857 
I also made the `makeSupervisedTask` and `makeUnsupervisedTask` paramters non-optional. This will prevent this kind of error in the future: `fixup.data` should always be given to these functions, since they are always called from functions that have an opinion on this.

Maybe it will break some tests. let's see.