### PR TITLE
Modify `makeBaseWrapper` to unlock wrapped feature selection and tuning and to prevent errors in wrapped feature selection and imputation

### DIFF
--- a/R/BaseWrapper.R
+++ b/R/BaseWrapper.R
@@ -1,10 +1,7 @@
 makeBaseWrapper = function(id, type, next.learner, package = character(0L), par.set = makeParamSet(),
   par.vals = list(), learner.subclass, model.subclass) {
-
-  if (inherits(next.learner, "TuneWrapper"))
-    stop("Cannot wrap a tuning wrapper with something else!")
-  if (inherits(next.learner, "OptWrapper") && inherits(next.learner, learner.subclass))
-    stop("Cannot wrap an optimization wrapper with the same class!")
+  if (inherits(next.learner, "OptWrapper") && is.element("TuneWrapper", learner.subclass))
+    stop("Cannot wrap a tuning wrapper around another optimization wrapper!")
   ns = intersect(names(par.set$pars), names(next.learner$par.set$pars))
   if (length(ns) > 0L)
     stopf("Hyperparameter names in wrapper clash with base learner names: %s", collapse(ns))

--- a/R/BaseWrapper.R
+++ b/R/BaseWrapper.R
@@ -1,8 +1,10 @@
 makeBaseWrapper = function(id, type, next.learner, package = character(0L), par.set = makeParamSet(),
   par.vals = list(), learner.subclass, model.subclass) {
 
-  if (inherits(next.learner, "OptWrapper"))
-    stop("Cannot wrap an optimization wrapper with something else!")
+  if (inherits(next.learner, "TuneWrapper"))
+    stop("Cannot wrap a tuning wrapper with something else!")
+  if (inherits(next.learner, "OptWrapper") && inherits(next.learner, learner.subclass))
+    stop("Cannot wrap an optimization wrapper with the same class!")
   ns = intersect(names(par.set$pars), names(next.learner$par.set$pars))
   if (length(ns) > 0L)
     stopf("Hyperparameter names in wrapper clash with base learner names: %s", collapse(ns))

--- a/tests/testthat/test_base_BaseWrapper.R
+++ b/tests/testthat/test_base_BaseWrapper.R
@@ -28,8 +28,8 @@ test_that("Joint model performance estimation, tuning, and model performance", {
   lrn2 = makeTuneWrapper(
     learner = lrn,
     par.set = makeParamSet(
-      makeDiscreteParam("C", values = 2^(-2:2)),
-      makeDiscreteParam("sigma", values = 2^(-2:2))
+      makeDiscreteParam("C", values = 2 ^ (-2:2)),
+      makeDiscreteParam("sigma", values = 2 ^ (-2:2))
     ),
     measures = list(auc, acc),
     control = makeTuneControlRandom(maxit = 3L),
@@ -57,8 +57,8 @@ test_that("Error when wrapping tune wrapper around another optimization wrapper"
     lrn3 = makeTuneWrapper(
       learner = lrn2,
       par.set = makeParamSet(
-        makeDiscreteParam("C", values = 2^(-2:2)),
-        makeDiscreteParam("sigma", values = 2^(-2:2))
+        makeDiscreteParam("C", values = 2 ^ (-2:2)),
+        makeDiscreteParam("sigma", values = 2 ^ (-2:2))
       ),
       measures = list(auc, acc),
       control = makeTuneControlRandom(maxit = 3L),

--- a/tests/testthat/test_base_BaseWrapper.R
+++ b/tests/testthat/test_base_BaseWrapper.R
@@ -22,3 +22,50 @@ test_that("BaseWrapper", {
   lrn2.rm = removeHyperPars(lrn2, names(getHyperPars(lrn2)))
   expect_equal(length(getHyperPars(lrn2.rm)), 0)
 })
+
+test_that("Joint model performance estimation, tuning, and model performance", {
+  lrn = makeLearner("classif.ksvm", predict.type = "prob")
+  lrn2 = makeTuneWrapper(
+    learner = lrn,
+    par.set = makeParamSet(
+      makeDiscreteParam("C", values = 2^(-2:2)),
+      makeDiscreteParam("sigma", values = 2^(-2:2))
+    ),
+    measures = list(auc, acc),
+    control = makeTuneControlRandom(maxit = 3L),
+    resampling = makeResampleDesc(method = "Holdout")
+  )
+  lrn3 = makeFeatSelWrapper(
+    learner = lrn2,
+    measures = list(auc, acc),
+    control = makeFeatSelControlRandom(maxit = 3L),
+    resampling = makeResampleDesc(method = "Holdout")
+  )
+  bmrk = benchmark(lrn3, pid.task, makeResampleDesc(method = "Holdout"))
+  expect_is(bmrk, "BenchmarkResult")
+})
+
+test_that("Error when wrapping tune wrapper around another optimization wrapper", {
+  expect_error({
+    lrn = makeLearner("classif.ksvm", predict.type = "prob")
+    lrn2 = makeFeatSelWrapper(
+      learner = lrn,
+      measures = list(auc, acc),
+      control = makeFeatSelControlRandom(maxit = 3L),
+      resampling = makeResampleDesc(method = "Holdout")
+    )
+    lrn3 = makeTuneWrapper(
+      learner = lrn2,
+      par.set = makeParamSet(
+        makeDiscreteParam("C", values = 2^(-2:2)),
+        makeDiscreteParam("sigma", values = 2^(-2:2))
+      ),
+      measures = list(auc, acc),
+      control = makeTuneControlRandom(maxit = 3L),
+      resampling = makeResampleDesc(method = "Holdout")
+    )
+    bmrk = benchmark(lrn3, pid.task)
+  }, "Cannot wrap a tuning wrapper around another optimization wrapper!")
+})
+
+


### PR DESCRIPTION
This change relaxes the restrictions in `makeBaseWrapper` so that:

1. Only wrappers of class `TuneWrapper` (instead of any of class `OptWrapper`) must be placed at innermost loop and cannot wrap around anything else.

This unlocks two use cases related to issues #1861 and #1806:

1. #1861 Allows feature selection in an outer loop and tuning within each candidate feature set.
2. #1806 Allows imputation to take place before the feature selection loop so that it does not fail in the case when the candidate feature set in feature selection does not include specified column names via the `cols` argument.

Thank you!