### PR TITLE
Enabling github templates for Issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,9 @@
 For bug reports, please respect the following guidelines and check the boxes accordingly.
+Please include your source code using the ticks ` like this:
+
+```r
+
+```
 
 For questions of the type: "How can this be done?", please consider posting them on Stackoverflow.
 
@@ -8,12 +13,5 @@ For everything else ignore this template.
 
 - [ ] Start a new R session
 - [ ] Install the latest version of mlr: `update.packages(oldPkgs="mlr", ask=FALSE)` or if you use a GitHub install of mlr: `devtools::install_github(c("BBmisc", "ParamHelpers", "mlr"))`
-- [ ] Give a minimal reproducible example
 - [ ] run `sessionInfo()`
-
-### Minimal reproducible example:
-
-```r
-lrn = makeLearner("classif.lda")
-resample(learner = lrn, task = iris.task, resampling = cv10)
-```
+- [ ] Give a minimal reproducible example

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+For bug reports please respect the following guidelines and check the boxes accordingly.
+
+For questions of the type: "How can this be done?": Please consider asking them on stackoverflow.
+
+For everything else ignore this template.
+
+## Bug report
+
+- [ ] Start a new R session
+- [ ] Install the latest version of caret: `update.packages(oldPkgs="mlr", ask=FALSE)`
+- [ ] If you use a GitHub install of mlr: `devtools::install_github(c("BBmisc", "ParamHelpers", "mlr"))
+- [ ] [Write a minimal reproducible example](http://stackoverflow.com/a/5963610)
+- [ ] run `sessionInfo()`
+
+### Minimal reproducible example:
+
+```r
+lrn = makeLearner("classif.lda")
+resample(learner = lrn, task = iris.task, resampling = cv10)
+```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,9 +7,8 @@ For everything else ignore this template.
 ## Bug report
 
 - [ ] Start a new R session
-- [ ] Install the latest version of mlr: `update.packages(oldPkgs="mlr", ask=FALSE)`
-- [ ] If you use a GitHub install of mlr: `devtools::install_github(c("BBmisc", "ParamHelpers", "mlr"))
-- [ ] [Give a minimal reproducible example](http://stackoverflow.com/a/5963610)
+- [ ] Install the latest version of mlr: `update.packages(oldPkgs="mlr", ask=FALSE)` or if you use a GitHub install of mlr: `devtools::install_github(c("BBmisc", "ParamHelpers", "mlr"))`
+- [ ] Give a minimal reproducible example
 - [ ] run `sessionInfo()`
 
 ### Minimal reproducible example:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,9 @@
 For bug reports, please respect the following guidelines and check the boxes accordingly.
 Please include your source code using tripple backticks ` like this:
 
-```
+
 ```r
+# your code
 ```
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,12 @@
 For bug reports, please respect the following guidelines and check the boxes accordingly.
-Please include your source code using the ticks ` like this:
+Please include your source code using tripple backticks ` like this:
 
+```
 ```r
 
 ```
+```
+
 
 For questions of the type: "How can this be done?", please consider posting them on Stackoverflow.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,3 +15,16 @@ For everything else ignore this template.
 - [ ] Install the latest version of mlr: `update.packages(oldPkgs="mlr", ask=FALSE)` or if you use a GitHub install of mlr: `devtools::install_github(c("BBmisc", "ParamHelpers", "mlr"))`
 - [ ] run `sessionInfo()`
 - [ ] Give a minimal reproducible example
+
+## Writing a good bug report
+
+[ Slightly adapted version of (this) [https://www.r-project.org/bugs.html#writing-a-good-bug-report] ]
+
+Bug reports should include a way of reproducing the bug. This should be as simple as possible. If the person trying to fix the bug can’t work out how to make it appear, or has to jump through a lot of unnecessary hoops to make it appear, you’re going to waste a lot of their time.
+
+mlr is maintained by a number of people, so it’s best to make sure your bug report is clear and well-written. If it’s not, it will suck in more energy from the maintainers and take longer for the bug to get fixed - or it may end up not getting handled at all. In particular, you should:
+
+Write a clear and unique summary for the bug. “Running a model on data set with a constant feature causes the following exception” is good; “software crashes” is not.
+Include, in the description, the steps to reproduce the bug mentioned above.
+Focus most on the facts of what happened, but if course helps if you can already give us (informed!) guesses where the bug comes from.
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -39,4 +39,5 @@ the minimal runnable code necessary to reproduce the error, which can be run on 
 the necessary information on the used packages, R version and system it is run on.
 in the case of random processes, a seed (set by set.seed()) for reproducibility
 
-If you want to learn more, read (this)[https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example]
+If you want to learn more, read
+https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,15 @@
-For bug reports please respect the following guidelines and check the boxes accordingly.
+For bug reports, please respect the following guidelines and check the boxes accordingly.
 
-For questions of the type: "How can this be done?": Please consider asking them on stackoverflow.
+For questions of the type: "How can this be done?", please consider posting them on Stackoverflow.
 
 For everything else ignore this template.
 
 ## Bug report
 
 - [ ] Start a new R session
-- [ ] Install the latest version of caret: `update.packages(oldPkgs="mlr", ask=FALSE)`
+- [ ] Install the latest version of mlr: `update.packages(oldPkgs="mlr", ask=FALSE)`
 - [ ] If you use a GitHub install of mlr: `devtools::install_github(c("BBmisc", "ParamHelpers", "mlr"))
-- [ ] [Write a minimal reproducible example](http://stackoverflow.com/a/5963610)
+- [ ] [Give a minimal reproducible example](http://stackoverflow.com/a/5963610)
 - [ ] run `sessionInfo()`
 
 ### Minimal reproducible example:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,3 +30,13 @@ Write a clear and unique summary for the bug. “Running a model on data set wit
 Include, in the description, the steps to reproduce the bug mentioned above.
 Focus most on the facts of what happened, but if course helps if you can already give us (informed!) guesses where the bug comes from.
 
+## Minimal reproducible example
+
+A minimal reproducible example consists of the following items:
+
+a minimal dataset, necessary to reproduce the error
+the minimal runnable code necessary to reproduce the error, which can be run on the given dataset.
+the necessary information on the used packages, R version and system it is run on.
+in the case of random processes, a seed (set by set.seed()) for reproducibility
+
+If you want to learn more, read (this)[https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,8 +3,6 @@ Please include your source code using tripple backticks ` like this:
 
 ```
 ```r
-
-```
 ```
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+We are always happy to receive pull requests.
+
+Please make sure you have read our coding guidelines: https://github.com/mlr-org/mlr/wiki/mlr-Coding-Guidelines
+
+Also it's helpful to find a buddy from the core team who helps you getting your PR merged.
+You might want to join our slack channel!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 We are always happy to receive pull requests.
 
-Please make sure you have read our coding guidelines: https://github.com/mlr-org/mlr/wiki/mlr-Coding-Guidelines
+Please make sure you have read our coding guidelines: 
+https://github.com/mlr-org/mlr/wiki/mlr-Coding-Guidelines
 
 This especially means that you have understood:
 
@@ -9,4 +10,5 @@ This especially means that you have understood:
 * How to run R CMD CHECK locally. See point before. 
 
 Also it's helpful to get into direct contact with the suggested reviewers to get help, getting your PR merged.
-You might want to join our (slack channel)[https://mlr-org.slack.com/]!
+You might want to join our slack at: 
+https://mlr-org.slack.com

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,5 @@ We are always happy to receive pull requests.
 
 Please make sure you have read our coding guidelines: https://github.com/mlr-org/mlr/wiki/mlr-Coding-Guidelines
 
-Also it's helpful to find a buddy from the core team who helps you getting your PR merged.
-You might want to join our slack channel!
+Also it's helpful to get into direct contact with the suggested reviewers to get help, getting your PR merged.
+You might want to join our (slack channel)[https://mlr-org.slack.com/]!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,11 @@ We are always happy to receive pull requests.
 
 Please make sure you have read our coding guidelines: https://github.com/mlr-org/mlr/wiki/mlr-Coding-Guidelines
 
+This especially means that you have understood:
+
+* The style guide - our lintr will provide you feedback on this
+* How to run tests locally. Yes, travis will also run them for you, bad it is annoying to wait for this.
+* How to run R CMD CHECK locally. See point before. 
+
 Also it's helpful to get into direct contact with the suggested reviewers to get help, getting your PR merged.
 You might want to join our (slack channel)[https://mlr-org.slack.com/]!


### PR DESCRIPTION
This PR enables github a issue and pr template that will be the shown
as a template when opening an Issue or a PR. Compare https://github.com/topepo/caret/issues/new