### PR TITLE
hand task instead of regr|classif in order to allow for fda learners

### DIFF
--- a/tests/testthat/test_learners_all_classif.R
+++ b/tests/testthat/test_learners_all_classif.R
@@ -28,11 +28,11 @@ test_that("learners work: classif ", {
   lapply(lrns, testBasicLearnerProperties, task = task, hyperpars = hyperpars)
 
   # binary classif with factors
-  lrns = mylist("classif", properties = "factors", create = TRUE)
+  lrns = mylist(task, properties = "factors", create = TRUE)
   lapply(lrns, testThatLearnerHandlesFactors, task = task, hyperpars = hyperpars)
 
   # binary classif with ordered factors
-  lrns = mylist("classif", properties = "ordered", create = TRUE)
+  lrns = mylist(task, properties = "ordered", create = TRUE)
   lapply(lrns, testThatLearnerHandlesOrderedFactors, task = task, hyperpars = hyperpars)
 
   # binary classif with prob
@@ -41,26 +41,26 @@ test_that("learners work: classif ", {
     hyperpars = hyperpars, pred.type = "prob")
 
   # binary classif with weights
-  lrns = mylist("classif", properties = "weights", create = TRUE)
+  lrns = mylist(binaryclass.task, properties = "weights", create = TRUE)
   lapply(lrns, testThatLearnerRespectsWeights, hyperpars = hyperpars,
     task = binaryclass.task, train.inds = binaryclass.train.inds, test.inds = binaryclass.test.inds,
     weights = rep(c(10000L, 1L), c(10L, length(binaryclass.train.inds) - 10L)),
     pred.type = "prob", get.pred.fun = getPredictionProbabilities)
 
   # classif with missing
-  lrns = mylist("classif", properties = "missings", create = TRUE)
+  lrns = mylist(task, properties = "missings", create = TRUE)
   lapply(lrns, testThatLearnerHandlesMissings, task = task, hyperpars = hyperpars)
 
   # classif with oobpreds
-  lrns = mylist("classif", properties = "oobpreds", create = TRUE)
+  lrns = mylist(task, properties = "oobpreds", create = TRUE)
   lapply(lrns, testThatGetOOBPredsWorks, task = task)
   # classif with oobpreds and probability
-  lrns = mylist("classif", properties = c("oobpreds", "prob"), create = TRUE)
+  lrns = mylist(task, properties = c("oobpreds", "prob"), create = TRUE)
   lrns = lapply(lrns, setPredictType, predict.type = "prob")
   lapply(lrns, testThatGetOOBPredsWorks, task = task)
 
   # classif with variable importance
-  lrns = mylist("classif", properties = "featimp", create = TRUE)
+  lrns = mylist(task, properties = "featimp", create = TRUE)
   lapply(lrns, testThatLearnerCanCalculateImportance, task = task, hyperpars = hyperpars)
 })
 

--- a/tests/testthat/test_learners_all_classif.R
+++ b/tests/testthat/test_learners_all_classif.R
@@ -54,7 +54,6 @@ test_that("learners work: classif ", {
   # classif with oobpreds
   lrns = mylist(task, properties = "oobpreds", create = TRUE)
   lapply(lrns, testThatGetOOBPredsWorks, task = task)
-
   # classif with oobpreds and probability
   lrns = mylist(task, properties = c("oobpreds", "prob"), create = TRUE)
   lrns = lapply(lrns, setPredictType, predict.type = "prob")

--- a/tests/testthat/test_learners_all_classif.R
+++ b/tests/testthat/test_learners_all_classif.R
@@ -54,6 +54,7 @@ test_that("learners work: classif ", {
   # classif with oobpreds
   lrns = mylist(task, properties = "oobpreds", create = TRUE)
   lapply(lrns, testThatGetOOBPredsWorks, task = task)
+
   # classif with oobpreds and probability
   lrns = mylist(task, properties = c("oobpreds", "prob"), create = TRUE)
   lrns = lapply(lrns, setPredictType, predict.type = "prob")

--- a/tests/testthat/test_learners_all_regr.R
+++ b/tests/testthat/test_learners_all_regr.R
@@ -19,16 +19,16 @@ test_that("learners work: regr ", {
   task = subsetTask(regr.task, subset = c(1:70), features = getTaskFeatureNames(regr.task)[c(1, 3)])
 
   # normal regr
-  lrns = mylist("regr", create = TRUE)
+  lrns = mylist(task, create = TRUE)
   lapply(lrns, testThatLearnerParamDefaultsAreInParamSet)
   lapply(lrns, testBasicLearnerProperties, task = task, hyperpars = hyperpars)
 
   # regr with factors
-  lrns = mylist("regr", properties = "factors", create = TRUE)
+  lrns = mylist(task, properties = "factors", create = TRUE)
   lapply(lrns, testThatLearnerHandlesFactors, task = task, hyperpars = hyperpars)
 
   # regr with ordered factors
-  lrns = mylist("regr", properties = "ordered", create = TRUE)
+  lrns = mylist(task, properties = "ordered", create = TRUE)
   lapply(lrns, testThatLearnerHandlesOrderedFactors, task = task, hyperpars = hyperpars)
 
   # regr with se
@@ -37,20 +37,20 @@ test_that("learners work: regr ", {
     pred.type = "se")
 
   # regr with weights
-  lrns = mylist("regr", properties = "weights", create = TRUE)
+  lrns = mylist(task, properties = "weights", create = TRUE)
   lapply(lrns, testThatLearnerRespectsWeights, hyperpars = hyperpars,
     task = task, train.inds = 1:70, test.inds = 1:70, weights = rep(c(1, 5), length.out = 70),
     pred.type = "response", get.pred.fun = getPredictionResponse)
 
   # regr with missing
-  lrns = mylist("regr", properties = "missings", create = TRUE)
+  lrns = mylist(task, properties = "missings", create = TRUE)
   lapply(lrns, testThatLearnerHandlesMissings, task = task, hyperpars = hyperpars)
 
   # regr variable importance
-  lrns = mylist("regr", properties = "featimp", create = TRUE)
+  lrns = mylist(task, properties = "featimp", create = TRUE)
   lapply(lrns, testThatLearnerCanCalculateImportance, task = task, hyperpars = hyperpars)
 
   # regr with oobpreds
-  lrns = mylist("regr", properties = "oobpreds", create = TRUE)
+  lrns = mylist(task, properties = "oobpreds", create = TRUE)
   lapply(lrns, testThatGetOOBPredsWorks, task = task)
 })


### PR DESCRIPTION
Pass task to ```mylist()``` instead of "regr" or "classif". 
This became a problem in the fda context, when the learners can not deal with scalar numeric features.

