### PR TITLE
Use BBmisc printHead instead of implementing it ourselves.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -13,13 +13,6 @@ getColEls = function(mat, inds) {
   getRowEls(t(mat), inds)
 }
 
-# prints more meaningful 'head' output indicating that there is more output
-printHead = function(x, n = 6L, ...) {
-  print(head(x, n = n, ...))
-  if (nrow(x) > n)
-    catf("... (%i rows, %i cols)\n", nrow(x), ncol(x))
-}
-
 # Do fuzzy string matching between input and a set of valid inputs
 # and return the most similar valid inputs.
 getNameProposals = function(input, possible.inputs, nproposals = 3L) {


### PR DESCRIPTION
See #1892 
This avoids an annoying namespace warning when `load_all`-ing mlr and a package that imports mlr. Another solution would be to rename `printHead`, but I have the feeling the BBmisc version was specifically written to replace this one?