### PR TITLE
Make loading of packages when loading a learner optional

### DIFF
--- a/R/RLearner.R
+++ b/R/RLearner.R
@@ -64,7 +64,9 @@ makeRLearnerInternal = function(id, type, package, par.set, par.vals, properties
   # must do that before accessing par.set
   # one case where lazy eval is actually helpful...
   assertCharacter(package, any.missing = FALSE)
-  requirePackages(package, why = stri_paste("learner", id, sep = " "), default.method = "load")
+  if (!coalesce(getMlrOption("defer.package.load"), FALSE)) {
+    requirePackages(package, why = stri_paste("learner", id, sep = " "), default.method = "load")
+  }
 
   assertString(id)
   assertChoice(type, choices = c("classif", "regr", "multilabel", "surv", "cluster", "costsens"))

--- a/R/configureMlr.R
+++ b/R/configureMlr.R
@@ -53,12 +53,15 @@
 #'   is \dQuote{warn} or \dQuote{quiet}. If it is \code{TRUE}, the dump can be accessed using
 #'   \code{\link{getFailureModelDump}} on the \code{\link{FailureModel}}, \code{\link{getPredictionDump}} on the failed prediction, and \code{\link{getRRDump}} on resample predictions.
 #'   Default is \code{FALSE}.
+#' @param defer.package.load [\code{logical(1)}]\cr
+#'   When set to \code{TRUE}, packages are not loaded when a learner is constructed.
+#'   Instead it is loaded during train / predict. Default is \code{FALSE}.
 #' @template ret_inv_null
 #' @family configure
 #' @export
 configureMlr = function(show.info, on.learner.error, on.learner.warning,
   on.par.without.desc, on.par.out.of.bounds, on.measure.not.applicable,
-  show.learner.output, on.error.dump) {
+  show.learner.output, on.error.dump, defer.package.load) {
 
   defaults = list(
     show.info = TRUE,
@@ -110,6 +113,11 @@ configureMlr = function(show.info, on.learner.error, on.learner.warning,
   if (!missing(on.error.dump)) {
     assertFlag(on.error.dump)
     setMlrOption("on.error.dump", on.error.dump)
+    any.change = TRUE
+  }
+  if (!missing(defer.package.load)) {
+    assertFlag(defer.package.load)
+    setMlrOption("defer.package.load", defer.package.load)
     any.change = TRUE
   }
 


### PR DESCRIPTION
See issue #1898.
This does not fix that issue, but it may be useful in these kind of cases. This commit can serve as a basis of discussion:
* Do we actually want something like this? If not, feel free to close.
* Should the config option have a different name and default to `TRUE` instead of `FALSE`?
* Possibly more elaborate checks whether the relevant package is at least present?