### PR TITLE
Added testgroup.sd aggregation.

### DIFF
--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -19,6 +19,9 @@
 #'   \item{\bold{testgroup.mean}}{\cr Performance values on test sets are grouped according
 #'     to resampling method. The mean for every group is calculated, then the mean of those means.
 #'     Mainly used for repeated CV.}
+#'   \item{\bold{testgroup.sd}}{\cr Similar to \bold{testgroup.sd} - after
+#'     the mean for every group is calculated, the sd of those means is obtained.
+#'     Mainly used for repeated CV.}
 #'   \item{\bold{test.join}}{\cr Performance measure on joined test sets.
 #'     This is especially useful for small sample sizes where unbalanced group sizes have a significant impact
 #'     on the aggregation, especially for cross-validation test.join might make sense now.

--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -19,8 +19,8 @@
 #'   \item{\bold{testgroup.mean}}{\cr Performance values on test sets are grouped according
 #'     to resampling method. The mean for every group is calculated, then the mean of those means.
 #'     Mainly used for repeated CV.}
-#'   \item{\bold{testgroup.sd}}{\cr Similar to \bold{testgroup.sd} - after
-#'     the mean for every group is calculated, the sd of those means is obtained.
+#'   \item{\bold{testgroup.sd}}{\cr Similar to \bold{testgroup.mean} - after
+#'     the mean for every group is calculated, the standard deviation of those means is obtained.
 #'     Mainly used for repeated CV.}
 #'   \item{\bold{test.join}}{\cr Performance measure on joined test sets.
 #'     This is especially useful for small sample sizes where unbalanced group sizes have a significant impact
@@ -232,7 +232,7 @@ testgroup.mean = makeAggregation(
 #' @rdname aggregations
 testgroup.sd = makeAggregation(
   id = "testgroup.sd",
-  name = "Test group sd",
+  name = "Test group standard deviation",
   properties = "req.test",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     sd(BBmisc::vnapply(split(perf.test, group), mean))

--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -227,6 +227,17 @@ testgroup.mean = makeAggregation(
 
 #' @export
 #' @rdname aggregations
+testgroup.sd = makeAggregation(
+  id = "testgroup.sd",
+  name = "Test group sd",
+  properties = "req.test",
+  fun = function(task, perf.test, perf.train, measure, group, pred) {
+    sd(BBmisc::vnapply(split(perf.test, group), mean))
+  }
+)
+
+#' @export
+#' @rdname aggregations
 test.join = makeAggregation(
   id = "test.join",
   name = "Test join",

--- a/tests/testthat/test_base_aggregations.R
+++ b/tests/testthat/test_base_aggregations.R
@@ -9,3 +9,17 @@ test_that("aggregations", {
   expect_equal(length(a), length(ms))
   expect_true(!any(is.na(as.logical(a))))
 })
+
+test_that("testgroup.mean", {
+  perf.test = 1:4
+  group = c(1,1,2,2)
+
+  expect_equal(testgroup.mean$fun(NA, perf.test, NA, mean, group, NA), mean(c(mean(1:2), mean(3:4))))
+})
+
+test_that("testgroup.sd", {
+  perf.test = 1:10
+  group = c(rep(1,5),rep(2,5))
+
+  expect_equal(testgroup.sd$fun(NA, perf.test, NA, mean, group, NA), sd(c(mean(1:5),mean(6:10))))
+})


### PR DESCRIPTION
Added `testgroup.sd` aggregation function to give some information about differences in performance measure values between different runs of `RepCV` resampling.