### PR TITLE
Use absolute values in conf matrix for roc measure calculation

### DIFF
--- a/R/calculateROCMeasures.R
+++ b/R/calculateROCMeasures.R
@@ -1,7 +1,7 @@
 #' @title Calculate receiver operator measures.
 #'
 #' @description
-#' Calculate the relative number of correct/incorrect classifications and the following evaluation measures:
+#' Calculate the absolute number of correct/incorrect classifications and the following evaluation measures:
 #'
 #'
 #' \itemize{
@@ -29,7 +29,7 @@
 #'
 #' @return [\code{ROCMeasures}].
 #'    A list containing two elements \code{confusion.matrix} which is
-#'    the 2 times 2 confusion matrix of relative frequencies and \code{measures}, a list of the above mentioned measures.
+#'    the 2 times 2 confusion matrix of absolute frequencies and \code{measures}, a list of the above mentioned measures.
 #' @export
 #' @family roc
 #' @family performance
@@ -42,7 +42,7 @@
 calculateROCMeasures = function(pred) {
 
   checkPrediction(pred, task.type = "classif", check.truth = TRUE, no.na = TRUE, binary = TRUE)
-  tab = calculateConfusionMatrix(pred, relative = TRUE)$relative.row[1:2, 1:2]
+  tab = calculateConfusionMatrix(pred, relative = FALSE)$result[1:2, 1:2]
   response = getPredictionResponse(pred)
   truth = getPredictionTruth(pred)
   positive = pred$task.desc$positive

--- a/tests/testthat/test_base_calculateROCMeasures.R
+++ b/tests/testthat/test_base_calculateROCMeasures.R
@@ -7,7 +7,7 @@ test_that("calculateROCMeasures", {
 
   expect_list(r$measures, types = "double", any.missing = FALSE, len = 12)
   expect_matrix(r$confusion.matrix, mode = "double", any.missing = FALSE, nrows = 2, ncols = 2)
-  expect_true(all(rowSums(r$confusion.matrix) == 1))
+  expect_true(all(rowSums(r$confusion.matrix) == table(getTaskTargets(binaryclass.task))))
 
   response = getPredictionResponse(pred$pred)
   truth = getPredictionTruth(pred$pred)


### PR DESCRIPTION
Fixes #1958 


I didn't add the row/col sums, since the ROCmeasures are only defined for two-class problems which makes them still easy to see imo.

If you really want I can add them, but the output is already a bit cluttered.