### PR TITLE
revert na.rm aggregations (PR #1980)

### DIFF
--- a/R/Aggregation.R
+++ b/R/Aggregation.R
@@ -54,8 +54,6 @@ NULL
 #'     \item{\code{pred} [\code{\link{Prediction}}]}{
 #'       Prediction object.}
 #'   }
-#' @param na.rm [\code{logical(1)}]\cr
-#'   Should `NA` values be removed? Default `FALSE`.
 #' @seealso \code{\link{aggregations}}, \code{\link{setAggregation}}
 #' @return [\code{\link{Aggregation}}].
 #' @examples
@@ -64,7 +62,7 @@ NULL
 #'   properties = "req.test",
 #'   fun = function (task, perf.test, perf.train, measure, group, pred) IQR(perf.test))
 #' @export
-makeAggregation = function(id, name = id, properties, fun, na.rm = FALSE) {
+makeAggregation = function(id, name = id, properties, fun) {
   assertString(id)
   assertString(name)
   makeS3Obj("Aggregation", id = id, name = name, fun = fun, properties = properties)

--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -40,7 +40,7 @@ test.mean = makeAggregation(
   id = "test.mean",
   name = "Test mean",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) mean(perf.test, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) mean(perf.test)
 )
 
 #' @export
@@ -49,7 +49,7 @@ test.sd = makeAggregation(
   id = "test.sd",
   name = "Test sd",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) sd(perf.test, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) sd(perf.test)
 )
 
 #' @export
@@ -58,7 +58,7 @@ test.median = makeAggregation(
   id = "test.median",
   name = "Test median",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) median(perf.test, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) median(perf.test)
 )
 
 #' @export
@@ -67,7 +67,7 @@ test.min = makeAggregation(
   id = "test.min",
   name = "Test minimum",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) min(perf.test, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) min(perf.test)
 )
 
 #' @export
@@ -76,7 +76,7 @@ test.max = makeAggregation(
   id = "test.max",
   name = "Test maximum",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) max(perf.test, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.test)
 )
 
 #' @export
@@ -85,7 +85,7 @@ test.sum = makeAggregation(
   id = "test.sum",
   name = "Test sum",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) sum(perf.test, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) sum(perf.test)
 )
 
 #' @export
@@ -94,7 +94,7 @@ test.range = makeAggregation(
   id = "test.range",
   name = "Test range",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) diff(range(perf.test, na.rm = na.rm))
+  fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.test))
 )
 
 #' @export
@@ -103,7 +103,7 @@ test.rmse = makeAggregation(
   id = "test.rmse",
   name = "Test RMSE",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) sqrt(mean(perf.test^2, na.rm = na.rm))
+  fun = function(task, perf.test, perf.train, measure, group, pred) sqrt(mean(perf.test^2))
 )
 
 #' @export
@@ -112,7 +112,7 @@ train.mean = makeAggregation(
   id = "train.mean",
   name = "Training mean",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) mean(perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) mean(perf.train)
 )
 
 #' @export
@@ -121,7 +121,7 @@ train.sd = makeAggregation(
   id = "train.sd",
   name = "Training sd",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) sd(perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) sd(perf.train)
 )
 
 #' @export
@@ -130,7 +130,7 @@ train.median = makeAggregation(
   id = "train.median",
   name = "Training median",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) median(perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) median(perf.train)
 )
 
 #' @export
@@ -139,7 +139,7 @@ train.min = makeAggregation(
   id = "train.min",
   name = "Training min",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) min(perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) min(perf.train)
 )
 
 #' @export
@@ -148,7 +148,7 @@ train.max = makeAggregation(
   id = "train.max",
   name = "Training max",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.train)
 )
 
 #' @export
@@ -157,7 +157,7 @@ train.sum = makeAggregation(
   id = "train.sum",
   name = "Training sum",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) sum(perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) sum(perf.train)
 )
 
 #' @export
@@ -166,7 +166,7 @@ train.range = makeAggregation(
   id = "train.range",
   name = "Training range",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.train, na.rm = na.rm))
+  fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.train))
 )
 
 #' @export
@@ -175,7 +175,7 @@ train.rmse = makeAggregation(
   id = "train.rmse",
   name = "Training RMSE",
   properties = "req.train",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) sqrt(mean(perf.train^2, na.rm = na.rm))
+  fun = function(task, perf.test, perf.train, measure, group, pred) sqrt(mean(perf.train^2))
 )
 
 #' @export
@@ -184,8 +184,8 @@ b632 = makeAggregation(
   id = "b632",
   name = ".632 Bootstrap",
   properties = c("req.train", "req.test"),
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) {
-    mean(0.632 * perf.test + 0.368 * perf.train, na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) {
+    mean(0.632 * perf.test + 0.368 * perf.train)
   }
 )
 
@@ -197,7 +197,7 @@ b632plus = makeAggregation(
   id = "b632plus",
   name = ".632 Bootstrap plus",
   properties = c("req.train", "req.test"),
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) {
+  fun = function(task, perf.test, perf.train, measure, group, pred) {
     df = as.data.frame(pred)
     a = numeric(length(perf.test))
     for (i in seq_along(a)) {
@@ -213,7 +213,7 @@ b632plus = makeAggregation(
       w = 0.632 / (1 - 0.368 * R)
       a[i] = (1 - w) * perf.train[i] + w * perf.test[i]
     }
-    return(mean(a, na.rm = na.rm))
+    return(mean(a))
   }
 )
 
@@ -223,8 +223,8 @@ testgroup.mean = makeAggregation(
   id = "testgroup.mean",
   name = "Test group mean",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) {
-    mean(vnapply(split(perf.test, group), mean), na.rm = na.rm)
+  fun = function(task, perf.test, perf.train, measure, group, pred) {
+    mean(vnapply(split(perf.test, group), mean))
   }
 )
 
@@ -234,8 +234,8 @@ testgroup.sd = makeAggregation(
   id = "testgroup.sd",
   name = "Test group standard deviation",
   properties = "req.test",
-  fun = function(task, perf.test, perf.train, measure, group, pred, na.rm) {
-    sd(BBmisc::vnapply(split(perf.test, group), mean, na.rm = na.rm))
+  fun = function(task, perf.test, perf.train, measure, group, pred) {
+    sd(BBmisc::vnapply(split(perf.test, group), mean))
   }
 )
 

--- a/R/checkMeasures.R
+++ b/R/checkMeasures.R
@@ -1,25 +1,8 @@
-#' @title Checks for correct strucutre of selected measures
-#'
-#' @param measures [\code{list}]\cr
-#'   list of measures
-#' @param obj [\code{data.frame}]\cr
-#'   task
-#' @param aggr [\code{function]\cr
-#'   aggregation function
-#' @param na.rm [\code{logical(1)}]\cr
-#'   Should `NA` values be removed? Default `FALSE`.
-#'   This applies to all selected measures.
-#' @keywords internal
-#' @export
-
-checkMeasures = function(measures, obj, aggr = NULL, na.rm = FALSE) {
+checkMeasures = function(measures, obj, aggr = NULL) {
   if (missing(measures)) {
     measures = list(getDefaultMeasure(obj))
   } else {
     measures = ensureVector(measures, n = 1L, cl = "Measure")
-    for (i in seq_along(measures)) {
-      measures[[i]]$aggr$na.rm = na.rm
-    }
     assertList(measures, types = "Measure", min.len = 1L)
   }
   if (!is.null(aggr))

--- a/R/performance.R
+++ b/R/performance.R
@@ -12,9 +12,6 @@
 #'   Features of predicted data, usually not needed except for clustering.
 #'   If the prediction was generated from a \code{task}, you can also pass this instead and the features
 #'   are extracted from it.
-#' @param na.rm [\code{logical(1)}]\cr
-#'   Should `NA` values be removed? Default `FALSE`.
-#'   This applies to all selected measures.
 #' @return [named \code{numeric}]. Performance value(s), named by measure(s).
 #' @export
 #' @family performance
@@ -31,10 +28,10 @@
 #' # Compute multiple performance measures at once
 #' ms = list("mmce" = mmce, "acc" = acc, "timetrain" = timetrain)
 #' performance(pred, measures = ms, task, mod)
-performance = function(pred, measures, task = NULL, model = NULL, feats = NULL, na.rm = FALSE) {
+performance = function(pred, measures, task = NULL, model = NULL, feats = NULL) {
   if (!is.null(pred))
     assertClass(pred, classes = "Prediction")
-  measures = checkMeasures(measures, pred$task.desc, na.rm = na.rm)
+  measures = checkMeasures(measures, pred$task.desc)
   res = vnapply(measures, doPerformanceIteration, pred = pred, task = task, model = model, td = NULL, feats = feats)
   # FIXME: This is really what the names should be, but it breaks all kinds of other stuff
   #if (inherits(pred, "ResamplePrediction")) {

--- a/R/resample.R
+++ b/R/resample.R
@@ -44,9 +44,6 @@
 #'   during resampling.
 #'   Default is to extract nothing.
 #' @template arg_keep_pred
-#' @param na.rm [\code{logical(1)}]\cr
-#'   Should `NA` values be removed during aggregation of results from `resample`? Default `FALSE`.
-#'   This applies to all selected measures.
 #' @param ... [any]\cr
 #'   Further hyperparameters passed to \code{learner}.
 #' @template arg_showinfo
@@ -70,7 +67,7 @@
 #'   measures = list(mmce, setAggregation(mmce, train.mean)))
 #' print(r$aggr)
 resample = function(learner, task, resampling, measures, weights = NULL, models = FALSE,
-  extract, keep.pred = TRUE, na.rm = FALSE, ..., show.info = getMlrOption("show.info")) {
+  extract, keep.pred = TRUE, ..., show.info = getMlrOption("show.info")) {
 
   learner = checkLearner(learner)
   learner = setHyperPars(learner, ...)
@@ -80,7 +77,7 @@ resample = function(learner, task, resampling, measures, weights = NULL, models 
   if (inherits(resampling, "ResampleDesc"))
     resampling = makeResampleInstance(resampling, task = task)
   assertClass(resampling, classes = "ResampleInstance")
-  measures = checkMeasures(measures, task, na.rm = na.rm)
+  measures = checkMeasures(measures, task)
   if (!is.null(weights)) {
     assertNumeric(weights, len = n, any.missing = FALSE, lower = 0)
   }
@@ -100,8 +97,7 @@ resample = function(learner, task, resampling, measures, weights = NULL, models 
 
   rin = resampling
   more.args = list(learner = learner, task = task, rin = rin, weights = NULL,
-    measures = measures, model = models, extract = extract, show.info = show.info,
-    na.rm = na.rm)
+    measures = measures, model = models, extract = extract, show.info = show.info)
   if (!is.null(weights)) {
     more.args$weights = weights
   } else if (!is.null(getTaskWeights(task))) {
@@ -137,18 +133,18 @@ resample = function(learner, task, resampling, measures, weights = NULL, models 
 
 
 # this wraps around calculateREsampleIterationResult and contains the subsetting for a specific fold i
-doResampleIteration = function(learner, task, rin, i, measures, weights, model, extract, show.info, na.rm) {
+doResampleIteration = function(learner, task, rin, i, measures, weights, model, extract, show.info) {
   setSlaveOptions()
   train.i = rin$train.inds[[i]]
   test.i = rin$test.inds[[i]]
   calculateResampleIterationResult(learner = learner, task = task, i = i, train.i = train.i, test.i = test.i, measures = measures,
-    weights = weights, rdesc = rin$desc, model = model, extract = extract, show.info = show.info, na.rm = na.rm)
+    weights = weights, rdesc = rin$desc, model = model, extract = extract, show.info = show.info)
 }
 
 
 #Evaluate one train/test split of the resample function and get one or more performance values
 calculateResampleIterationResult = function(learner, task, i, train.i, test.i, measures,
-  weights, rdesc, model, extract, show.info, na.rm) {
+  weights, rdesc, model, extract, show.info) {
 
   err.msgs = c(NA_character_, NA_character_)
   err.dumps = list()
@@ -180,7 +176,7 @@ calculateResampleIterationResult = function(learner, task, i, train.i, test.i, m
   } else if (pp == "test") {
     pred.test = predict(m, task, subset = test.i)
     if (!is.na(pred.test$error)) err.msgs[2L] = pred.test$error
-    ms.test = performance(task = task, model = m, pred = pred.test, measures = measures, na.rm = na.rm)
+    ms.test = performance(task = task, model = m, pred = pred.test, measures = measures)
     names(ms.test) = vcapply(measures, measureAggrName)
     err.dumps$predict.test = getPredictionDump(pred.test)
   } else { # "both"
@@ -258,7 +254,7 @@ mergeResampleResult = function(learner.id, task, iter.results, measures, rin, mo
   # aggr = vnapply(measures, function(m) m$aggr$fun(task, ms.test[, m$id], ms.train[, m$id], m, rin$group, pred))
   aggr = vnapply(seq_along(measures), function(i) {
     m = measures[[i]]
-    m$aggr$fun(task, ms.test[, i], ms.train[, i], m, rin$group, pred, m$aggr$na.rm)
+    m$aggr$fun(task, ms.test[, i], ms.train[, i], m, rin$group, pred)
   })
   names(aggr) = vcapply(measures, measureAggrName)
 

--- a/man/makeAggregation.Rd
+++ b/man/makeAggregation.Rd
@@ -4,7 +4,7 @@
 \alias{makeAggregation}
 \title{Specify your own aggregation of measures.}
 \usage{
-makeAggregation(id, name = id, properties, fun, na.rm = FALSE)
+makeAggregation(id, name = id, properties, fun)
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr
@@ -37,9 +37,6 @@ Calculates the aggregated performance. In most cases you will only need the perf
   \item{\code{pred} [\code{\link{Prediction}}]}{
     Prediction object.}
 }}
-
-\item{na.rm}{[\code{logical(1)}]\cr
-Should `NA` values be removed? Default `FALSE`.}
 }
 \value{
 [\code{\link{Aggregation}}].

--- a/man/performance.Rd
+++ b/man/performance.Rd
@@ -4,8 +4,7 @@
 \alias{performance}
 \title{Measure performance of prediction.}
 \usage{
-performance(pred, measures, task = NULL, model = NULL, feats = NULL,
-  na.rm = FALSE)
+performance(pred, measures, task = NULL, model = NULL, feats = NULL)
 }
 \arguments{
 \item{pred}{[\code{\link{Prediction}}]\cr

--- a/man/resample.Rd
+++ b/man/resample.Rd
@@ -12,7 +12,7 @@
 \title{Fit models according to a resampling strategy.}
 \usage{
 resample(learner, task, resampling, measures, weights = NULL,
-  models = FALSE, extract, keep.pred = TRUE, na.rm = FALSE, ...,
+  models = FALSE, extract, keep.pred = TRUE, ...,
   show.info = getMlrOption("show.info"))
 
 crossval(learner, task, iters = 10L, stratify = FALSE, measures,
@@ -82,10 +82,13 @@ object size / mem usage, if you do not really need them.
 In this case you can set this argument to \code{FALSE}.
 Default is \code{TRUE}.}
 
+<<<<<<< HEAD
 \item{na.rm}{[\code{logical(1)}]\cr
 Should `NA` values be removed during aggregation of results from `resample`? Default `FALSE`.
 This applies to all selected measures.}
 
+=======
+>>>>>>> parent of 71f700f... Add na.rm flag to remove NAs during resample aggregration (#1980)
 \item{...}{[any]\cr
 Further hyperparameters passed to \code{learner}.}
 

--- a/tests/testthat/test_base_aggregations.R
+++ b/tests/testthat/test_base_aggregations.R
@@ -14,28 +14,12 @@ test_that("testgroup.mean", {
   perf.test = 1:4
   group = c(1, 1, 2, 2)
 
-  expect_equal(testgroup.mean$fun(NA, perf.test, NA, mean, group, NA, FALSE), mean(c(mean(1:2), mean(3:4))))
+  expect_equal(testgroup.mean$fun(NA, perf.test, NA, mean, group, NA), mean(c(mean(1:2), mean(3:4))))
 })
 
 test_that("testgroup.sd", {
   perf.test = 1:10
   group = c(rep(1, 5), rep(2, 5))
 
-  expect_equal(testgroup.sd$fun(NA, perf.test, NA, mean, group, NA, FALSE), sd(c(mean(1:5), mean(6:10))))
-})
-
-# check na.rm argument
-
-test_that("test.mean with NA", {
-  perf.test = 1:4
-  perf.test[1] = NA
-
-  expect_scalar_na(test.mean$fun(NA, perf.test, NA, mean, NA, NA, na.rm = FALSE))
-})
-
-test_that("test.mean with NA removal", {
-  perf.test = 1:4
-  perf.test[1] = NA
-
-  expect_equal(test.mean$fun(NA, perf.test, NA, mean, NA, NA, na.rm = TRUE), 3)
+  expect_equal(testgroup.sd$fun(NA, perf.test, NA, mean, group, NA), sd(c(mean(1:5), mean(6:10))))
 })


### PR DESCRIPTION
This reverts #1980 as it breaks a lot of stuff and should (hopefully) keep everything we did afterward.

The original PR #1980 should be reopened when this is merged.