### PR TITLE
Add support for missings in h2o glm & deeplearning

### DIFF
--- a/R/RLearner_classif_h2odeeplearning.R
+++ b/R/RLearner_classif_h2odeeplearning.R
@@ -219,7 +219,7 @@ makeRLearner.classif.h2o.deeplearning = function() {
       makeLogicalLearnerParam("reproducible", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam("export_weights_and_biases", default = FALSE, tunable = FALSE)
     ),
-    properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights"),
+    properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights", "missings"),
     name = "h2o.deeplearning",
     short.name = "h2o.dl",
     callees = "h2o.deeplearning"

--- a/R/RLearner_classif_h2oglm.R
+++ b/R/RLearner_classif_h2oglm.R
@@ -21,7 +21,7 @@ makeRLearner.classif.h2o.glm = function() {
       makeUntypedLearnerParam("beta_constraints"),
       makeLogicalLearnerParam("intercept", default = TRUE)
     ),
-    properties = c("twoclass", "numerics", "factors", "prob", "weights"),
+    properties = c("twoclass", "numerics", "factors", "prob", "weights", "missings"),
     name = "h2o.glm",
     short.name = "h2o.glm",
     note = "'family' is always set to 'binomial' to get a binary classifier.",

--- a/R/RLearner_regr_h2odeeplearning.R
+++ b/R/RLearner_regr_h2odeeplearning.R
@@ -227,7 +227,7 @@ makeRLearner.regr.h2o.deeplearning = function() {
       makeLogicalLearnerParam("reproducible", default = FALSE, tunable = FALSE),
       makeLogicalLearnerParam("export_weights_and_biases", default = FALSE, tunable = FALSE)
     ),
-    properties = c("numerics", "factors", "weights"),
+    properties = c("numerics", "factors", "weights", "missings"),
     name = "h2o.deeplearning",
     short.name = "h2o.dl",
     callees = "h2o.deeplearning"

--- a/R/RLearner_regr_h2oglm.R
+++ b/R/RLearner_regr_h2oglm.R
@@ -19,7 +19,7 @@ makeRLearner.regr.h2o.glm = function() {
       makeUntypedLearnerParam("beta_constraints"),
       makeLogicalLearnerParam("intercept", default = TRUE)
     ),
-    properties = c("numerics", "factors", "weights"),
+    properties = c("numerics", "factors", "weights", "missings"),
     name = "h2o.glm",
     short.name = "h2o.glm",
     note = "'family' is always set to 'gaussian'.",


### PR DESCRIPTION
This PR adds the "missings" property to H2O GLM and Deep Learning classification and regression functions.  Both H2O GLM and Deep Learning support missing values by default using mean imputation.  No action is required by the user, missings are handled automatically.

For the GLM, it was originally added in this [PR](https://github.com/mlr-org/mlr/pull/1710), but there was confusion about whether it was supported, so then it was removed [here](https://github.com/mlr-org/mlr/commit/7a18393cf82615bb6d1f1036400f6056e1cba78d).  

