### PR TITLE
Replacing MeanSquare with Quadratic in h2o deeplearning issue #2000

### DIFF
--- a/R/RLearner_classif_h2odeeplearning.R
+++ b/R/RLearner_classif_h2odeeplearning.R
@@ -62,7 +62,7 @@
 # Unifrom: -value ... value, Normal: stddev
 
 # loss
-# Loss function: Automatic, CrossEntropy (for classification only), MeanSquare, Absolute (experimental) or Huber (experimental)
+# Loss function: Automatic, CrossEntropy (for classification only), Quadratic, Absolute (experimental) or Huber (experimental)
 
 # score_interval
 # Shortest time interval (in secs) between model scoring
@@ -188,7 +188,7 @@ makeRLearner.classif.h2o.deeplearning = function() {
         values = c("UniformAdaptive", "Uniform", "Normal"), default = "UniformAdaptive"),
       makeNumericLearnerParam("initial_weight_scale", default = 1),
       makeDiscreteLearnerParam("loss", values = c("Automatic", "CrossEntropy",
-        "MeanSquare", "Absolute", "Huber")),
+        "Quadratic", "Absolute", "Huber")),
       makeNumericLearnerParam("score_interval", default = 5),
       makeIntegerLearnerParam("score_training_samples", default = 10000),
       makeIntegerLearnerParam("score_validation_samples", default = 0),

--- a/R/RLearner_regr_h2odeeplearning.R
+++ b/R/RLearner_regr_h2odeeplearning.R
@@ -62,7 +62,7 @@
 # Unifrom: -value ... value, Normal: stddev
 
 # loss
-# Loss function: Automatic, CrossEntropy (for classification only), MeanSquare, Absolute (experimental) or Huber (experimental)
+# Loss function: Automatic, CrossEntropy (for classification only), Quadratic, Absolute (experimental) or Huber (experimental)
 
 # score_interval
 # Shortest time interval (in secs) between model scoring
@@ -186,7 +186,7 @@ makeRLearner.regr.h2o.deeplearning = function() {
       makeDiscreteLearnerParam("initial_weight_distribution",
         values = c("UniformAdaptive", "Uniform", "Normal"), default = "UniformAdaptive"),
       makeNumericLearnerParam("initial_weight_scale", default = 1),
-      makeDiscreteLearnerParam("loss", values = c("Automatic", "MeanSquare",
+      makeDiscreteLearnerParam("loss", values = c("Automatic", "Quadratic",
         "Absolute", "Huber")),
       makeDiscreteLearnerParam("distribution", values = c("AUTO", "gaussian",
         "bernoulli", "multinomial", "poisson", "gamma", "tweedie", "laplace",


### PR DESCRIPTION
This fixes: https://github.com/mlr-org/mlr/issues/2000  This PR is a simple string replace of "MeanSquare" for "Quadratic" in the H2O Deep Learning classification and regression functions.