### PR TITLE
Adding notes on missing vals to h2o glm & deeplearning

### DIFF
--- a/R/RLearner_classif_h2odeeplearning.R
+++ b/R/RLearner_classif_h2odeeplearning.R
@@ -222,6 +222,7 @@ makeRLearner.classif.h2o.deeplearning = function() {
     properties = c("twoclass", "multiclass", "numerics", "factors", "prob", "weights", "missings"),
     name = "h2o.deeplearning",
     short.name = "h2o.dl",
+    note = 'The default value of `missing_values_handling` is `"MeanImputation"`, so missing values are automatically mean-imputed.',
     callees = "h2o.deeplearning"
   )
 }

--- a/R/RLearner_classif_h2oglm.R
+++ b/R/RLearner_classif_h2oglm.R
@@ -24,7 +24,7 @@ makeRLearner.classif.h2o.glm = function() {
     properties = c("twoclass", "numerics", "factors", "prob", "weights", "missings"),
     name = "h2o.glm",
     short.name = "h2o.glm",
-    note = "'family' is always set to 'binomial' to get a binary classifier.",
+    note = '`family` is always set to `"binomial"` to get a binary classifier. The default value of `missing_values_handling` is `"MeanImputation"`, so missing values are automatically mean-imputed.',
     callees = "h2o.glm"
   )
 }

--- a/R/RLearner_regr_h2odeeplearning.R
+++ b/R/RLearner_regr_h2odeeplearning.R
@@ -230,6 +230,7 @@ makeRLearner.regr.h2o.deeplearning = function() {
     properties = c("numerics", "factors", "weights", "missings"),
     name = "h2o.deeplearning",
     short.name = "h2o.dl",
+    note = 'The default value of `missing_values_handling` is `"MeanImputation"`, so missing values are automatically mean-imputed.',
     callees = "h2o.deeplearning"
   )
 }

--- a/R/RLearner_regr_h2oglm.R
+++ b/R/RLearner_regr_h2oglm.R
@@ -22,7 +22,7 @@ makeRLearner.regr.h2o.glm = function() {
     properties = c("numerics", "factors", "weights", "missings"),
     name = "h2o.glm",
     short.name = "h2o.glm",
-    note = "'family' is always set to 'gaussian'.",
+    note = '`family` is always set to `"gaussian"`. The default value of `missing_values_handling` is `"MeanImputation"`, so missing values are automatically mean-imputed.',
     callees = "h2o.glm"
   )
 }


### PR DESCRIPTION
As suggested by @kdpsingh and @berndbischl in this PR, https://github.com/mlr-org/mlr/pull/1710, I have added a note to the H2O GLM and Deep Learning functions about how missing values are handled (they are mean-imputed), so that it will appear in the [integrated learners table](https://mlr-org.github.io/mlr-tutorial/devel/html/integrated_learners/index.html) in the MLR Tutorial.