### PR TITLE
Adding .github to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@ testinfo.RData
 ^thirdparty$
 ^.git$
 ^makeR$
+.github


### PR DESCRIPTION
When running `R CMD check`, I was getting the following NOTE:

```
* checking for hidden files and directories ... NOTE
Found the following hidden files and directories:
  .github
These were most likely included in error. See section ‘Package
structure’ in the ‘Writing R Extensions’ manual.
```
So I've added `.github` to the `.Rbuildignore` file.  Unless the mlr dev team has some reason for not adding this (that I am not aware of), it seems like a good idea to add this line.  After this change, the NOTE goes away.