### PR TITLE
fix seeding for new version of rfsrc

### DIFF
--- a/R/RLearner_classif_randomForestSRC.R
+++ b/R/RLearner_classif_randomForestSRC.R
@@ -34,7 +34,7 @@ makeRLearner.classif.randomForestSRC = function() {
         values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
       makeDiscreteLearnerParam(id = "split.depth", default = FALSE, tunable = FALSE,
         values = list(`FALSE` = FALSE, "all.trees", "by.tree")),
-      makeIntegerLearnerParam(id = "seed", upper = 0L, tunable = FALSE),
+      makeIntegerLearnerParam(id = "seed", lower = 0L, tunable = FALSE),
       makeLogicalLearnerParam(id = "do.trace", default = FALSE, tunable = FALSE, when = "both"), # is currently ignored
       makeLogicalLearnerParam(id = "membership", default = TRUE, tunable = FALSE),
       makeLogicalLearnerParam(id = "statistics", default = FALSE, tunable = FALSE),

--- a/tests/testthat/test_classif_randomForestSRC.R
+++ b/tests/testthat/test_classif_randomForestSRC.R
@@ -4,10 +4,10 @@ test_that("classif_randomForestSRC", {
   requirePackagesOrSkip("randomForestSRC", default.method = "load")
 
   parset.list = list(
-    list(),
-    list(ntree = 100),
-    list(ntree = 250, mtry = 5L),
-    list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE)
+    list(seed = getOption("mlr.debug.seed")),
+    list(ntree = 100, seed = getOption("mlr.debug.seed")),
+    list(ntree = 250, mtry = 5L, seed = getOption("mlr.debug.seed")),
+    list(ntree = 250, nodesize = 2, na.action = "na.impute", importance = "permute", proximity = FALSE, seed = getOption("mlr.debug.seed"))
   )
   old.predicts.list = list()
   old.probs.list = list()


### PR DESCRIPTION
It seems that something changed with the seeding of randomForestSRC in the new version.

added the seed argument for the unit test. This should hopefully fix travis.


If you have a nicer fix, feel free