### PR TITLE
Add Citations, fixes #1694

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,23 +1,107 @@
-bibentry(
-  bibtype = "Article",
-  key = "mlr",
-  title = "{mlr}: Machine Learning in R",
-  author = c(
-    person("Bernd", "Bischl"),
-    person("Michel", "Lang"),
-    person("Lars", "Kotthoff"),
-    person("Julia", "Schiffner"),
-    person("Jakob", "Richter"),
-    person("Erich", "Studerus"),
-    person("Giuseppe", "Casalicchio"),
-    person("Zachary M.", "Jones")
+bref = c(
+  bibentry(
+    bibtype = "Article",
+    key = "mlr",
+    title = "{mlr}: Machine Learning in R",
+    author = c(
+      person("Bernd", "Bischl"),
+      person("Michel", "Lang"),
+      person("Lars", "Kotthoff"),
+      person("Julia", "Schiffner"),
+      person("Jakob", "Richter"),
+      person("Erich", "Studerus"),
+      person("Giuseppe", "Casalicchio"),
+      person("Zachary M.", "Jones")
+    ),
+    journal = "Journal of Machine Learning Research",
+    year = 2016L,
+    volume = 17L,
+    number = 170L,
+    pages = "1-5",
+    url = "http://jmlr.org/papers/v17/15-066.html"
   ),
-  journal = "Journal of Machine Learning Research",
-  year = 2016L,
-  volume = 17L,
-  number = 170L,
-  pages = "1-5",
-  url = "http://jmlr.org/papers/v17/15-066.html"
+  bibentry(
+    bibtype = "Article",
+    key = "automatic",
+    title = "Automatic model selection for high-dimensional survival analysis",
+    author = c(
+      person("Michel", "Lang"),
+      person("Helena", "Kotthaus"),
+      person("Peter", "Marwedel"),
+      person("Claus", "Weihs"),
+      person("Jörg", "Rahnenführer"),
+      person("Bernd", "Bischl")
+    ),
+    journal = "Journal of Statistical Computation and Simulation",
+    year = 2014L,
+    volume = 85L,
+    number = 1L,
+    pages = "62-76",
+    publisher= "Taylor & Francis"
+  ),
+  bibentry(
+    bibtype = "incollection",
+    title = "On Class Imbalance Correction for Classification Algorithms in Credit Scoring",
+    key = 'bischl2016class',
+    author = c(
+      person("Bernd", "Bischl"),
+      person("Tobias", "Kühn"),
+      person("Gero", "Szepannek")
+    ),
+    booktitle = "Operations Research Proceedings 2014",
+    pages = "37-43",
+    year = 2016L,
+    publisher = "Springer"
+  ),
+  bibentry(
+    bibtype = "Article",
+    title = "mlrMBO: A Modular Framework for Model-Based Optimization of Expensive Black-Box Functions",
+    key = "mlrmbo",
+    author = c(
+      person("Bernd", "Bischl"),
+      person("Jakob", "Richter"),
+      person("Jakob", "Bossek"),
+      person("Daniel", "Horn"),
+      person("Janek", "Thomas"),
+      person("Michel", "Lang")
+    ),
+    journal = "arXiv preprint arXiv:1703.03373",
+    year = 2017L
+  ),
+  bibentry(
+    bibtype = "Article",
+    title = "Multilabel Classification with R Package mlr",
+    key = "multilabel",
+    author = c(
+      person("Philipp", "Probst"),
+      person("Quay", "Au"),
+      person("Giuseppe", "Casalicchio"),
+      person("Clemens", "Stachl"),
+      person("Bernd", "Bischl")
+    ),
+    journal = "arXiv preprint arXiv:1703.08991",
+    year = 2017L
+  ),
+  bibentry(
+    bibtype = "Article",
+    title = "OpenML: An R package to connect to the machine learning platform OpenML",
+    key = "openml",
+    author = c(
+      person("Giuseppe", "Casalicchio"),
+      person("Jakob", "Bossek"),
+      person("Michel", "Lang"),
+      person("Dominik", "Kirchhoff"),
+      person("Pascal", "Kerschke"),
+      person("Benjamin", "Hofner"),
+      person("Heidi", "Seibold"),
+      person("Joaquin", "Vanschoren"),
+      person("Bernd", "Bischl")
+    ),
+    journal = "Computational Statistics",
+    pages = "1-15",
+    year = 2017L,
+    publisher = "Springer"
+  )
 )
 
 # vim: ft=r


### PR DESCRIPTION
Updates the citation file with the mentioned articles in Readme.md. 


Citing mlr looks like this now:
```r
> citation('mlr')

Bischl B, Lang M, Kotthoff L, Schiffner J, Richter J, Studerus E,
Casalicchio G and Jones Z (2016). “mlr: Machine Learning in R.”
_Journal of Machine Learning Research_, *17*(170), pp. 1-5. <URL:
http://jmlr.org/papers/v17/15-066.html>.

Lang M, Kotthaus H, Marwedel P, Weihs C, Rahnenführer J and Bischl B
(2014). “Automatic model selection for high-dimensional survival
analysis.” _Journal of Statistical Computation and Simulation_,
*85*(1), pp. 62-76.

Bischl B, Kühn T and Szepannek G (2016). “On Class Imbalance Correction
for Classification Algorithms in Credit Scoring.” In _Operations
Research Proceedings 2014_, pp. 37-43. Springer.

Bischl B, Richter J, Bossek J, Horn D, Thomas J and Lang M (2017).
“mlrMBO: A Modular Framework for Model-Based Optimization of Expensive
Black-Box Functions.” _arXiv preprint arXiv:1703.03373_.

Probst P, Au Q, Casalicchio G, Stachl C and Bischl B (2017).
“Multilabel Classification with R Package mlr.” _arXiv preprint
arXiv:1703.08991_.

Casalicchio G, Bossek J, Lang M, Kirchhoff D, Kerschke P, Hofner B,
Seibold H, Vanschoren J and Bischl B (2017). “OpenML: An R package to
connect to the machine learning platform OpenML.” _Computational
Statistics_, pp. 1-15.

```
