### PR TITLE
Fix issue #2047 and refix #838

### DIFF
--- a/R/DownsampleWrapper.R
+++ b/R/DownsampleWrapper.R
@@ -42,11 +42,11 @@ makeDownsampleWrapper = function(learner, dw.perc = 1, dw.stratify = FALSE) {
 trainLearner.DownsampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL,
   dw.perc = 1, dw.stratify = FALSE, ...) {
   if (length(.weights) == getTaskSize(.task)) {
-    .task$weights = .weights  
+    .task$weights = .weights 
     .task = subsetTask(.task, .subset)
   } else {
     .task = subsetTask(.task, .subset)
-    .task$weights = .weights  
+    .task$weights = .weights 
   }
   .task = downsample(.task, perc = dw.perc, stratify = dw.stratify)
   m = train(.learner$next.learner, .task, weights = .task$weights)

--- a/R/DownsampleWrapper.R
+++ b/R/DownsampleWrapper.R
@@ -42,11 +42,11 @@ makeDownsampleWrapper = function(learner, dw.perc = 1, dw.stratify = FALSE) {
 trainLearner.DownsampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL,
   dw.perc = 1, dw.stratify = FALSE, ...) {
   if (length(.weights) == getTaskSize(.task)) {
-    .task$weights = .weights 
+    .task$weights = .weights
     .task = subsetTask(.task, .subset)
   } else {
     .task = subsetTask(.task, .subset)
-    .task$weights = .weights 
+    .task$weights = .weights
   }
   .task = downsample(.task, perc = dw.perc, stratify = dw.stratify)
   m = train(.learner$next.learner, .task, weights = .task$weights)

--- a/R/DownsampleWrapper.R
+++ b/R/DownsampleWrapper.R
@@ -41,8 +41,13 @@ makeDownsampleWrapper = function(learner, dw.perc = 1, dw.stratify = FALSE) {
 #' @export
 trainLearner.DownsampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL,
   dw.perc = 1, dw.stratify = FALSE, ...) {
-  .task$weights = .weights
-  .task = subsetTask(.task, .subset)
+  if (length(.weights) == getTaskSize(.task)) {
+    .task$weights = .weights  
+    .task = subsetTask(.task, .subset)
+  } else {
+    .task = subsetTask(.task, .subset)
+    .task$weights = .weights  
+  }
   .task = downsample(.task, perc = dw.perc, stratify = dw.stratify)
   m = train(.learner$next.learner, .task, weights = .task$weights)
   m$train.task = .task

--- a/R/OverUndersampleWrapper.R
+++ b/R/OverUndersampleWrapper.R
@@ -73,11 +73,11 @@ makeOversampleWrapper = function(learner, osw.rate = 1, osw.cl = NULL) {
 #' @export
 trainLearner.UndersampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL, usw.rate = 1, usw.cl = NULL, ...) {
   if (length(.weights) == getTaskSize(.task)) {
-    .task$weights = .weights 
+    .task$weights = .weights
     .task = subsetTask(.task, .subset)
   } else {
     .task = subsetTask(.task, .subset)
-    .task$weights = .weights 
+    .task$weights = .weights
   }
   .task = undersample(.task, rate = usw.rate, cl = usw.cl)
   m = train(.learner$next.learner, .task, weights = .task$.weights)
@@ -88,11 +88,11 @@ trainLearner.UndersampleWrapper = function(.learner, .task, .subset = NULL, .wei
 #' @export
 trainLearner.OversampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL, osw.rate = 1, osw.cl = NULL, ...) {
     if (length(.weights) == getTaskSize(.task)) {
-    .task$weights = .weights 
+    .task$weights = .weights
     .task = subsetTask(.task, .subset)
   } else {
     .task = subsetTask(.task, .subset)
-    .task$weights = .weights 
+    .task$weights = .weights
   }
   .task = oversample(.task, rate = osw.rate, cl = osw.cl)
   m = train(.learner$next.learner, .task, weights = .task$.weights)

--- a/R/OverUndersampleWrapper.R
+++ b/R/OverUndersampleWrapper.R
@@ -72,18 +72,30 @@ makeOversampleWrapper = function(learner, osw.rate = 1, osw.cl = NULL) {
 
 #' @export
 trainLearner.UndersampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL, usw.rate = 1, usw.cl = NULL, ...) {
-  .task = subsetTask(.task, .subset)
+  if (length(.weights) == getTaskSize(.task)) {
+    .task$weights = .weights  
+    .task = subsetTask(.task, .subset)
+  } else {
+    .task = subsetTask(.task, .subset)
+    .task$weights = .weights  
+  }
   .task = undersample(.task, rate = usw.rate, cl = usw.cl)
-  m = train(.learner$next.learner, .task, weights = .weights)
+  m = train(.learner$next.learner, .task, weights = .task$.weights)
   m$train.task = .task
   makeChainModel(next.model = m, cl = "UndersampleModel")
 }
 
 #' @export
 trainLearner.OversampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL, osw.rate = 1, osw.cl = NULL, ...) {
-  .task = subsetTask(.task, .subset)
+    if (length(.weights) == getTaskSize(.task)) {
+    .task$weights = .weights  
+    .task = subsetTask(.task, .subset)
+  } else {
+    .task = subsetTask(.task, .subset)
+    .task$weights = .weights  
+  }
   .task = oversample(.task, rate = osw.rate, cl = osw.cl)
-  m = train(.learner$next.learner, .task, weights = .weights)
+  m = train(.learner$next.learner, .task, weights = .task$.weights)
   m$train.task = .task
   makeChainModel(next.model = m, cl = "OversampleModel")
 }

--- a/R/OverUndersampleWrapper.R
+++ b/R/OverUndersampleWrapper.R
@@ -73,11 +73,11 @@ makeOversampleWrapper = function(learner, osw.rate = 1, osw.cl = NULL) {
 #' @export
 trainLearner.UndersampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL, usw.rate = 1, usw.cl = NULL, ...) {
   if (length(.weights) == getTaskSize(.task)) {
-    .task$weights = .weights  
+    .task$weights = .weights 
     .task = subsetTask(.task, .subset)
   } else {
     .task = subsetTask(.task, .subset)
-    .task$weights = .weights  
+    .task$weights = .weights 
   }
   .task = undersample(.task, rate = usw.rate, cl = usw.cl)
   m = train(.learner$next.learner, .task, weights = .task$.weights)
@@ -88,11 +88,11 @@ trainLearner.UndersampleWrapper = function(.learner, .task, .subset = NULL, .wei
 #' @export
 trainLearner.OversampleWrapper = function(.learner, .task, .subset = NULL, .weights = NULL, osw.rate = 1, osw.cl = NULL, ...) {
     if (length(.weights) == getTaskSize(.task)) {
-    .task$weights = .weights  
+    .task$weights = .weights 
     .task = subsetTask(.task, .subset)
   } else {
     .task = subsetTask(.task, .subset)
-    .task$weights = .weights  
+    .task$weights = .weights 
   }
   .task = oversample(.task, rate = osw.rate, cl = osw.cl)
   m = train(.learner$next.learner, .task, weights = .task$.weights)

--- a/tests/testthat/helper_mock_learners.R
+++ b/tests/testthat/helper_mock_learners.R
@@ -115,6 +115,25 @@ registerS3method("makeRLearner", "regr.__mlrmocklearners__6", makeRLearner.regr.
 registerS3method("trainLearner", "regr.__mlrmocklearners__6", trainLearner.regr.__mlrmocklearners__6)
 registerS3method("predictLearner", "regr.__mlrmocklearners__6", predictLearner.regr.__mlrmocklearners__6)
 
+makeRLearner.classif.__mlrmocklearners__6 = function() {  # nolint
+  makeRLearnerClassif(
+    cl = "classif.__mlrmocklearners__6", package = character(0L),
+    par.set = makeParamSet(),
+    properties = c("missings", "numerics", "factors", "weights", "twoclass", "multiclass")
+  )
+}
+
+trainLearner.classif.__mlrmocklearners__6 = function(.learner, .task, .subset, .weights = NULL, ...) {  # nolint
+  list(weights = .weights)
+}
+
+predictLearner.classif.__mlrmocklearners__6 = function(.learner, .model, .newdata) {  # nolint
+  rep(1, nrow(.newdata))
+}
+registerS3method("makeRLearner", "classif.__mlrmocklearners__6", makeRLearner.classif.__mlrmocklearners__6)
+registerS3method("trainLearner", "classif.__mlrmocklearners__6", trainLearner.classif.__mlrmocklearners__6)
+registerS3method("predictLearner", "classif.__mlrmocklearners__6", predictLearner.classif.__mlrmocklearners__6)
+
 
 
 

--- a/tests/testthat/test_base_downsample.R
+++ b/tests/testthat/test_base_downsample.R
@@ -53,13 +53,15 @@ test_that("downsample wrapper works with weights, we had issue #838",  {
   lrn = makeDownsampleWrapper("regr.__mlrmocklearners__6", dw.perc = 0.5)
   m = train(lrn, task)
   u = getLearnerModel(m, more.unwrap = TRUE)$weights
-  expect_true(length(u) == n / 2 && all(u %in% w))
+  expect_equal(length(u), n / 2)
+  expect_subset(u, w)
 
   # weights from train
   lrn = makeDownsampleWrapper("regr.__mlrmocklearners__6", dw.perc = 0.5)
-  m = train(lrn, task, subset = 1:10, weights = 1:10)
+  m = train(lrn, task, subset = 11:20, weights = 1:10)
   u = getLearnerModel(m, more.unwrap = TRUE)$weights
-  expect_true(length(u) == 5 && all(u %in% 1:10))
+  expect_equal(length(u), 5)
+  expect_subset(u, 1:10)
 })
 
 test_that("training performance works as expected (#1357)", {

--- a/tests/testthat/test_base_imbal_overundersample.R
+++ b/tests/testthat/test_base_imbal_overundersample.R
@@ -96,3 +96,47 @@ test_that("training performance works as expected (#1357)", {
   r = resample(lrn, binaryclass.task, rdesc, measures = list(setAggregation(num, train.mean)))
   expect_gt(r$measures.train$num, getTaskSize(binaryclass.task) * 0.5 + 1)
 })
+
+test_that("Wrapper works with weights, we had issue #2047", {
+  n = nrow(binaryclass.df)
+  w = 1:n
+  task = makeClassifTask(data = binaryclass.df, target = binaryclass.target, weights = w)
+  b = table(getTaskTargets(task))
+
+  # weights from task, use all
+  lrn = makeOversampleWrapper("classif.__mlrmocklearners__6", osw.rate = 1)
+  m = train(lrn, task)
+  expect_set_equal(getLearnerModel(m, more.unwrap = TRUE)$weights, w)
+
+  lrn = makeUndersampleWrapper("classif.__mlrmocklearners__6", usw.rate = 1)
+  m = train(lrn, task)
+  expect_set_equal(getLearnerModel(m, more.unwrap = TRUE)$weights, w)
+
+  # weights from task, really sample
+  lrn = makeOversampleWrapper("classif.__mlrmocklearners__6", osw.rate = 2)
+  m = train(lrn, task)
+  u = getLearnerModel(m, more.unwrap = TRUE)$weights
+  expect_equal(length(u), min(b)*2 + max(b))
+  expect_subset(u, w)
+
+  lrn = makeUndersampleWrapper("classif.__mlrmocklearners__6", usw.rate = 0.5)
+  m = train(lrn, task)
+  u = getLearnerModel(m, more.unwrap = TRUE)$weights
+  expect_equal(length(u), round(max(b)/2) + min(b))
+  expect_subset(u, w)
+
+  # weights from train
+  subset = c(head(which(getTaskTargets(task) == names(b)[1]), 5),head(which(getTaskTargets(task) == names(b)[2]), 5))
+  lrn = makeOversampleWrapper("classif.__mlrmocklearners__6", osw.rate = 2)
+  m = train(lrn, task, subset = subset, weights = 1:10)
+  u = getLearnerModel(m, more.unwrap = TRUE)$weights
+  expect_equal(length(u), 15)
+  expect_subset(u, 1:10)
+
+  lrn = makeUndersampleWrapper("classif.__mlrmocklearners__6", usw.rate = 2/5)
+  m = train(lrn, task, subset = subset, weights = 1:10)
+  u = getLearnerModel(m, more.unwrap = TRUE)$weights
+  expect_equal(length(u), 7)
+  expect_subset(u, 1:10)
+
+})

--- a/tests/testthat/test_base_imbal_overundersample.R
+++ b/tests/testthat/test_base_imbal_overundersample.R
@@ -116,24 +116,24 @@ test_that("Wrapper works with weights, we had issue #2047", {
   lrn = makeOversampleWrapper("classif.__mlrmocklearners__6", osw.rate = 2)
   m = train(lrn, task)
   u = getLearnerModel(m, more.unwrap = TRUE)$weights
-  expect_equal(length(u), min(b)*2 + max(b))
+  expect_equal(length(u), min(b) * 2 + max(b))
   expect_subset(u, w)
 
   lrn = makeUndersampleWrapper("classif.__mlrmocklearners__6", usw.rate = 0.5)
   m = train(lrn, task)
   u = getLearnerModel(m, more.unwrap = TRUE)$weights
-  expect_equal(length(u), round(max(b)/2) + min(b))
+  expect_equal(length(u), round(max(b) / 2) + min(b))
   expect_subset(u, w)
 
   # weights from train
-  subset = c(head(which(getTaskTargets(task) == names(b)[1]), 5),head(which(getTaskTargets(task) == names(b)[2]), 5))
+  subset = c(head(which(getTaskTargets(task) == names(b)[1]), 5), head(which(getTaskTargets(task) == names(b)[2]), 5))
   lrn = makeOversampleWrapper("classif.__mlrmocklearners__6", osw.rate = 2)
   m = train(lrn, task, subset = subset, weights = 1:10)
   u = getLearnerModel(m, more.unwrap = TRUE)$weights
   expect_equal(length(u), 15)
   expect_subset(u, 1:10)
 
-  lrn = makeUndersampleWrapper("classif.__mlrmocklearners__6", usw.rate = 2/5)
+  lrn = makeUndersampleWrapper("classif.__mlrmocklearners__6", usw.rate = 2 / 5)
   m = train(lrn, task, subset = subset, weights = 1:10)
   u = getLearnerModel(m, more.unwrap = TRUE)$weights
   expect_equal(length(u), 7)


### PR DESCRIPTION
This fixes the issue in #2047.
Furthermore the fix for #838 was not totally correct in the handling of weights if passed in the `train()` call.

I don't know if it's specified somewhere but if weights are passed alongside with subset I suppose the weights go with the subset vector? At least the test by @berndbischl for issue #838 indicates that.
