### PR TITLE
Fix for smote's wrong labeling of constant factors

### DIFF
--- a/R/smote.R
+++ b/R/smote.R
@@ -133,9 +133,10 @@ smote = function(task, rate, nn = 5L, standardize = TRUE, alt.logic = FALSE) {
   # convert ints back to factors
   if (any(!is.num)) {
     for (i in seq_len(ncol(res))) {
-      if (!is.num[i])
+      if (!is.num[i]){
         res[, i] = as.factor(as.integer(res[, i]))
-      levels(res[, i]) = levels(x[, i])
+        levels(res[, i]) = levels(x[, i])
+      }
     }
   }
 

--- a/R/smote.R
+++ b/R/smote.R
@@ -133,9 +133,9 @@ smote = function(task, rate, nn = 5L, standardize = TRUE, alt.logic = FALSE) {
   # convert ints back to factors
   if (any(!is.num)) {
     for (i in seq_len(ncol(res))) {
-      if (!is.num[i]){
-        res[, i] = as.factor(as.integer(res[, i]))
-        levels(res[, i]) = levels(x[, i])
+      if (!is.num[i]) {
+        res[, i] = factor(levels(x[, i])[as.integer(res[, i])],
+                          levels = levels(x[, i]))
       }
     }
   }

--- a/tests/testthat/test_base_imbal_smote.R
+++ b/tests/testthat/test_base_imbal_smote.R
@@ -78,3 +78,18 @@ test_that("smote works with only integer features", {
   task2 = smote(tsk, 2)
   expect_equal(getTaskSize(task2), 1036)
 })
+
+test_that("smote works with constant factor features", {
+  # This reproduces the bug from issue #1951  
+  d = data.frame(
+    x1 = rpois(100, 2),
+    x2 = gl(5, 20, labels=LETTERS[1:5]),
+    y = as.factor(c(rep("+", 90), rep("-", 10)))
+  )
+
+  task = makeClassifTask(data = d, target = "y")
+  task2 = smote(task, rate = 9, nn = 4L)
+
+  expect_equal(table(getTaskData(task2)$x2, getTaskData(task2)$y)[5, 1], 90)
+})
+

--- a/tests/testthat/test_base_imbal_smote.R
+++ b/tests/testthat/test_base_imbal_smote.R
@@ -80,10 +80,10 @@ test_that("smote works with only integer features", {
 })
 
 test_that("smote works with constant factor features", {
-  # This reproduces the bug from issue #1951  
+  # This reproduces the bug from issue #1951
   d = data.frame(
     x1 = rpois(100, 2),
-    x2 = gl(5, 20, labels=LETTERS[1:5]),
+    x2 = gl(5, 20, labels = LETTERS[1:5]),
     y = as.factor(c(rep("+", 90), rep("-", 10)))
   )
 


### PR DESCRIPTION
I added a comment to issue #1951 why it happens. Briefly, assigning levels to integers does not work in the current code. What should be E,E,F,F becomes A,A,B,B:

```
> x <- as.factor(c(4,4,5,5))
> levels(x) <- LETTERS[1:5]
> x
[1] A A B B
Levels: A B C D E
```

This PR is a fix for that bug and a unit test reproducing it. 

Again, I'm new to this, so handle with care. Feedback welcome. *Edit:* Specifically, feedback on why Travis seems to fail for tests I haven't touched :) This didn't happen on my machine.

Fixes #1951 