### PR TITLE
Add different Ids for Multilabel Wrappers

### DIFF
--- a/R/MultilabelBinaryRelevanceWrapper.R
+++ b/R/MultilabelBinaryRelevanceWrapper.R
@@ -27,9 +27,10 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelBinaryRelevanceWrapper = function(learner) {
   learner = checkLearner(learner, type = "classif")
-  id = stri_paste("multilabelBinaryRelevance", learner$id, sep = ".")
-  packs = learner$package
-  x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
+  id = stri_paste("multilabel.binaryRelevance", getLearnerId(learner), sep = ".")
+  packs = getLearnerPackages(learner)
+  type = getLearnerType(learner)
+  x = makeHomogeneousEnsemble(id, type, learner, packs,
     learner.subclass = "MultilabelBinaryRelevanceWrapper", model.subclass = "MultilabelBinaryRelevanceModel")
   x$type = "multilabel"
   return(x)

--- a/R/MultilabelBinaryRelevanceWrapper.R
+++ b/R/MultilabelBinaryRelevanceWrapper.R
@@ -27,7 +27,7 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelBinaryRelevanceWrapper = function(learner) {
   learner = checkLearner(learner, type = "classif")
-  id = stri_paste("multilabel", learner$id, sep = ".")
+  id = stri_paste("multilabelBinaryRelevance", learner$id, sep = ".")
   packs = learner$package
   x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
     learner.subclass = "MultilabelBinaryRelevanceWrapper", model.subclass = "MultilabelBinaryRelevanceModel")

--- a/R/MultilabelClassifierChainsWrapper.R
+++ b/R/MultilabelClassifierChainsWrapper.R
@@ -23,9 +23,10 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelClassifierChainsWrapper = function(learner, order = NULL) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabelClassifierChains", learner$id, sep = ".")
-  packs = learner$package
-  x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
+  id = stri_paste("multilabel.classifierChains", getLearnerId(learner), sep = ".")
+  packs = getLearnerPackages(learner)
+  type = getLearnerType(learner)
+  x = makeHomogeneousEnsemble(id, type, learner, packs,
     learner.subclass = "MultilabelClassifierChainsWrapper",
     model.subclass = "MultilabelClassifierChainsModel")
   x$type = "multilabel"

--- a/R/MultilabelClassifierChainsWrapper.R
+++ b/R/MultilabelClassifierChainsWrapper.R
@@ -23,7 +23,7 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelClassifierChainsWrapper = function(learner, order = NULL) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabel", learner$id, sep = ".")
+  id = paste("multilabelClassifierChains", learner$id, sep = ".")
   packs = learner$package
   x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
     learner.subclass = "MultilabelClassifierChainsWrapper",

--- a/R/MultilabelDBRWrapper.R
+++ b/R/MultilabelDBRWrapper.R
@@ -22,7 +22,7 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelDBRWrapper = function(learner) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabel", learner$id, sep = ".")
+  id = paste("multilabelDBR", learner$id, sep = ".")
   packs = learner$package
   x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
     learner.subclass = "MultilabelDBRWrapper",

--- a/R/MultilabelDBRWrapper.R
+++ b/R/MultilabelDBRWrapper.R
@@ -22,9 +22,10 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelDBRWrapper = function(learner) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabelDBR", learner$id, sep = ".")
-  packs = learner$package
-  x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
+  id = stri_paste("multilabel.DBR", getLearnerId(learner), sep = ".")
+  packs = getLearnerPackages(learner)
+  type = getLearnerType(learner)
+  x = makeHomogeneousEnsemble(id, type, learner, packs,
     learner.subclass = "MultilabelDBRWrapper",
     model.subclass = "MultilabelDBRModel")
   x$type = "multilabel"

--- a/R/MultilabelNestedStackingWrapper.R
+++ b/R/MultilabelNestedStackingWrapper.R
@@ -25,9 +25,10 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelNestedStackingWrapper = function(learner, order = NULL, cv.folds = 2) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabelNestedStacking", learner$id, sep = ".")
-  packs = learner$package
-  x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
+  id = stri_paste("multilabel.nestedStacking", getLearnerId(learner), sep = ".")
+  packs = getLearnerPackages(learner)
+  type = getLearnerType(learner)
+  x = makeHomogeneousEnsemble(id, type, learner, packs,
     learner.subclass = "MultilabelNestedStackingWrapper",
     model.subclass = "MultilabelNestedStackingModel")
   x$type = "multilabel"

--- a/R/MultilabelNestedStackingWrapper.R
+++ b/R/MultilabelNestedStackingWrapper.R
@@ -25,7 +25,7 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelNestedStackingWrapper = function(learner, order = NULL, cv.folds = 2) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabel", learner$id, sep = ".")
+  id = paste("multilabelNestedStacking", learner$id, sep = ".")
   packs = learner$package
   x = makeHomogeneousEnsemble(id, learner$type, learner, packs,
     learner.subclass = "MultilabelNestedStackingWrapper",

--- a/R/MultilabelStackingWrapper.R
+++ b/R/MultilabelStackingWrapper.R
@@ -22,9 +22,10 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelStackingWrapper = function(learner, cv.folds = 2) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabelStacking", learner$id, sep = ".")
-  packs = learner$package
-  x = makeHomogeneousEnsemble(id, learner$type, learner, packs, learner.subclass = "MultilabelStackingWrapper", model.subclass = "MultilabelStackingModel")
+  id = stri_paste("multilabel.stacking", getLearnerId(learner), sep = ".")
+  packs = getLearnerPackages(learner)
+  type = getLearnerType(learner)
+  x = makeHomogeneousEnsemble(id, type, learner, packs, learner.subclass = "MultilabelStackingWrapper", model.subclass = "MultilabelStackingModel")
   x$type = "multilabel"
   x$cv.folds = cv.folds
   return(x)

--- a/R/MultilabelStackingWrapper.R
+++ b/R/MultilabelStackingWrapper.R
@@ -22,7 +22,7 @@
 #' @example inst/examples/MultilabelWrapper.R
 makeMultilabelStackingWrapper = function(learner, cv.folds = 2) {
   learner = checkLearner(learner, type = "classif", props = "twoclass")
-  id = paste("multilabel", learner$id, sep = ".")
+  id = paste("multilabelStacking", learner$id, sep = ".")
   packs = learner$package
   x = makeHomogeneousEnsemble(id, learner$type, learner, packs, learner.subclass = "MultilabelStackingWrapper", model.subclass = "MultilabelStackingModel")
   x$type = "multilabel"

--- a/tests/testthat/test_base_multilabelWrapperIds.R
+++ b/tests/testthat/test_base_multilabelWrapperIds.R
@@ -1,31 +1,28 @@
 context("multiLabelWrapperIds")
 
+binary.learner = makeLearner("classif.rpart")
+
 test_that("multiLabelWrapperIds DBR", {
-  binary.learner = makeLearner("classif.rpart")
   mlw = makeMultilabelDBRWrapper(binary.learner)
-  expect_equal(getLearnerId(mlw), "multilabelDBR.classif.rpart")
+  expect_equal(getLearnerId(mlw), "multilabel.DBR.classif.rpart")
 })
 
 test_that("multiLabelWrapperIds NestedStacking", {
-  binary.learner = makeLearner("classif.rpart")
   mlw = makeMultilabelNestedStackingWrapper(binary.learner)
-  expect_equal(getLearnerId(mlw), "multilabelNestedStacking.classif.rpart")
+  expect_equal(getLearnerId(mlw), "multilabel.nestedStacking.classif.rpart")
 })
 
 test_that("multiLabelWrapperIds Stacking", {
-  binary.learner = makeLearner("classif.rpart")
   mlw = makeMultilabelStackingWrapper(binary.learner)
-  expect_equal(getLearnerId(mlw), "multilabelStacking.classif.rpart")
+  expect_equal(getLearnerId(mlw), "multilabel.stacking.classif.rpart")
 })
 
 test_that("multiLabelWrapperIds BinaryRelevance", {
-  binary.learner = makeLearner("classif.rpart")
   mlw = makeMultilabelBinaryRelevanceWrapper(binary.learner)
-  expect_equal(getLearnerId(mlw), "multilabelBinaryRelevance.classif.rpart")
+  expect_equal(getLearnerId(mlw), "multilabel.binaryRelevance.classif.rpart")
 })
 
 test_that("multiLabelWrapperIds ClassifierChains", {
-  binary.learner = makeLearner("classif.rpart")
   mlw = makeMultilabelClassifierChainsWrapper(binary.learner)
-  expect_equal(getLearnerId(mlw), "multilabelClassifierChains.classif.rpart")
+  expect_equal(getLearnerId(mlw), "multilabel.classifierChains.classif.rpart")
 })

--- a/tests/testthat/test_base_multilabelWrapperIds.R
+++ b/tests/testthat/test_base_multilabelWrapperIds.R
@@ -1,0 +1,31 @@
+context("multiLabelWrapperIds")
+
+test_that("multiLabelWrapperIds DBR", {
+  binary.learner = makeLearner("classif.rpart")
+  mlw = makeMultilabelDBRWrapper(binary.learner)
+  expect_equal(getLearnerId(mlw), "multilabelDBR.classif.rpart")
+})
+
+test_that("multiLabelWrapperIds NestedStacking", {
+  binary.learner = makeLearner("classif.rpart")
+  mlw = makeMultilabelNestedStackingWrapper(binary.learner)
+  expect_equal(getLearnerId(mlw), "multilabelNestedStacking.classif.rpart")
+})
+
+test_that("multiLabelWrapperIds Stacking", {
+  binary.learner = makeLearner("classif.rpart")
+  mlw = makeMultilabelStackingWrapper(binary.learner)
+  expect_equal(getLearnerId(mlw), "multilabelStacking.classif.rpart")
+})
+
+test_that("multiLabelWrapperIds BinaryRelevance", {
+  binary.learner = makeLearner("classif.rpart")
+  mlw = makeMultilabelBinaryRelevanceWrapper(binary.learner)
+  expect_equal(getLearnerId(mlw), "multilabelBinaryRelevance.classif.rpart")
+})
+
+test_that("multiLabelWrapperIds ClassifierChains", {
+  binary.learner = makeLearner("classif.rpart")
+  mlw = makeMultilabelClassifierChainsWrapper(binary.learner)
+  expect_equal(getLearnerId(mlw), "multilabelClassifierChains.classif.rpart")
+})


### PR DESCRIPTION
#1700 

- Changed Ids
- Used getLearnerId(), getLearnerPackages(), getLernerType() instead of learner$...
- Used stri_paste() instead of paste()
- Added test to check Ids