### PR TITLE
Automatically predict NA for rows w/ NAs and learners that don't support missings

### DIFF
--- a/R/generateHyperParsEffect.R
+++ b/R/generateHyperParsEffect.R
@@ -362,7 +362,7 @@ plotHyperParsEffect = function(hyperpars.effect.data, x = NULL, y = NULL,
           regr.task = makeRegrTask(id = "interp", data = d.run[, c(x, y, z)],
             target = z)
           mod = train(lrn, regr.task)
-          prediction = predict(mod, newdata = grid)
+          prediction = predict(mod, newdata = grid[c(x, y)])
           grid[, z] = prediction$data[, prediction$predict.type]
           grid$learner_status = "Interpolated Point"
           grid$iteration = NA

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -62,6 +62,8 @@ predictLearner2 = function(.learner, .model, .newdata, ...) {
     no.na = removeNALines(.newdata)
   else
     no.na = list(newdata = .newdata, inserts = FALSE)
+  if (!nrow(no.na$newdata))
+    no.na = list(newdata = .newdata, inserts = FALSE)  # no choice if all lines contain NA
   p = predictLearner(.learner, .model, no.na$newdata, ...)
   p = checkPredictLearnerOutput(.learner, .model, p)
   return(insertLines(p, no.na$inserts))

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -74,7 +74,7 @@ removeNALines = function(newdata) {
     return(list(newdata = newdata, inserts = FALSE))
   }
   narows = apply(namat, 1, any)
-  return(list(newdata = newdata[!narows, ], inserts = narows))
+  return(list(newdata = newdata[!narows, , drop = FALSE], inserts = narows))
 }
 
 insertLines = function(prediction, inserts) {
@@ -82,7 +82,7 @@ insertLines = function(prediction, inserts) {
 #    return(prediction)
   if (is.matrix(prediction)) {
     ret = matrix(nrow = nrow(prediction) + sum(inserts), ncol = ncol(prediction))
-    ret[!inserts, ] = prediction
+    ret[!inserts, , drop = FALSE] = prediction
     colnames(ret) = colnames(prediction)
   } else {
     ret = rep(NA, length(prediction) + sum(inserts))

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -82,7 +82,7 @@ insertLines = function(prediction, inserts) {
 #    return(prediction)
   if (is.matrix(prediction)) {
     ret = matrix(nrow = nrow(prediction) + sum(inserts), ncol = ncol(prediction))
-    ret[!inserts, , drop = FALSE] = prediction
+    ret[!inserts, ] = prediction
     colnames(ret) = colnames(prediction)
   } else {
     ret = rep(NA, length(prediction) + sum(inserts))

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -58,9 +58,39 @@ predictLearner2 = function(.learner, .model, .newdata, ...) {
       .newdata[ns] = mapply(factor, x = .newdata[ns],
          levels = fls, SIMPLIFY = FALSE)
   }
-  p = predictLearner(.learner, .model, .newdata, ...)
+  if ("missings" %nin% getLearnerProperties(.learner))
+    no.na = removeNALines(.newdata)
+  else
+    no.na = list(newdata = .newdata, inserts = FALSE)
+  p = predictLearner(.learner, .model, no.na$newdata, ...)
   p = checkPredictLearnerOutput(.learner, .model, p)
-  return(p)
+  return(insertLines(p, no.na$inserts))
+}
+
+removeNALines = function(newdata) {
+  namat = is.na(newdata)
+  if (!any(vlapply(namat, any))) {
+    # no NAs
+    return(list(newdata = newdata, inserts = FALSE))
+  }
+  narows = apply(namat, 1, any)
+  return(list(newdata = newdata[!narows, ], inserts = narows))
+}
+
+insertLines = function(prediction, inserts) {
+#  if (!any(inserts))
+#    return(prediction)
+  if (is.matrix(prediction)) {
+    ret = matrix(nrow = nrow(prediction) + sum(inserts), ncol = ncol(prediction))
+    ret[!inserts, ] = prediction
+    colnames(ret) = colnames(prediction)
+  } else {
+    ret = rep(NA, length(prediction) + sum(inserts))
+    ret[!inserts] = prediction
+    attributes(ret) = attributes(prediction)
+    names(ret) = NULL
+  }
+  return(ret)
 }
 
 checkPredictLearnerOutput = function(learner, model, p) {

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -71,10 +71,6 @@ predictLearner2 = function(.learner, .model, .newdata, ...) {
 
 removeNALines = function(newdata) {
   namat = is.na(newdata)
-  if (!any(vlapply(namat, any))) {
-    # no NAs
-    return(list(newdata = newdata, inserts = FALSE))
-  }
   narows = apply(namat, 1, any)
   return(list(newdata = newdata[!narows, , drop = FALSE], inserts = narows))
 }

--- a/tests/testthat/test_base_predict.R
+++ b/tests/testthat/test_base_predict.R
@@ -144,3 +144,11 @@ test_that("predict works with data.table as newdata", {
   expect_warning(predict(mod, newdata = data.table(iris)), regexp = "Provided data for prediction is not a pure data.frame but from class data.table, hence it will be converted.")
 })
 
+test_that("predict with NA rows for learners that don't support missings automatically returns NA", {
+  mod = train("classif.knn", pid.task)
+  newdata = getTaskData(pid.task, target.extra = TRUE)$data
+  newdata[[1]][1] = NA
+  prediction = predict(mod, newdata = newdata)
+  expect_equal(which(is.na(prediction$data$response[1])), 1)
+})
+

--- a/tests/testthat/test_base_predict.R
+++ b/tests/testthat/test_base_predict.R
@@ -145,10 +145,16 @@ test_that("predict works with data.table as newdata", {
 })
 
 test_that("predict with NA rows for learners that don't support missings automatically returns NA", {
-  mod = train("classif.knn", pid.task)
+  modknn = train("classif.knn", pid.task)
+  modrf = train(makeLearner("classif.randomForest", mtry = 1), pid.task)
   newdata = getTaskData(pid.task, target.extra = TRUE)$data
-  newdata[[1]][1] = NA
-  prediction = predict(mod, newdata = newdata)
-  expect_equal(which(is.na(prediction$data$response[1])), 1)
+  newdata.na = newdata
+  newdata.na[[1]][1] = NA
+  for (mod in list(modknn, modrf)) {
+    prediction = predict(mod, newdata = newdata)
+    prediction.na = predict(mod, newdata = newdata.na)
+    expect_equal(which(is.na(prediction.na$data$response[1])), 1)
+    expect_equal(prediction.na$data[-1, ], prediction$data[-1, ])
+  }
 })
 


### PR DESCRIPTION
A comprehensive fix for the larger issue around #1515, this does what I described in [my comment to #2068](https://github.com/mlr-org/mlr/pull/2068#issuecomment-347551112):
If the learner doesn't support 'missings', the rows containing missings are stripped, and `NA`s are added to the prediction in their place. This has two weaknesses:
1) Apparently there are Learners that don't support "missings" in their training data, but *do* support them in the prediction data. There is no easy fix for this, one might think about adding another Learner-property, or redefining `"missings"` to mean support for missings in the prediction data.
2) If every line of the input contains at least one `NA`, this falls back to the old prediction mode (and possibly creates an error if the Learner doesn't silently ignore `NA`s). A more thorough implementation could create the matrix / vector of `NA`s of appropriate type without calling `predictLearner` at all.