### PR TITLE
Missing levels suggestion

### DIFF
--- a/R/RLearner_classif_featureless.R
+++ b/R/RLearner_classif_featureless.R
@@ -41,7 +41,10 @@ makeRLearner.classif.featureless = function() {
 #' @export
 trainLearner.classif.featureless = function(.learner, .task, .subset, .weights = NULL,
   method = "majority", ...) {
-  y = getTaskTargets(.task)[.subset]
+  y = getTaskTargets(.task)
+  if (!is.null(.subset)) {
+    y = y[.subset]
+  }
   lvls = getTaskClassLevels(.task)
   # probs is always complete, if a class is empty is has 0 frequency in probs
   probs = prop.table(table(y))

--- a/R/RLearner_regr_featureless.R
+++ b/R/RLearner_regr_featureless.R
@@ -33,8 +33,10 @@ makeRLearner.regr.featureless = function() {
 
 #' @export
 trainLearner.regr.featureless = function(.learner, .task, .subset, .weights = NULL, method = "mean", ...) {
-  y = getTaskTargets(.task)[.subset]
-
+  y = getTaskTargets(.task)
+  if (!is.null(.subset)) {
+    y = y[.subset]
+  }
   if (method == "mean") {
     response = mean(y)
   } else if (method == "median") {

--- a/R/ResamplePrediction.R
+++ b/R/ResamplePrediction.R
@@ -15,7 +15,7 @@
 NULL
 
 
-makeResamplePrediction = function(instance, preds.test, preds.train) {
+makeResamplePrediction = function(instance, preds.test, preds.train, task.desc) {
   tenull = sapply(preds.test, is.null)
   trnull = sapply(preds.train, is.null)
   if (any(tenull)) pr.te = preds.test[!tenull] else pr.te = preds.test
@@ -40,7 +40,7 @@ makeResamplePrediction = function(instance, preds.test, preds.train) {
     predict.type = p1$predict.type,
     data = data,
     threshold = p1$threshold,
-    task.desc = p1$task.desc,
+    task.desc = task.desc,
     time = extractSubList(pall, "time")
   )
 }

--- a/R/getOOBPreds.R
+++ b/R/getOOBPreds.R
@@ -64,6 +64,7 @@ getOOBPredsLearner.BaseWrapper = function(.learner, .model) {
 # checks if the model was trained on the corresponding task by comparing
 # the descriptions
 checkModelCorrespondsTask = function(model, task) {
-  if (!identical(task$task.desc, model$task.desc))
+  compare = c("id", "type", "target", "n.feats", "has.weights", "has.blocking", "is.spatial", "positive")
+  if (!identical(task$task.desc[compare], model$task.desc[compare]))
     stopf("Description of the model does not correspond to the task")
 }

--- a/R/resample.R
+++ b/R/resample.R
@@ -269,7 +269,7 @@ mergeResampleResult = function(learner.id, task, iter.results, measures, rin, mo
 
   preds.test = extractSubList(iter.results, "pred.test", simplify = FALSE)
   preds.train = extractSubList(iter.results, "pred.train", simplify = FALSE)
-  pred = makeResamplePrediction(instance = rin, preds.test = preds.test, preds.train = preds.train)
+  pred = makeResamplePrediction(instance = rin, preds.test = preds.test, preds.train = preds.train, task.desc = getTaskDesc(task))
 
   # aggr = vnapply(measures, function(m) m$aggr$fun(task, ms.test[, m$id], ms.train[, m$id], m, rin$group, pred))
   aggr = vnapply(seq_along(measures), function(i) {

--- a/R/train.R
+++ b/R/train.R
@@ -33,12 +33,14 @@ train = function(learner, task, subset, weights = NULL) {
   assertClass(task, classes = "Task")
   if (missing(subset))
     subset = NULL
+  if (is.logical(subset))
+    subset = which(subset)  # I believe this is a bug, see #2098
   task = subsetTask(task, subset)
   if (is.null(subset)) {
     subset = seq_len(getTaskSize(task))
   } else {
     if (is.logical(subset))
-      subset = which(subset)
+      subset = which(subset)  # I believe this is a bug, see #2098
     else
       subset = asInteger(subset)
   }

--- a/R/train.R
+++ b/R/train.R
@@ -28,11 +28,9 @@
 #' learner = makeLearner("classif.rpart", minsplit = 7, predict.type = "prob")
 #' mod = train(learner, task, subset = training.set)
 #' print(mod)
-train = function(learner, task, subset, weights = NULL) {
+train = function(learner, task, subset = NULL, weights = NULL) {
   learner = checkLearner(learner)
   assertClass(task, classes = "Task")
-  if (missing(subset))
-    subset = NULL
   if (is.logical(subset))
     subset = which(subset)  # I believe this is a bug, see #2098
   task = subsetTask(task, subset)
@@ -60,7 +58,7 @@ train = function(learner, task, subset, weights = NULL) {
 
   # FIXME: code is bad here, set weights, the simply check it in checktasklearner
   if (!is.null(weights)) {
-    assertNumeric(weights, len = nrow(task$env$data), any.missing = FALSE, lower = 0)
+    assertNumeric(weights, len = getTaskSize(task), any.missing = FALSE, lower = 0)
   } else {
     weights = getTaskWeights(task)
   }

--- a/man-roxygen/arg_subset.R
+++ b/man-roxygen/arg_subset.R
@@ -1,3 +1,3 @@
-#' @param subset [\code{integer} | \code{logical}]\cr
+#' @param subset [\code{integer} | \code{logical} | \code{NULL}]\cr
 #'   Selected cases. Either a logical or an index vector.
-#'   By default all observations are used.
+#'   By default (\code{NULL}) all observations are used.


### PR DESCRIPTION
This is my suggestion for the solution of #811 and hence an alternative for the part of #1882 that I was [commenting on](https://github.com/mlr-org/mlr/pull/1882#issuecomment-313875375).

@pat-s maybe you can take this instead of some off the very learner-specific code you have.

This only turns factor levels that were not present during training into `NA`s; it does not help the measures or measure aggregates during resampling or give the user feedback on dropped levels (as #1882 apparently does). I believe handling of `NA`s in predictions during resampling should be independent of `fix.factors.prediction` and in fact happen on the side of the measures (by either dropping or imputing `NA`s) or aggregates (that `na.rm` PR).
I don't think giving messages about dropped factor levels is useful, these measures are not usually given when `fix.factors.prediction` drops levels (when given an entirely novel dataset).