### PR TITLE
Fix 2101 surv task type

### DIFF
--- a/R/SurvTask.R
+++ b/R/SurvTask.R
@@ -30,7 +30,7 @@ makeSurvTask = function(id = deparse(substitute(data)), data, target, weights = 
     }
   }
 
-  task = makeSupervisedTask("regr", data, target, weights, blocking, spatial, fixup.data = fixup.data, check.data = check.data)
+  task = makeSupervisedTask("surv", data, target, weights, blocking, spatial, fixup.data = fixup.data, check.data = check.data)
 
   if (check.data) {
     time = data[[target[1L]]]

--- a/tests/testthat/test_base_SupervisedTask.R
+++ b/tests/testthat/test_base_SupervisedTask.R
@@ -70,3 +70,16 @@ test_that("SupervisedTask does not drop positive class", {
   td = getTaskDesc(task)
   expect_true(setequal(c(td$positive, td$negative), unique(data$Species)))
 })
+
+test_that("Task $type and $task.desc$type agree", {
+  check = list(
+    classif = binaryclass.task,
+    multilabel = multilabel.task,
+    regr = regr.task,
+    surv = surv.task,
+    costsens = costsens.task)
+  for (type in names(check)) {
+    expect_identical(type, check[[type]]$type)
+    expect_identical(type, getTaskDesc(check[[type]])$type)
+  }
+})


### PR DESCRIPTION
Fix #2101 
On second thought I'm not 100% sure this is a bug, maybe "surv" is supposed to be a subclass of "regr" in some way? The places I've seen don't use the `task$type` slot at all, so maybe it can also be dropped.