### PR TITLE
fix #2125

### DIFF
--- a/R/Task_operators.R
+++ b/R/Task_operators.R
@@ -333,20 +333,6 @@ getTaskData = function(task, subset = NULL, features, target.extra = FALSE, reco
     if (recode.target %nin% c("no", "surv")) {
       res[, tn] = recodeY(res[, tn], type = recode.target, task$task.desc)
     }
-    # first condition checks if 'getTaskData' was called directly, i.e. checks if
-    # the call was from the GlobalEnv
-    # second condition checks which function called 'getTaskData' if call was not
-    # from the GlobalEnv. If cond2 is FALSE, 'getTaskData' was called from
-    # 'subsetTask' in a nested resampling call. In this case we remove x and y
-    # later (later = we arrive in 'getTaskData' twice in a 'resample' call) as
-    # we still need it for partitioning in upcoming function calls and only need
-    # to remove `x` and `y` before we proceed to the training step.
-    if (!identical(parent.frame(n = 1), globalenv()) &&
-        !sys.call(-2) == "subsetTask(.task, .subset)" &&
-        task$task.desc$is.spatial == TRUE) {
-      res$x = NULL
-      res$y = NULL
-    }
   }
   res
 }

--- a/R/predict.R
+++ b/R/predict.R
@@ -118,10 +118,7 @@ predict.WrappedModel = function(object, task, newdata, subset = NULL, ...) {
       on.exit(options(warn = old.warn.opt))
       options(warn = -1L)
     }
-    if (td$is.spatial == TRUE) {
-      pars$.newdata$x = NULL
-      pars$.newdata$y = NULL
-    }
+
     time.predict = measureTime(fun1({p = fun2(fun3(do.call(predictLearner2, pars)))}))
 
     # was there an error during prediction?

--- a/R/train.R
+++ b/R/train.R
@@ -72,6 +72,13 @@ train = function(learner, task, subset = NULL, weights = NULL) {
   vars = getTaskFeatureNames(task)
   # no vars? then use no vars model
 
+  # remove coordinates from data for train call
+  # only do so if we are NOT in a nested cv setting -> there we remove the coordinates in tuneParams()
+  if (isTRUE(task$task.desc$is.spatial) && !grepl("tuned", pars$.learner$id)) {
+    task$env$data$x = NULL
+    task$env$data$y = NULL
+  }
+
   if (length(vars) == 0L) {
     learner.model = makeNoFeaturesModel(targets = task$env$data[, tn], task.desc = getTaskDesc(task))
     time.train = 0

--- a/R/tuneParams.R
+++ b/R/tuneParams.R
@@ -120,6 +120,13 @@ tuneParams = function(learner, task, resampling, measures, par.set, control, sho
     messagef("With control class: %s", cl)
     messagef("Imputation value: %g", control$impute.val)
   }
+
+  # remove coordinates from data for follow-up train() call
+  if (isTRUE(task$task.desc$is.spatial)) {
+    task$env$data$x = NULL
+    task$env$data$y = NULL
+  }
+
   or = sel.func(learner, task, resampling, measures, par.set, control, opt.path, show.info, resample.fun)
   if (show.info)
     messagef("[Tune] Result: %s : %s", paramValueToString(par.set, or$x), perfsToString(or$y))

--- a/tests/testthat/test_base_resample_cv.R
+++ b/tests/testthat/test_base_resample_cv.R
@@ -38,6 +38,30 @@ test_that("SpCV instance works", {
   }
 })
 
+test_that("Nested SpRepCV works without errors", {
+  bc.task.spatial
+
+  lrn.ksvm = makeLearner("classif.ksvm",
+    predict.type = "prob",kernel = "rbfdot")
+
+  ps = makeParamSet(makeNumericParam("C", lower = 1, upper = 1),
+    makeNumericParam("sigma", lower = 1, upper = 1))
+
+  ctrl = makeTuneControlRandom(maxit = 1)
+  inner = makeResampleDesc("SpCV", iters = 2)
+
+  wrapper.ksvm = makeTuneWrapper(lrn.ksvm, resampling = inner, par.set = ps,
+    control = ctrl, show.info = FALSE, measures = list(auc))
+
+  outer = makeResampleDesc("SpRepCV", folds = 2, reps = 2)
+
+  parallelStart(mode = "multicore", level = "mlr.tuneParams", cpus = 2)
+
+  resa.svm.spatial = resample(wrapper.ksvm, bc.task.spatial,
+    resampling = outer, show.info = TRUE, measures = list(auc))
+  parallelStop()
+})
+
 test_that("cv resampling works", {
   data = multiclass.df
   formula = multiclass.formula

--- a/tests/testthat/test_base_resample_cv.R
+++ b/tests/testthat/test_base_resample_cv.R
@@ -42,7 +42,7 @@ test_that("Nested SpRepCV works without errors", {
   bc.task.spatial
 
   lrn.ksvm = makeLearner("classif.ksvm",
-    predict.type = "prob",kernel = "rbfdot")
+    predict.type = "prob", kernel = "rbfdot")
 
   ps = makeParamSet(makeNumericParam("C", lower = 1, upper = 1),
     makeNumericParam("sigma", lower = 1, upper = 1))


### PR DESCRIPTION
* Removed  [this hacky code part](https://github.com/mlr-org/mlr/blob/7541988ca65c4198907ce63fab7a46d2676449fb/R/Task_operators.R#L344-L349).

* Added a test for nested SpCV.

@mb706 
What's your opinion on the 

```r
task$env$data$x = NULL
task$env$data$y = NULL
```

parts, would it be "better" in terms of mlr coding style (and maybe robustness (?)) to use `getTaskData()` here instead of setting the coordinates `x` and `y` in `$env$data = NULL`?

# Details

When arriving in `train()` at around [l.77](https://github.com/mlr-org/mlr/blob/248356ba0412ba5d7d3eb0599604b078ef507fa8/R/train.R#L77) in a `SpCV` call (without tuning), I need to remove coordinates `x` and `y` there because in this setting the models gets trained right [afterwards](https://github.com/mlr-org/mlr/blob/7541988ca65c4198907ce63fab7a46d2676449fb/R/train.R#L96). 

While this works fine in `SpRepCV` because the partitioning is already done at this point, it does not work in a nested setting with `tuneParams()`. 
There, the partitioning is done after I arrive at `train()` [l.77](https://github.com/mlr-org/mlr/blob/248356ba0412ba5d7d3eb0599604b078ef507fa8/R/train.R#L77) and if the code removes the coordinates at this point, they are not available when the resampling instance is created later on.

So I somehow have to check whether we are in a `SpRepCV` **with tuning** or `SpRepCV` **without tuning**. 

I now do so by checking in the `pars` object existing at `train` [l.70](https://github.com/mlr-org/mlr/blob/248356ba0412ba5d7d3eb0599604b078ef507fa8/R/train.R#L70)) whether the `.learner$id` has "tuned" in its name, e.g. `classif.ksvm.tuned`.
This is only the case if we are in a nested cv setting with tuning.
Subsequently, I make the removal of the coordinates in `train()` conditional on this property.
If we are in a nested setting, I remove the coordinates for the tuning step at `tuneParams()` [l.124](https://github.com/mlr-org/mlr/blob/248356ba0412ba5d7d3eb0599604b078ef507fa8/R/tuneParams.R#L124-L127).

We are arriving at this "removal point" (`train()` [l.77](https://github.com/mlr-org/mlr/blob/248356ba0412ba5d7d3eb0599604b078ef507fa8/R/train.R#L77)) several times (basically for every model that is fitted, no matter if for tuning or performance estimation) and the `if` part is entered every time and coordinates are removed although they are not existent anymore. 
However, we need to do it at least once for every fold as then the task arrives at `train()` [l.77](https://github.com/mlr-org/mlr/blob/248356ba0412ba5d7d3eb0599604b078ef507fa8/R/train.R#L77) with coordinates.
