### PR TITLE
bugfix and new tests for generatePartialDependenceData

### DIFF
--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -303,13 +303,14 @@ doDerivativeMarginalPrediction = function(x, z = sample(seq_len(nrow(data)), n[2
       individual = individual, ...),
       points[[x]], if (individual) z)
   } else {
-    ret = cbind(numDeriv::jacobian(numDerivWrapper,
-      x = points[[x]], model = obj, data = data,
-      uniform = uniform, aggregate.fun = fun, vars = x,
-      int.points = z,
-      predict.fun = getPrediction, n = n, target = target,
-      individual = individual, ...),
-      points[[x]], if (individual) z)
+    out = lapply(points[[x]], function(x.value) {
+      t(numDeriv::jacobian(numDerivWrapper, x = x.value, model = obj, data = data,
+        uniform = uniform, aggregate.fun = fun, vars = x, int.points = z,
+        predict.fun = getPrediction, n = n, target = target,
+        individual = individual, ...))
+    })
+    out = do.call("rbind", out)
+    ret = cbind(out, points[[x]], if (individual) z)
   }
   ret = as.data.table(ret)
   setnames(ret, names(ret), c(target, x, if (individual) "n"))

--- a/tests/testthat/test_base_generatePartialDependence.R
+++ b/tests/testthat/test_base_generatePartialDependence.R
@@ -1,7 +1,7 @@
 context("generatePartialDependence")
 
 test_that("generatePartialDependenceData", {
-  m = c(3, 10)
+  m = c(4, 10)
 
   # test regression with interactions, centering, and mixed factor features
   fr = train("regr.rpart", regr.task)
@@ -159,4 +159,8 @@ test_that("generatePartialDependenceData", {
   # issue 63 in the tutorial
   pd = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width",
     individual = TRUE, derivative = TRUE, n = m)
+
+  # test that would have caught a bug that occurs when the jacobian is estimated
+  pd.der.classif = generatePartialDependenceData(fcp, multiclass.task, "Petal.Width",
+    derivative = TRUE, n = m)
 })


### PR DESCRIPTION
jacobian estimation bug which was hidden in tests because the
multiclass tests where the jacobian was estimated use the iris data
where the number of classes matched the n[1] arg

tests are added that would have caught it and n[1] was changed to
equal 4 as well as the actual bug being fixed