### PR TITLE
Rename measureMultiLabelF1 to measureMultilabelF1 (lower case L)

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -1262,15 +1262,15 @@ multilabel.f1 = makeMeasure(id = "multilabel.f1", minimize = FALSE, best = 1, wo
   definition by Montanes et al.: http: / /www.sciencedirect.com / science / article / pii / S0031320313004019.
   Fractions where the denominator becomes 0 are replaced with 1 before computing the average across all instances.",
   fun = function(task, model, pred, feats, extra.args) {
-    measureMultiLabelF1(getPredictionTruth.PredictionMultilabel(pred),
+    measureMultilabelF1(getPredictionTruth.PredictionMultilabel(pred),
     getPredictionResponse.PredictionMultilabel(pred))
   }
 )
 
-#' @export measureMultiLabelF1
+#' @export measureMultilabelF1
 #' @rdname measures
 #' @format none
-measureMultiLabelF1 = function(truth, response) {
+measureMultilabelF1 = function(truth, response) {
   numerator = 2 * rowSums(truth & response)
   denominator = rowSums(truth + response)
   mean(ifelse(denominator == 0, 1, numerator / denominator))

--- a/R/measures.R
+++ b/R/measures.R
@@ -1267,6 +1267,15 @@ multilabel.f1 = makeMeasure(id = "multilabel.f1", minimize = FALSE, best = 1, wo
   }
 )
 
+#' Deprecated, use `measureMultilabelF1` instead.
+#' @export measureMultiLabelF1
+#' @rdname measures
+#' @format none
+measureMultiLabelF1 = function(truth, response) {
+  .Deprecated("measureMultilabelF1")
+  measureMultilabelF1(truth, response)
+}
+
 #' @export measureMultilabelF1
 #' @rdname measures
 #' @format none

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -683,13 +683,13 @@ test_that("check measure calculations", {
   expect_equal(f1.test, multilabel.f1$fun(pred = pred.multilabel))
   expect_equal(f1.test, as.numeric(f1.perf))
   # check best and worst
-  expect_equal(measureMultiLabelF1(multi.y, multi.y), multilabel.f1$best)
-  expect_equal(measureMultiLabelF1(multi.y, !multi.y), multilabel.f1$worst)
+  expect_equal(measureMultilabelF1(multi.y, multi.y), multilabel.f1$best)
+  expect_equal(measureMultilabelF1(multi.y, !multi.y), multilabel.f1$worst)
   # compare with mldr: mldr has a bug when RealPositives or PredictedPositives are 0 (see https://github.com/fcharte/mldr/issues/36)
-  expect_equal(mldr:::mldr_FMeasure(counters[-3, ]), measureMultiLabelF1(multi.y[-3, ], multi.p[-3, ]))
+  expect_equal(mldr:::mldr_FMeasure(counters[-3, ]), measureMultilabelF1(multi.y[-3, ], multi.p[-3, ]))
   # manual checks
-  expect_equal(measureMultiLabelF1(matrix(tf, ncol = 2), matrix(tt, ncol = 2)), 2 * 1 / 3) # 1 TRUE-TRUE match of 3 TRUE values
-  expect_equal(measureMultiLabelF1(rbind(tf, tf), rbind(tf, tt)), mean(c(2 * 1 / 2, 2 * 1 / 3))) # 1 TRUE-TRUE match of 2 and 3 TRUE values per obs
+  expect_equal(measureMultilabelF1(matrix(tf, ncol = 2), matrix(tt, ncol = 2)), 2 * 1 / 3) # 1 TRUE-TRUE match of 3 TRUE values
+  expect_equal(measureMultilabelF1(rbind(tf, tf), rbind(tf, tt)), mean(c(2 * 1 / 2, 2 * 1 / 3))) # 1 TRUE-TRUE match of 2 and 3 TRUE values per obs
 
   #accmult
   acc.test = vnapply(seq_row(multi.y), function(i) sum(multi.y[i, ] & multi.p[i, ]) / (sum(multi.y[i, ] | multi.p[i, ])))


### PR DESCRIPTION
measureMultiLabelF1 has an upper case L in it, all other multilabel measures don't.

I hope I got all occurrences of this notation. I did a `grep -r` for it, and skipped what I consider auto-generated files.

Fixes #2160 