### PR TITLE
more pkgdown tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,8 @@ jobs:
         - mv vignettes/tutorial/devel/pdf/_pdf_wrapper.pdf vignettes/tutorial/devel/pdf/mlr-tutorial.pdf
         - git add --force vignettes/tutorial/devel/pdf/mlr-tutorial.pdf
         - git commit -a -m "update auto-generated tutorial pdf version [ci skip]"
-        - git push --force
+        # only push for non cron jobs
+        - if [[ "${TRAVIS_EVENT_TYPE}" != "cron"]]; then git push --force; fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - R -q -e 'install.packages(c("rmarkdown", "pander"));tic::prepare_all_stages(); tic::before_install()'
         # for some reason we need to install from github as 'R CMD BUILD' results in build errors of the PDF
         - R -q -e 'devtools::install_github("mlr-org/mlr")'
-      before_deploy: R -q -e 'tic::before_deploy(); devtools::install_github("jimhester/lintr");devtools::install_github("pat-s/pkgdown@cc1579abcf00cb11bc856e48f3b9d3c91432c2c2")'
+      before_deploy: R -q -e 'tic::before_deploy(); devtools::install_github("jimhester/lintr");devtools::install_github("pat-s/pkgdown@63a1dcd18c12bc1d585419bf53195e5cf18ba32e")'
       deploy:
          provider: script
          script: R -q -e 'tic::deploy()'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![mlr](https://raw.githubusercontent.com/mlr-org/mlr/master/logo.png) Machine Learning in R
+![mlr](https://raw.githubusercontent.com/mlr-org/mlr/master/man/figures/logo.png) Machine Learning in R
 ==========================
 [![Build Status](https://travis-ci.org/mlr-org/mlr.svg?branch=master)](https://travis-ci.org/mlr-org/mlr)
 [![CRAN Status Badge](http://www.r-pkg.org/badges/version/mlr)](https://CRAN.R-project.org/package=mlr)


### PR DESCRIPTION
* do not push PDF vignette for cron jobs (maybe we should push to another repo at all to not clutter the main repo with the PDF updates)
* update logo path in README
* incorporate latest pkgdown changes (tested)

We need to use the fork as it holds the custom navbar. I'll check if there is a better way to specify the template than using a fork install. This would release me from having to update the fork all the time which is of course annoying. 

FYI: `pkgdown` is on the way to support a release/dev approach soon. 