### PR TITLE
Allow stratify.cols to be integer

### DIFF
--- a/R/ResampleDesc.R
+++ b/R/ResampleDesc.R
@@ -73,7 +73,7 @@
 #'   For survival tasks stratification is done on the events, resulting in training sets with comparable
 #'   censoring rates.
 #' @param stratify.cols ([character])\cr
-#'   Stratify on specific columns referenced by name. All columns have to be factors.
+#'   Stratify on specific columns referenced by name. All columns have to be factor or integer.
 #'   Note that you have to ensure yourself that stratification is possible, i.e.
 #'   that each strata contains enough observations.
 #'   This argument and `stratify` are mutually exclusive.

--- a/R/ResampleInstance.R
+++ b/R/ResampleInstance.R
@@ -91,7 +91,7 @@ makeResampleInstance = function(desc, task, size, ...) {
     if (length(i) > 0L)
       stopf("Columns specified for stratification, but not present in task: %s", collapse(stratify.cols[i]))
     index = getTaskData(task, features = stratify.cols, target.extra = FALSE)[stratify.cols]
-    if (any(vlapply(index, is.numeric)))
+    if (any(vlapply(index, is.double)))
       stop("Stratification on numeric variables not possible")
     grp = tapply(seq_row(index), index, simplify = FALSE)
     grp = unname(split(seq_row(index), grp))

--- a/R/ResampleInstance.R
+++ b/R/ResampleInstance.R
@@ -92,7 +92,7 @@ makeResampleInstance = function(desc, task, size, ...) {
       stopf("Columns specified for stratification, but not present in task: %s", collapse(stratify.cols[i]))
     index = getTaskData(task, features = stratify.cols, target.extra = FALSE)[stratify.cols]
     if (any(vlapply(index, is.double)))
-      stop("Stratification on numeric variables not possible")
+      stop("Stratification on numeric double-precision variables not possible")
     grp = tapply(seq_row(index), index, simplify = FALSE)
     grp = unname(split(seq_row(index), grp))
 

--- a/man/makeResampleDesc.Rd
+++ b/man/makeResampleDesc.Rd
@@ -62,7 +62,7 @@ For survival tasks stratification is done on the events, resulting in training s
 censoring rates.}
 
 \item{stratify.cols}{(\link{character})\cr
-Stratify on specific columns referenced by name. All columns have to be factors.
+Stratify on specific columns referenced by name. All columns have to be factor or integer.
 Note that you have to ensure yourself that stratification is possible, i.e.
 that each strata contains enough observations.
 This argument and \code{stratify} are mutually exclusive.}

--- a/tests/testthat/test_base_resample_stratify.R
+++ b/tests/testthat/test_base_resample_stratify.R
@@ -78,3 +78,22 @@ test_that("stratification on features work", {
   expect_true(setequal(apply(train[c("x", "y")], 1, collapse, sep = ""), c("aa", "ab", "ba", "bb")))
   expect_true(setequal(apply(test[c("x", "y")], 1, collapse, sep = ""), c("aa", "ab", "ba", "bb")))
 })
+
+test_that("stratification on integers work", {
+  df = data.frame(x = rep(c("a", "b"), each = 4), y = rep(c("a", "b"), times = 4), z = rep(1:2, each = 4))
+  task = makeClassifTask(data = df, target = "y")
+  rdesc = makeResampleDesc("Holdout", split = 0.5, stratify.cols = "z")
+  rin = makeResampleInstance(rdesc, task = task)
+  train = df[rin$train.inds[[1]], ]
+  test = df[rin$test.inds[[1]], ]
+  expect_equal(as.integer(table(train$z)), c(2L, 2L))
+  expect_equal(as.integer(table(test$z)), c(2L, 2L))
+})
+
+test_that("stratification on doubles does not work", {
+  df = data.frame(x = rep(c("a", "b"), each = 4), y = rep(c("a", "b"), times = 4), z = rep(1:2, each = 4))
+  df$z = as.double(df$z)
+  task = makeClassifTask(data = df, target = "y")
+  rdesc = makeResampleDesc("Holdout", split = 0.5, stratify.cols = "z")
+  expect_error(makeResampleInstance(rdesc, task = task), "double-precision")
+})


### PR DESCRIPTION
Currently the checks are a bit too restrictive. This PR allows to stratify on integer columns.