### PR TITLE
Require pander for Tutorial HTML

### DIFF
--- a/tic.R
+++ b/tic.R
@@ -29,6 +29,7 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
 
   get_stage("install") %>%
     add_code_step(if (length(find.package("magick", quiet = TRUE)) == 0) install.packages("magick")) %>% # favicon creation
+    add_code_step(if (length(find.package("pander", quiet = TRUE)) == 0) install.packages("pander")) %>%
     add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
 
   get_stage("before_deploy") %>%


### PR DESCRIPTION
With an empty cache and no cache sharing yet between the envs, we also need to require `pander` for the HTML build. 

https://travis-ci.org/mlr-org/mlr/jobs/370688013