### PR TITLE
Travis: Fix allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,7 @@ jobs:
              - $TRAVIS_PULL_REQUEST = false
              - $TRAVIS_EVENT_TYPE != cron
     - stage: Tutorial
-      env:
-        - TUTORIAL=HTML
+      env: TUTORIAL=HTML
       addons:
         apt:
           packages:
@@ -94,8 +93,7 @@ jobs:
              - $TRAVIS_PULL_REQUEST = false
              - $TRAVIS_EVENT_TYPE != cron
     - stage: Tutorial
-      env:
-        - TUTORIAL=PDF
+      env: TUTORIAL=PDF
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ r_github_packages:
   - jimhester/lintr
 
 jobs:
-  fast_finish: true
-  allow_failures:
-    - env: TUTORIAL=HTML
-    - env: TUTORIAL=PDF
   include:
     - stage: warmup-1
       env: RCMDCHECK=TRUE


### PR DESCRIPTION
If the tutorial fails, the Travis build should still succeed. 
This did not happen in https://travis-ci.org/mlr-org/mlr/builds/370688009

I did some testing and found out that the cause for this is a slightly wrong specification of the "env" setting in the stages. 

It now works as desired: https://travis-ci.org/mlr-org/mlr/builds/371611368