### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -1370,7 +1370,7 @@ cindex = makeMeasure(id = "cindex", minimize = FALSE, best = 1, worst = 0,
 #' @references
 #' H. Uno et al.
 #' *On the C-statistics for Evaluating Overall Adequacy of Risk Prediction Procedures with Censored Survival Data*
-#' Statistics in medicine. 2011;30(10):1105-1117. <http://dx.doi.org/10.1002/sim.4154>.
+#' Statistics in medicine. 2011;30(10):1105-1117. <https://doi.org/10.1002/sim.4154>.
 cindex.uno = makeMeasure(id = "cindex.uno", minimize = FALSE, best = 1, worst = 0,
   properties = c("surv", "req.pred", "req.truth", "req.model", "req.task"),
   name = "Uno's Concordance index",

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Please cite our [JMLR paper](http://jmlr.org/papers/v17/15-066.html) [[bibtex](h
 Some parts of the package were created as part of other publications.
 If you use these parts, please cite the relevant work appropriately:
 
-* Tuning with Iterated F-Racing: [Automatic model selection for high-dimensional survival analysis.](https://dx.doi.org/10.1080/00949655.2014.929131).
-* Class Imbalance Correction Algorithms: [On Class Imbalance Correction for Classification Algorithms in Credit Scoring](https://dx.doi.org/10.1007/978-3-319-28697-6_6).
+* Tuning with Iterated F-Racing: [Automatic model selection for high-dimensional survival analysis.](https://doi.org/10.1080/00949655.2014.929131).
+* Class Imbalance Correction Algorithms: [On Class Imbalance Correction for Classification Algorithms in Credit Scoring](https://doi.org/10.1007/978-3-319-28697-6_6).
 * Bayesian Optimization with mlrMBO: [mlrMBO: A Modular Framework for Model-Based Optimization of Expensive Black-Box Functions](https://arxiv.org/abs/1703.03373)
 * Multilabel Classification: [Multilabel Classification with R Package mlr](https://arxiv.org/abs/1703.08991)
 * OpenML: [OpenML: An R Package to Connect to the Machine Learning Platform OpenML](https://arxiv.org/abs/1701.01293)

--- a/man/measures.Rd
+++ b/man/measures.Rd
@@ -428,7 +428,7 @@ IEEE Transactions on Knowledge and Data Engineering, vol. 21, no. 9. pp. 1263-12
 
 H. Uno et al.
 \emph{On the C-statistics for Evaluating Overall Adequacy of Risk Prediction Procedures with Censored Survival Data}
-Statistics in medicine. 2011;30(10):1105-1117. \url{http://dx.doi.org/10.1002/sim.4154}.
+Statistics in medicine. 2011;30(10):1105-1117. \url{https://doi.org/10.1002/sim.4154}.
 
 H. Uno et al.
 \emph{Evaluating Prediction Rules for T-Year Survivors with Censored Regression Models}

--- a/vignettes/tutorial/devel/cost_sensitive_classif.Rmd
+++ b/vignettes/tutorial/devel/cost_sensitive_classif.Rmd
@@ -458,7 +458,7 @@ In case of example-dependent costs we have to create a special `Task()` via func
 For this purpose the feature values $x$ and an $n \times K$ ``cost`` matrix that contains the cost vectors for all $n$ examples in the data set are required.
 
 We use the iris (`datasets::iris()`) data and generate an artificial cost matrix
-(see [Beygelzimer et al., 2005](http://dx.doi.org/10.1145/1102351.1102358)).
+(see [Beygelzimer et al., 2005](https://doi.org/10.1145/1102351.1102358)).
 
 ```{r}
 df = iris

--- a/vignettes/tutorial/devel/task.Rmd
+++ b/vignettes/tutorial/devel/task.Rmd
@@ -139,7 +139,7 @@ The $k$-th component indicates the cost of assigning $x$ to class $k$. Naturally
 
 As the cost vector contains all relevant information about the intended class $y$, only the feature values $x$ and a ``cost`` matrix, which contains the cost vectors for all examples in the data set, are required to create the `CostSensTask()`.
 
-In the following example we use the `datasets::iris()` data and an artificial cost matrix (which is generated as proposed by [Beygelzimer et al., 2005](http://dx.doi.org/10.1145/1102351.1102358)):
+In the following example we use the `datasets::iris()` data and an artificial cost matrix (which is generated as proposed by [Beygelzimer et al., 2005](https://doi.org/10.1145/1102351.1102358)):
 
 ```{r}
 df = iris

--- a/vignettes/tutorial/old/2.10/html/cost_sensitive_classif/index.html
+++ b/vignettes/tutorial/old/2.10/html/cost_sensitive_classif/index.html
@@ -915,7 +915,7 @@ For this purpose the feature values <script type="math/tex">x</script> and an <s
 <code>cost</code> matrix that contains
 the cost vectors for all <script type="math/tex">n</script> examples in the data set are required.</p>
 <p>We use the <a href="http://www.rdocumentation.org/packages/datasets/functions/iris.html">iris</a> data and generate an artificial cost matrix
-(see <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
+(see <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,] + runif(150, 0, 10)
 colnames(cost) = levels(iris$Species)

--- a/vignettes/tutorial/old/2.10/html/task/index.html
+++ b/vignettes/tutorial/old/2.10/html/task/index.html
@@ -422,7 +422,7 @@ minimal.</p>
 the feature values <script type="math/tex">x</script> and a <code>cost</code> matrix, which contains the cost vectors for all examples in the data
 set, are required to create the <a href="http://www.rdocumentation.org/packages/mlr/functions/Task.html">CostSensTask</a>.</p>
 <p>In the following example we use the <a href="http://www.rdocumentation.org/packages/datasets/functions/iris.html">iris</a>  data and an artificial cost matrix
-(which is generated as proposed by <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
+(which is generated as proposed by <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,]
 df$Species = NULL

--- a/vignettes/tutorial/old/2.4/html/task/index.html
+++ b/vignettes/tutorial/old/2.4/html/task/index.html
@@ -445,7 +445,7 @@ minimal.</p>
 the feature values <em>x</em> and a <code>cost</code> matrix, which contains the cost vectors for all examples in the data
 set, are required to create the <a href="http://www.rdocumentation.org/packages/mlr/functions/Task.html">CostSensTask</a>.</p>
 <p>In the following example we use the <a href="http://www.rdocumentation.org/packages/datasets/functions/iris.html">iris data</a> and generate an artificial cost matrix
-(following <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
+(following <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,]
 df$Species = NULL

--- a/vignettes/tutorial/old/2.7/html/cost_sensitive_classif/index.html
+++ b/vignettes/tutorial/old/2.7/html/cost_sensitive_classif/index.html
@@ -1029,7 +1029,7 @@ For this purpose the feature values <script type="math/tex">x</script> and an <s
 <code>cost</code> matrix that contains
 the cost vectors for all <script type="math/tex">n</script> examples in the data set are required.</p>
 <p>We use the <a href="http://www.inside-r.org/r-doc/datasets/iris">iris</a> data and generate an artificial cost matrix
-(see <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
+(see <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,] + runif(150, 0, 10)
 colnames(cost) = levels(iris$Species)

--- a/vignettes/tutorial/old/2.7/html/task/index.html
+++ b/vignettes/tutorial/old/2.7/html/task/index.html
@@ -514,7 +514,7 @@ minimal.</p>
 the feature values <script type="math/tex">x</script> and a <code>cost</code> matrix, which contains the cost vectors for all examples in the data
 set, are required to create the <a href="http://rpackages.ianhowson.com/cran/mlr/man/Task.html">CostSensTask</a>.</p>
 <p>In the following example we use the <a href="http://www.inside-r.org/r-doc/datasets/iris">iris</a>  data and an artificial cost matrix
-(which is generated as proposed by <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
+(which is generated as proposed by <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,]
 df$Species = NULL

--- a/vignettes/tutorial/old/2.8/html/cost_sensitive_classif/index.html
+++ b/vignettes/tutorial/old/2.8/html/cost_sensitive_classif/index.html
@@ -1048,7 +1048,7 @@ For this purpose the feature values <script type="math/tex">x</script> and an <s
 <code>cost</code> matrix that contains
 the cost vectors for all <script type="math/tex">n</script> examples in the data set are required.</p>
 <p>We use the <a href="http://www.inside-r.org/r-doc/datasets/iris">iris</a> data and generate an artificial cost matrix
-(see <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
+(see <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,] + runif(150, 0, 10)
 colnames(cost) = levels(iris$Species)

--- a/vignettes/tutorial/old/2.8/html/task/index.html
+++ b/vignettes/tutorial/old/2.8/html/task/index.html
@@ -514,7 +514,7 @@ minimal.</p>
 the feature values <script type="math/tex">x</script> and a <code>cost</code> matrix, which contains the cost vectors for all examples in the data
 set, are required to create the <a href="http://rpackages.ianhowson.com/cran/mlr/man/Task.html">CostSensTask</a>.</p>
 <p>In the following example we use the <a href="http://www.inside-r.org/r-doc/datasets/iris">iris</a>  data and an artificial cost matrix
-(which is generated as proposed by <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
+(which is generated as proposed by <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,]
 df$Species = NULL

--- a/vignettes/tutorial/old/2.9/html/cost_sensitive_classif/index.html
+++ b/vignettes/tutorial/old/2.9/html/cost_sensitive_classif/index.html
@@ -1056,7 +1056,7 @@ For this purpose the feature values <script type="math/tex">x</script> and an <s
 <code>cost</code> matrix that contains
 the cost vectors for all <script type="math/tex">n</script> examples in the data set are required.</p>
 <p>We use the <a href="http://www.inside-r.org/r-doc/datasets/iris">iris</a> data and generate an artificial cost matrix
-(see <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
+(see <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,] + runif(150, 0, 10)
 colnames(cost) = levels(iris$Species)

--- a/vignettes/tutorial/old/2.9/html/task/index.html
+++ b/vignettes/tutorial/old/2.9/html/task/index.html
@@ -520,7 +520,7 @@ minimal.</p>
 the feature values <script type="math/tex">x</script> and a <code>cost</code> matrix, which contains the cost vectors for all examples in the data
 set, are required to create the <a href="http://rpackages.ianhowson.com/cran/mlr/man/Task.html">CostSensTask</a>.</p>
 <p>In the following example we use the <a href="http://www.inside-r.org/r-doc/datasets/iris">iris</a>  data and an artificial cost matrix
-(which is generated as proposed by <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
+(which is generated as proposed by <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,]
 df$Species = NULL

--- a/vignettes/tutorial/release/cost_sensitive_classif.html
+++ b/vignettes/tutorial/release/cost_sensitive_classif.html
@@ -919,7 +919,7 @@ For this purpose the feature values <script type="math/tex">x</script> and an <s
 <code>cost</code> matrix that contains
 the cost vectors for all <script type="math/tex">n</script> examples in the data set are required.</p>
 <p>We use the <a href="http://www.rdocumentation.org/packages/datasets/functions/iris.html">iris</a> data and generate an artificial cost matrix
-(see <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
+(see <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>).</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,] + runif(150, 0, 10)
 colnames(cost) = levels(iris$Species)

--- a/vignettes/tutorial/release/task.html
+++ b/vignettes/tutorial/release/task.html
@@ -426,7 +426,7 @@ minimal.</p>
 the feature values <script type="math/tex">x</script> and a <code>cost</code> matrix, which contains the cost vectors for all examples in the data
 set, are required to create the <a href="http://www.rdocumentation.org/packages/mlr/functions/Task.html">CostSensTask</a>.</p>
 <p>In the following example we use the <a href="http://www.rdocumentation.org/packages/datasets/functions/iris.html">iris</a>  data and an artificial cost matrix
-(which is generated as proposed by <a href="http://dx.doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
+(which is generated as proposed by <a href="https://doi.org/10.1145/1102351.1102358">Beygelzimer et al., 2005</a>):</p>
 <pre><code class="r">df = iris
 cost = matrix(runif(150 * 3, 0, 2000), 150) * (1 - diag(3))[df$Species,]
 df$Species = NULL


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links. Because that seems like a minor change, I did not go through the entire list of Coding Guidelines, but will updates this PR if Travis warns about something or your request changes.

Cheers!