### PR TITLE
Optimize navbar logo rendering

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -56,8 +56,20 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4 {
 }
 
 /* margins of navbar-brand, default 14.5 and 10 */
+
+/* this sets the mlr logo in the navbar */
 .navbar-brand {
-    padding: 7px 7px;
+    /*padding: 7px 7px;
+    font-family: "Source Code Pro", Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-weight: normal;
+    font-size: 32px; */
+    padding: 0 0 0 85px;
+    height: 50px;
+    line-height: 50px;
+    background-image: url(../docs/logo.png);
+    background-size: 64px auto;
+    background-repeat: no-repeat;
+    background-position: 15px center;
 }
 
 /* relax lower margins of headers, default -60px */

--- a/pkgdown/templates/navbar.html
+++ b/pkgdown/templates/navbar.html
@@ -7,10 +7,10 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <span class="navbar-brand">
-        <a class="navbar-link" href="{{#site}}{{root}}{{/site}}index.html"><img src="https://github.com/mlr-org/mlr/blob/master/man/figures/logo.png?raw=true" width="70"></a>
-        <span class="label label-{{#development}}{{version_label}}{{/development}}" data-toggle="tooltip" data-placement="bottom" title="{{#development}}{{version_tooltip}}{{/development}}">{{#package}}{{version}}{{/package}}</span>
-      </span>
+
+      <div class="navbar-brand-container">
+        <a class="navbar-brand" href="{{#site}}{{root}}{{/site}}index.html"></a>
+      </div>
     </div>
 
     <div id="navbar" class="navbar-collapse collapse">


### PR DESCRIPTION
Currently there is a small delay in loading the navbar logo when loading a tutorial page.
The PR now uses the `dplyr` approach (which uses CSS instead of specifying the logo stuff in `navbar.html`) and solves the delay problem.

#2236 