### PR TITLE
fix tuneCMAES and tuneGenSA bug

### DIFF
--- a/R/tuneCMAES.R
+++ b/R/tuneCMAES.R
@@ -5,7 +5,7 @@ tuneCMAES = function(learner, task, resampling, measures, par.set, control, opt.
   upp = getUpper(par.set)
   start = control$start
   if (is.null(start))
-    start = sampleValue(par.set, start, trafo = FALSE)
+    start = sampleValue(par.set, discrete.names = FALSE, trafo = FALSE)
   start = convertStartToNumeric(start, par.set)
   # set sigma to 1/4 per dim, defaults in cmaes are crap for this, last time I looked
   # and vectorized evals for speed and parallel, then insert user controls

--- a/R/tuneGenSA.R
+++ b/R/tuneGenSA.R
@@ -5,7 +5,7 @@ tuneGenSA = function(learner, task, resampling, measures, par.set, control, opt.
   upp = getUpper(par.set)
   start = control$start
   if (is.null(start))
-    start = sampleValue(par.set, start, trafo = FALSE)
+    start = sampleValue(par.set, discrete.names = FALSE, trafo = FALSE)
   start = convertStartToNumeric(start, par.set)
   ctrl.gensa = control$extra.args
 


### PR DESCRIPTION
They won't work with PH 1.11
This bug was cought by a new ParamHelpers release with more strict assertions.
Actually I don't know what this was supposed to mean or if it simply was accidental nonesense.