### PR TITLE
Some tutorial fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
            - libgsl0-dev
       # only stages with the same env share a cache
       # this should be share to other stages via the cache
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
       install:
       #  - Rscript -e 'pkgs = trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]); pkgs = pkgs[!pkgs %in% installed.packages()]; if (length(pkgs) > 0) install.packages(pkgs)'
         - R -q -e 'tic::install()'
@@ -42,7 +42,7 @@ jobs:
           packages:
            - libgmp-dev
            - libgsl0-dev
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
       before_script: R -q -e 'tic::before_script()'
       script: true
     - stage: check
@@ -53,7 +53,7 @@ jobs:
            - libgmp-dev
            - libgsl0-dev
       before_install:
-        - R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+        - R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
       warnings_are_errors: false
       before_script: R -q -e 'tic::before_script()'
       script: R -q -e 'tic::script()'
@@ -76,7 +76,7 @@ jobs:
            - imagemagick # for favicon
       latex: false
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       before_deploy: R -q -e 'tic::before_deploy()'
@@ -97,7 +97,7 @@ jobs:
            - libgsl0-dev
            - ghostscript # for mlr-tutorial pdf
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       before_deploy: R -q -e 'tic::before_deploy()'
@@ -118,7 +118,7 @@ jobs:
            - libgsl0-dev
            - ghostscript # for mlr-tutorial pdf
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       before_deploy: R -q -e 'tic::before_deploy()'

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -66,7 +66,7 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4 {
     padding: 0 0 0 85px;
     height: 50px;
     line-height: 50px;
-    background-image: url(../docs/logo.png);
+    background-image: url(logo.png);
     background-size: 64px auto;
     background-repeat: no-repeat;
     background-position: 15px center;


### PR DESCRIPTION
Commit 1: Currently there is an issue with the most recent version of `tic` when deploying (https://github.com/ropenscilabs/tic/issues/56). Using an older version for now that works. 

Commit 2: Fix path for logo rendering of the tutorial. The most recent state of the tutorial was pushed by a test branch to `gh-pages` that included this fix. 
