### PR TITLE
Tutorial fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ Thumbs.db
 .project
 .settings
 .ipynb_checkpoints
-man/*.Rd

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       # only stages with the same env share a cache
       # this should be share to other stages via the cache
       before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
-      install: - R -q -e 'tic::install()'
+      install: R -q -e 'tic::install()'
       script: true
     - stage: warmup-2
       env: RCMDCHECK=TRUE

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ jobs:
       # only stages with the same env share a cache
       # this should be share to other stages via the cache
       before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
-      install:
-      #  - Rscript -e 'pkgs = trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]); pkgs = pkgs[!pkgs %in% installed.packages()]; if (length(pkgs) > 0) install.packages(pkgs)'
-        - R -q -e 'tic::install()'
+      install: - R -q -e 'tic::install()'
       script: true
     - stage: warmup-2
       env: RCMDCHECK=TRUE
@@ -73,7 +71,7 @@ jobs:
           packages:
            - libgmp-dev
            - libgsl0-dev
-           - imagemagick # for favicon
+           - libmagick++-dev # for favicon
       latex: false
       pandoc_version: 2.2.1
       before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'

--- a/tic.R
+++ b/tic.R
@@ -32,8 +32,7 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
     add_code_step(if (length(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()]) > 0)
       install.packages(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()])) %>%
     add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
-                                           "-install-package", "thirdparty/XMeans1.0.4.zip"))) %>%
-    add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
+                                           "-install-package", "thirdparty/XMeans1.0.4.zip")))
 
   get_stage("install") %>%
     add_code_step(if (length(find.package("magick", quiet = TRUE)) == 0) install.packages("magick")) %>% # favicon creation
@@ -41,9 +40,7 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
     add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
 
   get_stage("before_deploy") %>%
-    add_step(step_setup_ssh()) %>%
-    add_code_step(system2("sed", c("-i","-e", '/^##/ s/#/', "-e", "'/^###/ s/#/'", "'/^####/ s/#/'", "vignettes/tutorial/devel/*.Rmd"))) %>%
-    add_code_step(system2("sed", c("-i","-e", '/^##/ s/#/', "-e", "'/^###/ s/#/'", "'/^####/ s/#/'", "vignettes/tutorial/release/*.Rmd")))
+    add_step(step_setup_ssh())
 
   get_stage("deploy") %>%
     add_code_step(devtools::document(roclets=c('rd', 'collate', 'namespace'))) %>%
@@ -56,8 +53,7 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
     add_code_step(if (length(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()]) > 0)
       install.packages(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()])) %>%
     add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
-                                           "-install-package", "thirdparty/XMeans1.0.4.zip"))) %>%
-    add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
+                                           "-install-package", "thirdparty/XMeans1.0.4.zip")))
 
   get_stage("install") %>%
     add_code_step(if (length(find.package("pander", quiet = TRUE)) == 0) install.packages("pander")) %>%
@@ -67,14 +63,11 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
     add_code_step(if (length(find.package("roxygen2", quiet = TRUE)) == 0) devtools::install_github("klutometis/roxygen")) %>%
     add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
 
-  # this ensures that the NAMESPACE is correct. R CMD Build is not enough for the PDF build.
-  get_stage("script") %>%
-    add_code_step(devtools::document())
-
   get_stage("before_deploy") %>%
     add_step(step_setup_ssh())
 
   get_stage("deploy") %>%
+    add_code_step(devtools::install_github("mlr-org/mlr")) %>%
     add_code_step(rmarkdown::render("vignettes/tutorial/devel/pdf/_pdf_wrapper.Rmd")) %>%
     add_code_step(fs::file_move("vignettes/tutorial/devel/pdf/_pdf_wrapper.pdf", "vignettes/tutorial/devel/pdf/mlr-tutorial_dev.pdf")) %>%
     add_step(step_push_deploy(orphan = FALSE, commit_paths = "vignettes/tutorial/dev/pdf/mlr-tutorial_dev.pdf", branch = "tutorial_pdf"))
@@ -86,8 +79,7 @@ if (Sys.getenv("TUTORIAL") == "PDFrelease") {
     add_code_step(if (length(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()]) > 0)
       install.packages(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()])) %>%
     add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
-                                           "-install-package", "thirdparty/XMeans1.0.4.zip"))) %>%
-    add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
+                                           "-install-package", "thirdparty/XMeans1.0.4.zip")))
 
   get_stage("install") %>%
     add_code_step(if (length(find.package("pander", quiet = TRUE)) == 0) install.packages("pander")) %>%
@@ -97,14 +89,11 @@ if (Sys.getenv("TUTORIAL") == "PDFrelease") {
     add_code_step(if (length(find.package("roxygen2", quiet = TRUE)) == 0) devtools::install_github("klutometis/roxygen")) %>%
     add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
 
-  # this ensures that the NAMESPACE is correct. R CMD Build is not enough for the PDF build.
-  get_stage("script") %>%
-    add_code_step(devtools::document())
-
   get_stage("before_deploy") %>%
     add_step(step_setup_ssh())
 
   get_stage("deploy") %>%
+    add_code_step(devtools::install_github("mlr-org/mlr")) %>%
     add_code_step(rmarkdown::render("vignettes/tutorial/release/pdf/_pdf_wrapper.Rmd")) %>%
     add_code_step(fs::file_move("vignettes/tutorial/release/pdf/_pdf_wrapper.pdf", "vignettes/tutorial/release/pdf/mlr-tutorial_release.pdf")) %>%
     add_step(step_push_deploy(orphan = FALSE, commit_paths = "vignettes/tutorial/release/pdf/mlr-tutorial_release.pdf", branch = "tutorial_pdf"))


### PR DESCRIPTION
Hopefully the last ones for a while.

- Deployment of man/* files couldn't work when man/* was still listed in `.gitignore`.

- `libmagick++dev` is required instead of `imagemagick` for `pkgdown` favicon creation

- For some reason `devtools::document()` is not enough to provide a valid `mlr` installation for the PDF build stages. I tried all Travis stages. Using `devtools::install_github("mlr-org/mlr")` works.

- Removed the (broken) `sed` call for changing the HTML tutorial headers. I have an open PR on `pkgdown` to let the user specify the ToC depth. Currently its limited to h2 which is why we lack a ToC in the sidebar.

- The `add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))` existed twice in some stages so I cleaned up. 

All these fixes should clear the issues of NAMESPACE and man/ deployment in the "check" stage and the PDF tutorial. I verified both in other branches. The HTML tutorial was already ok for the latest builds. 

However, to get the favicon creation working, we need to rebuild the `master` cache. Why? Currently `magick` is in the cache but not linked against `libmagick++dev`. Hence it will not be reinstalled for a new build but also cannot be used due to the missing linking. EDIT: I just deleted the master cache.
