### PR TITLE
Add info about special.vals to learner API doc

### DIFF
--- a/R/RLearner_classif_xgboost.R
+++ b/R/RLearner_classif_xgboost.R
@@ -23,7 +23,7 @@ makeRLearner.classif.xgboost = function() {
       makeUntypedLearnerParam(id = "eval_metric", default = "error", tunable = FALSE),
       makeNumericLearnerParam(id = "base_score", default = 0.5, tunable = FALSE),
       makeNumericLearnerParam(id = "max_delta_step", lower = 0, default = 0),
-      makeNumericLearnerParam(id = "missing", default = NULL, tunable = FALSE, when = "both",
+      makeNumericLearnerParam(id = "missing", default = NA, tunable = FALSE, when = "both",
         special.vals = list(NA, NA_real_, NULL)),
       makeIntegerVectorLearnerParam(id = "monotone_constraints", default = 0, lower = -1, upper = 1),
       makeNumericLearnerParam(id = "tweedie_variance_power", lower = 1, upper = 2, default = 1.5, requires = quote(objective == "reg:tweedie")),

--- a/R/RLearner_regr_xgboost.R
+++ b/R/RLearner_regr_xgboost.R
@@ -23,7 +23,7 @@ makeRLearner.regr.xgboost = function() {
       makeUntypedLearnerParam(id = "eval_metric", default = "rmse", tunable = FALSE),
       makeNumericLearnerParam(id = "base_score", default = 0.5, tunable = FALSE),
       makeNumericLearnerParam(id = "max_delta_step", lower = 0, default = 0),
-      makeNumericLearnerParam(id = "missing", default = NULL, tunable = FALSE, when = "both",
+      makeNumericLearnerParam(id = "missing", default = NA, tunable = FALSE, when = "both",
         special.vals = list(NA, NA_real_, NULL)),
       makeIntegerVectorLearnerParam(id = "monotone_constraints", default = 0, lower = -1, upper = 1),
       makeNumericLearnerParam(id = "tweedie_variance_power", lower = 1, upper = 2, default = 1.5, requires = quote(objective == "reg:tweedie")),

--- a/vignettes/tutorial/devel/create_learner.Rmd
+++ b/vignettes/tutorial/devel/create_learner.Rmd
@@ -99,6 +99,19 @@ Can the learner predict posterior probabilities?
 
 If the learner supports class weights the name of the relevant learner parameter can be specified via argument `class.weights.param`.
 
+Sometimes parameters allow certain values that dont "fit" the formal param types. 
+Very often, but not always, these are also the default values. 
+For example:
+A numeric param that accepts values as `NA`, `NULL`, `"auto"`, and so on.
+For these there is the option `special.vals`, for param definitions, that allows to list these extra values, and defines them as feasible as well. 
+An example is the `missing` argument in `xgboost`. 
+It accepts numeric values (that's why its set as a numeric param) and `NULL` but the default is `NA`.
+
+```{r, eval = FALSE}
+makeNumericLearnerParam(id = "missing", default = NA, tunable = FALSE, when = "both",
+  special.vals = list(NA, NA_real_, NULL))
+```
+
 Below is the complete code for the definition of the LDA learner. 
 It has one discrete parameter, ``method``, and two continuous ones, ``nu`` and ``tol``. 
 It supports classification problems with two or more classes and can deal with numeric and factor explanatory variables. 

--- a/vignettes/tutorial/devel/create_learner.Rmd
+++ b/vignettes/tutorial/devel/create_learner.Rmd
@@ -99,13 +99,13 @@ Can the learner predict posterior probabilities?
 
 If the learner supports class weights the name of the relevant learner parameter can be specified via argument `class.weights.param`.
 
-Sometimes parameters allow certain values that dont "fit" the formal param types. 
-Very often, but not always, these are also the default values. 
+Sometimes parameters allow certain values that don't "fit" the formal parameter types. 
+Often, these are also the default values. 
 For example:
-A numeric param that accepts values as `NA`, `NULL`, `"auto"`, and so on.
-For these there is the option `special.vals`, for param definitions, that allows to list these extra values, and defines them as feasible as well. 
+A numeric parameter that accepts values as `NA`, `NULL`, `"auto"`, and so on.
+For these there is the option `special.vals`, which allows to list these extra values as feasible. 
 An example is the `missing` argument in `xgboost`. 
-It accepts numeric values (that's why its set as a numeric param) and `NULL` but the default is `NA`.
+It accepts numeric values (that's why it's set as a numeric parameter) and `NULL` but the default is `NA`.
 
 ```{r, eval = FALSE}
 makeNumericLearnerParam(id = "missing", default = NA, tunable = FALSE, when = "both",


### PR DESCRIPTION
fixes #2323 
cross-ref #1191

Also `xgboost` has changed the default of param `missing` again to `NA`. I changed that for both learners. 