### PR TITLE
Update README, fix favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![mlr](https://raw.githubusercontent.com/mlr-org/mlr/master/man/figures/logo_navbar.png) Machine Learning in R
-==========================
+# Machine Learning in R <img src="man/figures/logo_navbar.png" align="right" />
+
 [![Build Status](https://travis-ci.org/mlr-org/mlr.svg?branch=master)](https://travis-ci.org/mlr-org/mlr)
 [![CRAN Status Badge](http://www.r-pkg.org/badges/version/mlr)](https://CRAN.R-project.org/package=mlr)
 [![CRAN Downloads](http://cranlogs.r-pkg.org/badges/mlr)](https://cran.rstudio.com/web/packages/mlr/index.html)
@@ -9,8 +9,8 @@
 * [mlr cheatsheet](https://github.com/mlr-org/mlr/blob/master/vignettes/tutorial/cheatsheet/MlrCheatsheet.pdf)
 * Detailed Tutorial:
     * [Main: Online as HTML (devel)](https://mlr-org.github.io/mlr/) (For the HTML docs of the current CRAN version, replace `devel` by `release` in the URL.)
-    * [Download PDF for offline usage (CRAN)](https://github.com/mlr-org/mlr/blob/tutorial_pdf_release/vignettes/tutorial/release/pdf/mlr-tutorial_release.pdf))
-    * [Download PDF for offline usage (devel)](https://github.com/mlr-org/mlr/blob/tutorial_pdf_dev/vignettes/tutorial/devel/pdf/mlr-tutorial_dev.pdf))
+    * [Download PDF for offline usage (CRAN)](https://github.com/mlr-org/mlr/blob/tutorial_pdf_release/vignettes/tutorial/release/pdf/mlr-tutorial_release.pdf)
+    * [Download PDF for offline usage (devel)](https://github.com/mlr-org/mlr/blob/tutorial_pdf_dev/vignettes/tutorial/devel/pdf/mlr-tutorial_dev.pdf)
 * [R Documentation in HTML](https://mlr-org.github.io/mlr/reference/index.html)
 * Install the development version
 

--- a/pkgdown/templates/head.html
+++ b/pkgdown/templates/head.html
@@ -69,3 +69,6 @@
 {{#yaml}}{{#docsearch}}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 {{/docsearch}}{{/yaml}}
+
+<link rel="icon" type="image/png" href="https://mlr-org.github.io/mlr/favicon.ico">
+<link rel="apple-touch-icon" type="image/png" href="https://mlr-org.github.io/mlr/favicon.ico">


### PR DESCRIPTION
The favicon linking needs to be hardoced in `head.html`, the default approach does for some reason not work and still links to the old logo (which does not even exist  anymore in the repo). Cleaning the cache in the browser (and favicon cache) also did not work but this way should fix the problem now.

I also updated the header of the README to get rid of one instance of "mlr". Imo we have enough "mlr" appearances close to each other. 