### PR TITLE
Travis: Fix travis deployment of docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,15 +55,23 @@ jobs:
       warnings_are_errors: false
       before_script: R -q -e 'tic::before_script()'
       script: R -q -e 'tic::script()'
-      before_deploy: R -q -e 'tic::before_deploy()'
-      deploy:
-         provider: script
-         script: R -q -e 'tic::deploy()'
-         on:
-           branch: master
-           condition:
-             - $TRAVIS_PULL_REQUEST = false
-             - $TRAVIS_EVENT_TYPE != cron
+      after_success:
+        - git checkout master
+        - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""
+        - R --no-save <<< 'library("devtools"); document()'
+        - ./thirdparty/gen_families.sh > man/mlrFamilies.Rd
+        - git config user.name $GN
+        - git config user.email $GM
+        - git config credential.helper "store --file=.git/credentials"
+        - bash inst/convert_to_ascii_news.sh
+        - echo "https://$GT:@github.com" >> .git/credentials
+        - git config push.default matching
+        - git add --force NEWS
+        - git add --force man/*
+        - git commit man DESCRIPTION NAMESPACE NEWS -m "update auto-generated documentation [ci skip]" || true
+        - git push
+        - "[ $TRAVIS_PULL_REQUEST == \"false\" -a $TRAVIS_BRANCH == \"master\" ] && curl -s -X POST -H \"Content-Type:application/json\" -H \"Accept:application/json\" -H \"Travis-API-Version:3\" -H \"Authorization:token $TT\" -d \"{\\\"request\\\":{\\\"branch\\\":\\\"gh-pages\\\", \\\"message\\\":\\\"commit $TRAVIS_COMMIT $TRAVIS_COMMIT_MSG\\\"}}\" https://api.travis-ci.org/repo/mlr-org%2Fmlr-tutorial/requests"
+
     - stage: Tutorial
       env: TUTORIAL=HTML
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ jobs:
         - git config push.default matching
         - git add --force NEWS
         - git add --force man/*
+        - git add --force NAMESPACE
         - git commit man DESCRIPTION NAMESPACE NEWS -m "update auto-generated documentation [ci skip]" || true
         - git push
         - "[ $TRAVIS_PULL_REQUEST == \"false\" -a $TRAVIS_BRANCH == \"master\" ] && curl -s -X POST -H \"Content-Type:application/json\" -H \"Accept:application/json\" -H \"Travis-API-Version:3\" -H \"Authorization:token $TT\" -d \"{\\\"request\\\":{\\\"branch\\\":\\\"gh-pages\\\", \\\"message\\\":\\\"commit $TRAVIS_COMMIT $TRAVIS_COMMIT_MSG\\\"}}\" https://api.travis-ci.org/repo/mlr-org%2Fmlr-tutorial/requests"


### PR DESCRIPTION
The last "ci skip" commit *again* reverted the merged changes of d477c7dac1deaa141b2cba0e4cfeab376b046f74 because 939d3fb3e4cff1f2b164bce2f02515703e8fa4eb was merged to with a too small time difference.

The Travis build for commit 939d3fb3e4cff1f2b164bce2f02515703e8fa4eb started delayed and finished after the next PR that was merged and subsequently overwrote the merged changes again. 

So to be safe in the future we should always wait until a merged master commit build finished on Travis before merging the next one. 
