### PR TITLE
Travis: Hotfix false positives in check stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
            - libgsl0-dev
       # only stages with the same env share a cache
       # this should be share to other stages via the cache
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script: true
     - stage: warmup-2
@@ -40,7 +40,7 @@ jobs:
           packages:
            - libgmp-dev
            - libgsl0-dev
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       before_script: R -q -e 'tic::before_script()'
       script: true
     - stage: check
@@ -51,7 +51,7 @@ jobs:
            - libgmp-dev
            - libgsl0-dev
       before_install:
-        - R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
+        - R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       warnings_are_errors: false
       before_script: R -q -e 'tic::before_script()'
       script: R -q -e 'tic::script()'
@@ -83,7 +83,7 @@ jobs:
            - libmagick++-dev # for favicon
       latex: false
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       before_deploy: R -q -e 'tic::before_deploy()'
@@ -104,7 +104,7 @@ jobs:
            - libgsl0-dev
            - ghostscript # for mlr-tutorial pdf
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       before_deploy: R -q -e 'tic::before_deploy()'
@@ -125,7 +125,7 @@ jobs:
            - libgsl0-dev
            - ghostscript # for mlr-tutorial pdf
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
+      before_install: R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       before_deploy: R -q -e 'tic::before_deploy()'

--- a/tic.R
+++ b/tic.R
@@ -18,7 +18,7 @@ if (Sys.getenv("RCMDCHECK") == "TRUE") {
     add_step(step_setup_ssh())
 
 get_stage("script") %>%
-    add_code_step(devtools::install_github("r-lib/rcmdcheck")) %>%
+    add_code_step(devtools::install_github("pat-s/rcmdcheck@catch-test-errors")) %>%
     add_code_step(devtools::document()) %>%
     add_step(step_rcmdcheck(notes_are_errors = FALSE))
 

--- a/tic.R
+++ b/tic.R
@@ -18,7 +18,7 @@ if (Sys.getenv("RCMDCHECK") == "TRUE") {
     add_step(step_setup_ssh())
 
 get_stage("script") %>%
-    add_code_step(devtools::install_github("pat-s/rcmdcheck@catch-test-errors")) %>%
+    add_code_step(devtools::install_github("pat-s/rcmdcheck@catch-test-errors")) %>% # FIXME: If this is solved in r-lib/rcmdcheck
     add_code_step(devtools::document()) %>%
     add_step(step_rcmdcheck(notes_are_errors = FALSE))
 


### PR DESCRIPTION
This patched version of `rcmdcheck` finally breaks the build if we have errors in tests at the check stage. 

Also,. using the most recent version of `tic` as this solves deployment errors for the tutorial due to the CRAN update of `git2r`.

fixes #2379 