### PR TITLE
Tut: Fix build and always build tutorial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ jobs:
       before_install: R -q -e 'install.packages("devtools"); devtools::install_github("pat-s/tic@rcmdcheck-build-args"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
+      after_script: R -q -e 'tic::after_script()'
       before_deploy: R -q -e 'tic::before_deploy()'
       deploy:
          provider: script

--- a/tic.R
+++ b/tic.R
@@ -36,10 +36,12 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
     add_code_step(if (length(find.package("pander", quiet = TRUE)) == 0) install.packages("pander")) %>%
     add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
 
-  get_stage("before_deploy") %>%
-    add_step(step_setup_ssh()) %>%
+  get_stage("after_script") %>%
     add_code_step(devtools::document(roclets=c('rd', 'collate', 'namespace'))) %>%
     add_step(step_build_pkgdown())
+
+  get_stage("before_deploy") %>%
+    add_step(step_setup_ssh())
 
   get_stage("deploy") %>%
     add_step(step_push_deploy(orphan = TRUE, path = "docs", branch = "gh-pages"))

--- a/tic.R
+++ b/tic.R
@@ -37,10 +37,10 @@ if (Sys.getenv("TUTORIAL") == "HTML") {
     add_code_step(devtools::install_deps(upgrade = TRUE, dependencies = TRUE))
 
   get_stage("before_deploy") %>%
-    add_step(step_setup_ssh())
+    add_step(step_setup_ssh()) %>%
+    add_code_step(devtools::document(roclets=c('rd', 'collate', 'namespace'))) %>%
+    add_step(step_build_pkgdown())
 
   get_stage("deploy") %>%
-    add_code_step(devtools::document(roclets=c('rd', 'collate', 'namespace'))) %>%
-    add_step(step_build_pkgdown()) %>%
     add_step(step_push_deploy(orphan = TRUE, path = "docs", branch = "gh-pages"))
 }

--- a/vignettes/handling_of_spatial_data.Rmd
+++ b/vignettes/handling_of_spatial_data.Rmd
@@ -116,7 +116,7 @@ mean(out$measures.test$auc)
 
 The introduced bias (caused by spatial autocorrelation) in performance in this example is around 0.12 AUROC. 
 
-### Visualization of spatial partitions
+# Visualization of spatial partitions
  
 You can visualize the spatial partitioning using `createSpatialResamplingPlots()`.
 This function creates multiple `ggplot2` objects that can then be visualized in a gridded way using your favorite "plot arrangement" function 
@@ -132,9 +132,9 @@ If you do not like the plot appearance, you can customize all plots stored in th
 library(mlr)
 library(cowplot)
  
-rdesc1 = makeResampleDesc("SpCV", folds = 5, reps = 4)
+rdesc1 = makeResampleDesc("SpRepCV", folds = 5, reps = 4)
 r1 = resample(makeLearner("classif.qda"), spatial.task, rdesc1, show.info = FALSE)
-rdesc2 = makeResampleDesc("CV", folds = 5, reps = 4)
+rdesc2 = makeResampleDesc("RepCV", folds = 5, reps = 4)
 r2 = resample(makeLearner("classif.qda"), spatial.task, rdesc2, show.info = FALSE)
  
 plots = createSpatialResamplingPlots(spatial.task,
@@ -144,7 +144,7 @@ plot_grid(plotlist = plots[["Plots"]], ncol = 5, nrow = 2,
   labels = plots[["Labels"]], label_size = 8)
 ```
  
-### Notes
+# Notes
  
 * Some models are more affected by spatial autocorrelation than others. 
 In general, it can be said that the more flexible a model is, the more it will profit from underlying spatial autocorrelation.


### PR DESCRIPTION
Because the tutorial is only build for `master` commits and nothing else, I did not catch the current Travis error in the last PR.

I modified the setup so that now we always build the tutorial in the "after_script" stage and only the deployment is conditioned on commits to the `master' branch.

With this, we catch potential errors introduced by tutorial PRs.