### PR TITLE
Tut: links fixed

### DIFF
--- a/vignettes/example_tasks.Rmd
+++ b/vignettes/example_tasks.Rmd
@@ -11,7 +11,7 @@ vignette: >
 library("mlr")
 library("BBmisc")
 library("ParamHelpers")
-urlMlrFunctions = "http://rpackages.ianhowson.com/cran/mlr/man/"
+urlMlrFunctions = "https://mlr-org.github.io/mlr/reference/"
 ext = ".html"
 library("pander")
 

--- a/vignettes/measures.Rmd
+++ b/vignettes/measures.Rmd
@@ -11,7 +11,7 @@ vignette: >
 library("mlr")
 library("BBmisc")
 library("ParamHelpers")
-urlMlrFunctions = "http://www.rdocumentation.org/packages/mlr/functions/"
+urlMlrFunctions = "https://mlr-org.github.io/mlr/reference/"
 ext = ".html"
 library("pander")
 


### PR DESCRIPTION
1. A broken link fixed.
2. A link changed to a more appropriate one which points to the function reference of the  `mlr` tutorial (which is usually more up to date) and no to an external website (www.rdocumentation.org).
