### PR TITLE
Robustify travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ jobs:
         - git push
         - "[ $TRAVIS_PULL_REQUEST == \"false\" -a $TRAVIS_BRANCH == \"master\" ] && curl -s -X POST -H \"Content-Type:application/json\" -H \"Accept:application/json\" -H \"Travis-API-Version:3\" -H \"Authorization:token $TT\" -d \"{\\\"request\\\":{\\\"branch\\\":\\\"gh-pages\\\", \\\"message\\\":\\\"commit $TRAVIS_COMMIT $TRAVIS_COMMIT_MSG\\\"}}\" https://api.travis-ci.org/repo/mlr-org%2Fmlr-tutorial/requests"
       before_cache: rm -rf $HOME/R/Library/00LOCK-*
+
     - stage: Tutorial
       env: TUTORIAL=HTML
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
       before_install: R -q -e 'install.packages("devtools"); devtools::install_github("pat-s/tic@rcmdcheck-build-args"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script: true
+      before_cache: rm -rf $HOME/R/Library/00LOCK-*
     - stage: check
       env: RCMDCHECK=TRUE
       addons:
@@ -64,7 +65,7 @@ jobs:
         - git commit man DESCRIPTION NAMESPACE NEWS -m "update auto-generated documentation [ci skip]" || true
         - git push
         - "[ $TRAVIS_PULL_REQUEST == \"false\" -a $TRAVIS_BRANCH == \"master\" ] && curl -s -X POST -H \"Content-Type:application/json\" -H \"Accept:application/json\" -H \"Travis-API-Version:3\" -H \"Authorization:token $TT\" -d \"{\\\"request\\\":{\\\"branch\\\":\\\"gh-pages\\\", \\\"message\\\":\\\"commit $TRAVIS_COMMIT $TRAVIS_COMMIT_MSG\\\"}}\" https://api.travis-ci.org/repo/mlr-org%2Fmlr-tutorial/requests"
-
+      before_cache: rm -rf $HOME/R/Library/00LOCK-*
     - stage: Tutorial
       env: TUTORIAL=HTML
       addons:

--- a/tic.R
+++ b/tic.R
@@ -5,6 +5,7 @@ if (Sys.getenv("RCMDCHECK") == "TRUE") {
   get_stage("install") %>%
     add_code_step(if (length(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()]) > 0)
       install.packages(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()])) %>%
+    add_code_step(devtools::update_packages(TRUE)) %>%
     add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
                                            "-install-package", "thirdparty/XMeans1.0.4.zip"))) %>%
     add_code_step(devtools::install_github("pat-s/rcmdcheck@build-args")) %>% # FIXME: If this is solved in r-lib/rcmdcheck


### PR DESCRIPTION
* Make sure that lock files will not get cached which can break future builds 
* Make sure that all packages are updated by explicitly calling `update_packages`.   Otherwise only packages in the current depencency graph are updated, neglecting those in the suggests of packages mlr depends on.