### PR TITLE
Fix Partial Dependence Plots for Numerical Targets

### DIFF
--- a/R/generatePartialDependence.R
+++ b/R/generatePartialDependence.R
@@ -103,7 +103,7 @@
 #' pd = generatePartialDependenceData(fit, iris.task, "Petal.Width")
 #' plotPartialDependence(pd, data = getTaskData(iris.task))
 #' @export
-generatePartialDependenceData = function(obj, input, features,
+generatePartialDependenceData = function(obj, input, features = NULL,
   interaction = FALSE, derivative = FALSE, individual = FALSE,
   fun = mean, bounds = c(qnorm(.025), qnorm(.975)),
   uniform = TRUE, n = c(10, NA), ...) {
@@ -129,10 +129,11 @@ generatePartialDependenceData = function(obj, input, features,
   if (is.na(n[2]))
     n[2] = nrow(data)
 
-  if (missing(features))
+  if (is.null(features)) {
     features = colnames(data)[!colnames(data) %in% td$target]
-  else
+  } else {
     assertSubset(features, obj$features)
+  }
 
   assertFlag(interaction)
   assertFlag(derivative)
@@ -146,8 +147,9 @@ generatePartialDependenceData = function(obj, input, features,
   se = Function = Class = patterns = NULL # nolint
 
   assertFlag(individual)
-  if (individual)
+  if (individual) {
     fun = identity
+  }
 
   assertFunction(fun)
   test.fun = fun(1:3)
@@ -165,19 +167,21 @@ generatePartialDependenceData = function(obj, input, features,
   assertFlag(uniform)
   assertCount(n[1], positive = TRUE)
   assertCount(n[2], positive = TRUE)
-  if (n[2] > nrow(data))
+  if (n[2] > nrow(data)) {
     stop("The number of points taken from the training data cannot exceed the number of training data points.")
+  }
 
   if (td$type == "regr")
     target = td$target
   else if (td$type == "classif") {
-    if (length(td$class.levels) > 2L)
+    if (length(td$class.levels) > 2L) {
       target = td$class.levels
-    else
+    } else {
       target = td$positive
-  } else
+    }
+  } else {
     target = "Risk"
-
+  }
   if (!derivative) {
     args = list(model = obj, data = data, uniform = uniform, aggregate.fun = fun,
       predict.fun = getPrediction, n = n, ...)
@@ -279,6 +283,10 @@ generatePartialDependenceData = function(obj, input, features,
     target = c("lower", target, "upper")
     setcolorder(out, c(target, features))
   }
+
+  colnames(out) = make.names(colnames(out))
+  features = make.names(features)
+  target = make.names(features)
 
   makeS3Obj("PartialDependenceData",
     data = out,


### PR DESCRIPTION
What was the problem?

Issue #2405 
`generatePartialDependenceData` created da date.frame with numeric colnames e.g. `0`. This got interpreted by `aes_string` directly as the number and not the column.

Solution

Sanitize names.

What could be another solution?

Avoid numeric colnames in the beginning

Why did I not do this?

Would take some more time to go through the code.

What is missing?

Tests, although I am not sure how to test it most efficiently.