### PR TITLE
fixed ibrier measure

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -1429,8 +1429,10 @@ ibrier = makeMeasure(id = "ibrier", minimize = TRUE, best = 0, worst = 1,
 
     probs = predictSurvProb(getLearnerModel(model, more.unwrap = TRUE), newdata = newdata, times = grid)
     perror = pec(probs, f, data = newdata[, tn], times = grid, exact = FALSE, exactness = 99L,
-      maxtime = max.time, verbose = FALSE, reference = F)
+      maxtime = max.time, verbose = FALSE, reference = FALSE)
+    
 
+    # FIXME: this might be the wrong number!
     crps(perror, times = max.time)[1L, ]
   },
   extra.args = list(max.time = NULL, resolution = 1000L)

--- a/R/measures.R
+++ b/R/measures.R
@@ -1429,10 +1429,8 @@ ibrier = makeMeasure(id = "ibrier", minimize = TRUE, best = 0, worst = 1,
 
     probs = predictSurvProb(getLearnerModel(model, more.unwrap = TRUE), newdata = newdata, times = grid)
     perror = pec(probs, f, data = newdata[, tn], times = grid, exact = FALSE, exactness = 99L,
-      maxtime = max.time, verbose = FALSE)
+      maxtime = max.time, verbose = FALSE, reference = F)
 
-    # FIXME: what is the difference between reference and matrix?
-    # FIXME: this might be the wrong number!
     crps(perror, times = max.time)[1L, ]
   },
   extra.args = list(max.time = NULL, resolution = 1000L)


### PR DESCRIPTION
Reference is a kaplan-meier curve model used to benchmark model performance against (since it uses no covariates). Matrix is the model performance measure. By adding "reference = F" in the pec call, I've removed the reference calculation thus speeding the code and fixing the problem of using reference instead of the fitted model error term.