### PR TITLE
Add inline ToC to vignettes

### DIFF
--- a/pkgdown/templates/content-article.html
+++ b/pkgdown/templates/content-article.html
@@ -28,6 +28,13 @@ $endfor$
       <h4 class="date">$date$</h4>
       $endif$
 
+      $if(toc)$
+      <div id="toc">
+      <h3>Table of Contents</h3>
+      $toc$
+      </div>
+      $endif$
+
       {{#source}}<small>{{{.}}}</small>{{/source}}
 
     </div>

--- a/pkgdown/templates/content-article.html
+++ b/pkgdown/templates/content-article.html
@@ -28,6 +28,7 @@ $endfor$
       <h4 class="date">$date$</h4>
       $endif$
 
+      <!--The 'toc' block was inserted manually by @pat-s. It triggeres the inline ToC in the vignettes.-->
       $if(toc)$
       <div id="toc">
       <h3>Table of Contents</h3>


### PR DESCRIPTION
Because the navbar ToC is really messy for long vignettes.

See the netlify preview for a preview (once it has been deployed).

Also template `content-vignette.html` now needs to be `content-article.html`.