### PR TITLE
Update Merging surv-prop-FailureModels

### DIFF
--- a/R/ResamplePrediction.R
+++ b/R/ResamplePrediction.R
@@ -22,8 +22,8 @@ makeResamplePrediction = function(instance, preds.test, preds.train, task.desc) 
   if (any(trnull)) pr.tr = preds.train[!trnull] else pr.tr = preds.train
 
   data = setDF(rbind(
-    rbindlist(lapply(seq_along(pr.te), function(X) cbind(pr.te[[X]]$data, iter = X, set = "test"))),
-    rbindlist(lapply(seq_along(pr.tr), function(X) cbind(pr.tr[[X]]$data, iter = X, set = "train")))
+    rbindlist(lapply(seq_along(pr.te), function(X) cbind(pr.te[[X]]$data, iter = X, set = "test")), fill = TRUE),
+    rbindlist(lapply(seq_along(pr.tr), function(X) cbind(pr.tr[[X]]$data, iter = X, set = "train")), fill = TRUE)
   ))
 
   if (!any(tenull) && instance$desc$predict %in% c("test", "both")) {


### PR DESCRIPTION
If survival models with predict.type = "prob" lead to an error in a benchmark iteration, merging them with successful iteration raised an error. prob-data.frames differed in dim().
