### PR TITLE
Remove _R_CHECK_FORCE_SUGGESTS_ from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ latex: true
 env:
   global:
     - _R_CHECK_TIMINGS_=0
-    - _R_CHECK_FORCE_SUGGESTS_=0  # no error if suggested packs are not avail
+    #- _R_CHECK_FORCE_SUGGESTS_=0  # no error if suggested packs are not avail
     - _R_CHECK_TESTS_NLINES_=999
     - secure: "d0xff7hriQyReF4y3/iR5sHJlXocKNKcN6/Gi/r9Hxsfuh2Hx3fouQCMSPP+Oba6MDgEvAfryToAxcmaoZByQMwgevB0OBy5xkatj3oTHmhN5Nbk3jNXxXfA6P0Oqxaf7lXVZk2+Ly+PWnbgXn0uhjzdaZo0cWtVJ660ajS0x9Q="
     - WARMUPPKGS='roxygen2 pander mlrMBO purrr cowplot sf mlbench mldr RWeka RWekajars knitr dplyr ggplot2 ranger randomForest kernlab igraph rjson rmarkdown xgboost xml2 ggpubr FSelectorRcpp praznik'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ latex: true
 env:
   global:
     - _R_CHECK_TIMINGS_=0
-    #- _R_CHECK_FORCE_SUGGESTS_=0  # no error if suggested packs are not avail
     - _R_CHECK_TESTS_NLINES_=999
     - secure: "d0xff7hriQyReF4y3/iR5sHJlXocKNKcN6/Gi/r9Hxsfuh2Hx3fouQCMSPP+Oba6MDgEvAfryToAxcmaoZByQMwgevB0OBy5xkatj3oTHmhN5Nbk3jNXxXfA6P0Oqxaf7lXVZk2+Ly+PWnbgXn0uhjzdaZo0cWtVJ660ajS0x9Q="
     - WARMUPPKGS='roxygen2 pander mlrMBO purrr cowplot sf mlbench mldr RWeka RWekajars knitr dplyr ggplot2 ranger randomForest kernlab igraph rjson rmarkdown xgboost xml2 ggpubr FSelectorRcpp praznik'
@@ -26,7 +25,7 @@ jobs:
            - libudunits2-dev # for sf
       before_install:
         - R -q -e 'install.packages("BiocManager"); BiocManager::install("genefilter")'
-        - R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes"); if (!requireNamespace("curl")) install.packages("curl"); remotes::install_github("ropenscilabs/tic@test"); tic::prepare_all_stages(); tic::before_install()'
+        - R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes"); if (!requireNamespace("curl")) install.packages("curl"); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
       install: R -q -e 'tic::install()'
       script: true
       after_script: R -q -e 'tic::after_script()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ jobs:
            - libproj-dev # for sf
            - libgeos-dev # for sf
            - libudunits2-dev # for sf
-      before_install: R -q -e 'if (!requireNamespace("devtools")) install.packages("devtools"); if (!requireNamespace("curl")) install.packages("curl"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
+      before_install:
+        - R -q -e 'install.packages("BiocManager"); BiocManager::install("genefilter")'
+        - R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes"); if (!requireNamespace("curl")) install.packages("curl"); remotes::install_github("ropenscilabs/tic@test"); tic::prepare_all_stages(); tic::before_install()'
       install: R -q -e 'tic::install()'
       script: true
       after_script: R -q -e 'tic::after_script()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,9 @@ jobs:
            - libudunits2-dev # for sf
       latex: false
       pandoc_version: 2.2.1
-      before_install: R -q -e 'install.packages("remotes"); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+      before_install:
+        - R -q -e 'if (!requireNamespace("BiocManager")) install.packages("BiocManager"); if (!requireNamespace("genefilter")) BiocManager::install("genefilter")'
+        - R -q -e 'install.packages("remotes"); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
       install: R -q -e 'tic::install()'
       script:  R -q -e 'tic::script()'
       after_script: R -q -e 'tic::after_script()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
            - libgeos-dev # for sf
            - libudunits2-dev # for sf
       before_install:
-        - R -q -e 'install.packages("BiocManager"); BiocManager::install("genefilter")'
+        - R -q -e 'if (!requireNamespace("BiocManager")) install.packages("BiocManager"); if (!requireNamespace("genefilter")) BiocManager::install("genefilter")'
         - R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes"); if (!requireNamespace("curl")) install.packages("curl"); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
       install: R -q -e 'tic::install()'
       script: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
            - libproj-dev # for sf
            - libgeos-dev # for sf
            - libudunits2-dev # for sf
-      before_install: R -q -e 'if (!requireNamespace("devtools")) install.packages("devtools"); if (!requireNamespace("curl")) install.packages("curl"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
+      before_install: R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes"); if (!requireNamespace("curl")) install.packages("curl"); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
       warnings_are_errors: false
       before_script: R -q -e 'tic::before_script()'
       script: R -q -e 'tic::script()'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ install:
   - cmd: rm -rf C:\RLibrary\00LOCK-*
   - cmd: R -q -e "if (!requireNamespace('remotes')) install.packages('remotes')"
   - cmd: R -q -e "if (!requireNamespace('curl')) install.packages('curl')"
+  - cmd: R -q -e 'if (!requireNamespace("BiocManager")) install.packages("BiocManager")'
+  - cmd: R -q -e 'if (!requireNamespace("genefilter")) BiocManager::install("genefilter")'
   - cmd: R -q -e "remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ install:
   - cmd: R -q -e "writeLines('options(repos = \'https://cloud.r-project.org\')', '~/.Rprofile')"
   - cmd: R -q -e "getOption('repos')"
   - cmd: rm -rf C:\RLibrary\00LOCK-*
-  - cmd: R -q -e "if (!requireNamespace('devtools')) install.packages('devtools')"
+  - cmd: R -q -e "if (!requireNamespace('devtools')) install.packages('remotes')"
   - cmd: R -q -e "if (!requireNamespace('curl')) install.packages('curl')"
-  - cmd: R -q -e "devtools::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
+  - cmd: R -q -e "remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
 
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ install:
   - cmd: rm -rf C:\RLibrary\00LOCK-*
   - cmd: R -q -e "if (!requireNamespace('remotes')) install.packages('remotes')"
   - cmd: R -q -e "if (!requireNamespace('curl')) install.packages('curl')"
-  - cmd: R -q -e 'if (!requireNamespace("BiocManager")) install.packages("BiocManager")'
-  - cmd: R -q -e 'if (!requireNamespace("genefilter")) BiocManager::install("genefilter")'
+  - cmd: R -q -e "if (!requireNamespace('BiocManager')) install.packages('BiocManager')"
+  - cmd: R -q -e "if (!requireNamespace('genefilter')) BiocManager::install('genefilter')"
   - cmd: R -q -e "remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - cmd: R -q -e "writeLines('options(repos = \'https://cloud.r-project.org\')', '~/.Rprofile')"
   - cmd: R -q -e "getOption('repos')"
   - cmd: rm -rf C:\RLibrary\00LOCK-*
-  - cmd: R -q -e "if (!requireNamespace('devtools')) install.packages('remotes')"
+  - cmd: R -q -e "if (!requireNamespace('remotes')) install.packages('remotes')"
   - cmd: R -q -e "if (!requireNamespace('curl')) install.packages('curl')"
   - cmd: R -q -e "remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
 

--- a/tic.R
+++ b/tic.R
@@ -15,7 +15,7 @@ if (Sys.getenv("RCMDCHECK") == "TRUE") {
       install.packages(trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]])[!trimws(strsplit(Sys.getenv("WARMUPPKGS"), " ")[[1]]) %in% installed.packages()])
     }
     ) %>%
-    add_code_step(devtools::update_packages(TRUE))
+    add_code_step(remotes::update_packages(TRUE))
 
   if (inherits(ci(), "TravisCI")) {
     get_stage("before_script") %>%


### PR DESCRIPTION
- This caused the recent build errors.
It does not play well with the new _remotes_ v2.0.0 update. https://github.com/r-lib/remotes/issues/238

- Also a dep pkg (idk which one) now seems to depend on a Bioconductor pkg. To install all deps withour an error, we need to install _genefilter_ by hand.


- all the install* functions from `devtools` got moved to `remotes`. Applying that change.
