### PR TITLE
fix test_regr_laGP.R

### DIFF
--- a/tests/testthat/test_regr_laGP.R
+++ b/tests/testthat/test_regr_laGP.R
@@ -5,7 +5,7 @@ test_that("regr_laGP", {
 
   parset.list = list(
     list(),
-    list(start = 6, end = 50, close = 50)
+    list(start = 6, end = 49, close = 50)
   )
   dd = regr.num.df[1:100, ]
   old.predicts.list = list()


### PR DESCRIPTION
fixes #2503 

arg `end` must be < than arg `close` in the new version (https://cran.r-project.org/web/packages/laGP/ChangeLog)