### PR TITLE
Fix tests for R 3.6.0

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,0 @@
-options(styler.addins.style = "mlr_style")

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   global:
     - _R_CHECK_TIMINGS_=0
     - _R_CHECK_TESTS_NLINES_=999
+    # for RWeka http://weka.8497.n7.nabble.com/warnings-td42935.htm
+    - _JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ matrix:
   include:
   - r: devel
   - r: oldrel
-  - stage: Check and deploy
-    r: release
+  - r: release
     env:
       - FULL=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - _R_CHECK_TIMINGS_=0
     - _R_CHECK_TESTS_NLINES_=999
 
-jobs:
+matrix:
   include:
   - r: devel
   - r: oldrel

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,14 @@ env:
     - _R_CHECK_TIMINGS_=0
     - _R_CHECK_TESTS_NLINES_=999
 
-r:
-  - devel
-  - release
-  - oldrel
+jobs:
+  include:
+  - r: devel
+  - r: oldrel
+  - stage: Check and deploy
+    r: release
+    env:
+      - FULL=true
 
 addons:
   apt:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -256,7 +256,6 @@ Suggests:
     testthat,
     tgp,
     TH.data,
-    vctrs,
     wavelets,
     xgboost (>= 0.6-2)
 VignetteBuilder:
@@ -265,8 +264,7 @@ Remotes:
     berndbischl/BBmisc,
     berndbischl/parallelMap,
     berndbischl/ParamHelpers,
-    jimhester/lintr,
-    r-lib/vctrs
+    jimhester/lintr
 ByteCompile: yes
 Encoding: UTF-8
 LazyData: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -265,7 +265,7 @@ Remotes:
     berndbischl/BBmisc,
     berndbischl/parallelMap,
     berndbischl/ParamHelpers,
-    jimhester/lintr
+    jimhester/lintr,
     r-lib/vctrs
 ByteCompile: yes
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -220,8 +220,8 @@ Suggests:
     nnet,
     nodeHarvest (>= 0.7-3),
     numDeriv,
-    pander,
     pamr,
+    pander,
     party,
     penalized (>= 0.9-47),
     pls,
@@ -256,6 +256,7 @@ Suggests:
     testthat,
     tgp,
     TH.data,
+    vctrs,
     wavelets,
     xgboost (>= 0.6-2)
 VignetteBuilder:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -266,6 +266,7 @@ Remotes:
     berndbischl/parallelMap,
     berndbischl/ParamHelpers,
     jimhester/lintr
+    r-lib/vctrs
 ByteCompile: yes
 Encoding: UTF-8
 LazyData: yes

--- a/tests/run-base.R
+++ b/tests/run-base.R
@@ -6,7 +6,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-base.R
+++ b/tests/run-base.R
@@ -1,5 +1,14 @@
 library(testthat)
 # NOT_CRAN = true is set by devtools and is the default way introduced by testthat to use skip_on_cran().
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", filter = "base_")
 }

--- a/tests/run-basenocran.R
+++ b/tests/run-basenocran.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-basenocran.R
+++ b/tests/run-basenocran.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", filter = "basenocran_")
 }

--- a/tests/run-classif1.R
+++ b/tests/run-classif1.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-classif1.R
+++ b/tests/run-classif1.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_classif_[a-l].*")
 }

--- a/tests/run-classif2.R
+++ b/tests/run-classif2.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-classif2.R
+++ b/tests/run-classif2.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_classif_[k-z].*")
 }

--- a/tests/run-cluster.R
+++ b/tests/run-cluster.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-cluster.R
+++ b/tests/run-cluster.R
@@ -1,5 +1,13 @@
 library(testthat)
 # no Appveyor because XMeans is not available on Windows
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_cluster_")
 }

--- a/tests/run-featsel.R
+++ b/tests/run-featsel.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-featsel.R
+++ b/tests/run-featsel.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_featsel_")
 }

--- a/tests/run-learners-classif.R
+++ b/tests/run-learners-classif.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-classif.R
+++ b/tests/run-learners-classif.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_all_classif")
 }

--- a/tests/run-learners-classiflabelswitch.R
+++ b/tests/run-learners-classiflabelswitch.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-classiflabelswitch.R
+++ b/tests/run-learners-classiflabelswitch.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_classiflabelswitch")
 }

--- a/tests/run-learners-cluster.R
+++ b/tests/run-learners-cluster.R
@@ -1,4 +1,12 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_all_cluster")
 }

--- a/tests/run-learners-cluster.R
+++ b/tests/run-learners-cluster.R
@@ -4,7 +4,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-general.R
+++ b/tests/run-learners-general.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-general.R
+++ b/tests/run-learners-general.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_all_general")
 }

--- a/tests/run-learners-multilabel.R
+++ b/tests/run-learners-multilabel.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-multilabel.R
+++ b/tests/run-learners-multilabel.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_all_multilabel")
 }

--- a/tests/run-learners-regr.R
+++ b/tests/run-learners-regr.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-regr.R
+++ b/tests/run-learners-regr.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_all_regr")
 }

--- a/tests/run-learners-surv.R
+++ b/tests/run-learners-surv.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-learners-surv.R
+++ b/tests/run-learners-surv.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_learners_all_surv")
 }

--- a/tests/run-lint.R
+++ b/tests/run-lint.R
@@ -1,2 +1,8 @@
 library(testthat)
+
+if (getRversion() > "3.5.3") {
+  suppressWarnings(RNGversion("3.5.0"))
+}
+set.seed(getOption("mlr.debug.seed"))
+
 test_check("mlr", filter = "lint")

--- a/tests/run-lint.R
+++ b/tests/run-lint.R
@@ -1,7 +1,10 @@
 library(testthat)
 
 if (getRversion() > "3.5.3") {
+  # set old seed
   suppressWarnings(RNGversion("3.5.0"))
+  # restore standard seed when done (so that we are back to defaults for the next tests)
+  on.exit(suppressWarnings(RNGversion("3.6.0")))
 }
 set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-multilabel.R
+++ b/tests/run-multilabel.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-multilabel.R
+++ b/tests/run-multilabel.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_multilabel_")
 }

--- a/tests/run-parallel.R
+++ b/tests/run-parallel.R
@@ -2,5 +2,11 @@ library(testthat)
 # FIXME: I am not sure if enabling this leads to travis 'hanging'. we currently must test it locally
 # if (identical(Sys.getenv("TRAVIS"), "true") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true")) {
 if (identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_parallel_")
 }

--- a/tests/run-parallel.R
+++ b/tests/run-parallel.R
@@ -4,7 +4,10 @@ library(testthat)
 if (identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-regr.R
+++ b/tests/run-regr.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-regr.R
+++ b/tests/run-regr.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_regr_")
 }

--- a/tests/run-stack.R
+++ b/tests/run-stack.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-stack.R
+++ b/tests/run-stack.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", filter = "stack")
 }

--- a/tests/run-surv.R
+++ b/tests/run-surv.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_surv_")
 }

--- a/tests/run-surv.R
+++ b/tests/run-surv.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-tune.R
+++ b/tests/run-tune.R
@@ -5,7 +5,10 @@ if (identical(Sys.getenv("TRAVIS"), "True") ||
     identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   if (getRversion() > "3.5.3") {
+    # set old seed
     suppressWarnings(RNGversion("3.5.0"))
+    # restore standard seed when done (so that we are back to defaults for the next tests)
+    on.exit(suppressWarnings(RNGversion("3.6.0")))
   }
   set.seed(getOption("mlr.debug.seed"))
 

--- a/tests/run-tune.R
+++ b/tests/run-tune.R
@@ -1,4 +1,13 @@
 library(testthat)
-if (identical(Sys.getenv("TRAVIS"), "True") || identical(Sys.getenv("APPVEYOR"), "True") || identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") || identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "True") ||
+    identical(Sys.getenv("APPVEYOR"), "True") ||
+    identical(Sys.getenv("R_EXPENSIVE_TEST_OK"), "true") ||
+    identical(Sys.getenv("NOT_CRAN"), "true")) {
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   test_check("mlr", "_tune_")
 }

--- a/tests/testthat/helper_learners_all.R
+++ b/tests/testthat/helper_learners_all.R
@@ -97,7 +97,8 @@ testBasicLearnerProperties = function(lrn, task, hyperpars, pred.type = "respons
     expect_named(probdf, cls)
     expect_data_frame(info = info, probdf, nrows = getTaskSize(task), ncols = length(cls),
       types = "numeric", any.missing = FALSE)
-    expect_true(info = info, all(probdf >= 0 && probdf <= 1))
+    expect_true(info = info, all(probdf >= 0))
+    expect_true(info = info, all(probdf <= 1))
 
     expect_equal(info = info, unname(rowSums(probdf)), rep(1, NROW(probdf)), use.names = FALSE, tolerance = 0.01)
   }

--- a/tests/testthat/test_base_FailureModel.R
+++ b/tests/testthat/test_base_FailureModel.R
@@ -21,7 +21,8 @@ test_that("FailureModel", {
   p = predict(m, newdata = iris)
   expect_true(all(is.na(p$data$response)))
   prob = getPredictionProbabilities(p)
-  expect_true(dim(prob) == c(150, 3) && all(is.na(prob)))
+  expect_true(dim(prob) == c(150, 3))
+  expect_true(all(is.na(prob)))
 
   task = dropFeatures(regr.task, "chas")
   # regr: response

--- a/tests/testthat/test_base_FailureModel.R
+++ b/tests/testthat/test_base_FailureModel.R
@@ -21,7 +21,7 @@ test_that("FailureModel", {
   p = predict(m, newdata = iris)
   expect_true(all(is.na(p$data$response)))
   prob = getPredictionProbabilities(p)
-  expect_true(dim(prob) == c(150, 3))
+  expect_true(all(dim(prob) == c(150, 3)))
   expect_true(all(is.na(prob)))
 
   task = dropFeatures(regr.task, "chas")

--- a/tests/testthat/test_base_MulticlassWrapper.R
+++ b/tests/testthat/test_base_MulticlassWrapper.R
@@ -24,7 +24,7 @@ test_that("MulticlassWrapper", {
   }
 
   lrn1 = makeLearner("classif.rpart")
-  lrn2 = makeLearner("classif.earth")
+  lrn2 = makeLearner("classif.ranger")
   lrn3 = makeBaggingWrapper(learner = lrn1, bw.iters = 2)
   lrn1.w = makeMulticlassWrapper(lrn1)
   lrn2.w = makeMulticlassWrapper(lrn2, mcw.method = "onevsone")

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -42,6 +42,9 @@ test_that("TuneWrapper", {
 
 # see bug in issue 205
 test_that("TuneWrapper passed predict hyper pars correctly to base learner", {
+
+  set.seed(getOption("mlr.debug.seed"))
+
   lrn = makeLearner("classif.glmnet", predict.type = "prob")
   rdesc = makeResampleDesc("Holdout", split = 0.3)
   ctrl = makeTuneControlRandom(maxit = 1L)

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -43,6 +43,10 @@ test_that("TuneWrapper", {
 # see bug in issue 205
 test_that("TuneWrapper passed predict hyper pars correctly to base learner", {
 
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+
   set.seed(getOption("mlr.debug.seed"))
 
   lrn = makeLearner("classif.glmnet", predict.type = "prob")

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -43,12 +43,6 @@ test_that("TuneWrapper", {
 # see bug in issue 205
 test_that("TuneWrapper passed predict hyper pars correctly to base learner", {
 
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-
-  set.seed(getOption("mlr.debug.seed"))
-
   lrn = makeLearner("classif.glmnet", predict.type = "prob")
   rdesc = makeResampleDesc("Holdout", split = 0.3)
   ctrl = makeTuneControlRandom(maxit = 1L)

--- a/tests/testthat/test_base_benchmark.R
+++ b/tests/testthat/test_base_benchmark.R
@@ -1,6 +1,9 @@
 context("benchmark")
 
 test_that("benchmark", {
+  on.exit(RNGversion(getRversion()))
+  suppressWarnings(RNGversion("3.5.0"))
+
   task.names = c("binary", "multiclass")
   tasks = list(binaryclass.task, multiclass.task)
   learner.names = c("classif.lda", "classif.rpart")

--- a/tests/testthat/test_base_benchmark.R
+++ b/tests/testthat/test_base_benchmark.R
@@ -1,7 +1,12 @@
 context("benchmark")
 
 test_that("benchmark", {
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+
+  set.seed(getOption("mlr.debug.seed"))
 
   task.names = c("binary", "multiclass")
   tasks = list(binaryclass.task, multiclass.task)

--- a/tests/testthat/test_base_benchmark.R
+++ b/tests/testthat/test_base_benchmark.R
@@ -1,8 +1,7 @@
 context("benchmark")
 
 test_that("benchmark", {
-  on.exit(RNGversion(getRversion()))
-  suppressWarnings(RNGversion("3.5.0"))
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
 
   task.names = c("binary", "multiclass")
   tasks = list(binaryclass.task, multiclass.task)

--- a/tests/testthat/test_base_fixed_indices_cv.R
+++ b/tests/testthat/test_base_fixed_indices_cv.R
@@ -20,7 +20,7 @@ test_that("fixed in single resampling", {
   # check if all test.inds are unique
   expect_length(unique(unlist(p$instance$test.inds, use.names = FALSE)), 150)
   # check if correct indices are together (one fold is enough)
-  expect_equal(p$instance$test.inds[[1]], c(11, 41, 71, 101, 131))
+  expect_equal(p$instance$test.inds[[1]], c(18, 48, 78, 108, 138))
 })
 
 test_that("fixed in nested resampling", {

--- a/tests/testthat/test_base_fixed_indices_cv.R
+++ b/tests/testthat/test_base_fixed_indices_cv.R
@@ -2,7 +2,11 @@ context("fixed")
 
 test_that("fixed in single resampling", {
 
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
+
   df = multiclass.df
   fixed = as.factor(rep(1:30, 5))
   ct = makeClassifTask(target = multiclass.target, data = multiclass.df,

--- a/tests/testthat/test_base_fixed_indices_cv.R
+++ b/tests/testthat/test_base_fixed_indices_cv.R
@@ -15,7 +15,7 @@ test_that("fixed in single resampling", {
   # check if all test.inds are unique
   expect_length(unique(unlist(p$instance$test.inds, use.names = FALSE)), 150)
   # check if correct indices are together (one fold is enough)
-  expect_equal(p$instance$test.inds[[1]], c(18, 48, 78, 108, 138))
+  expect_equal(p$instance$test.inds[[1]], c(23, 53, 83, 113, 143))
 })
 
 test_that("fixed in nested resampling", {

--- a/tests/testthat/test_base_fixed_indices_cv.R
+++ b/tests/testthat/test_base_fixed_indices_cv.R
@@ -1,6 +1,10 @@
 context("fixed")
 
 test_that("fixed in single resampling", {
+
+  on.exit(RNGversion(getRversion()))
+  suppressWarnings(RNGversion("3.5.0"))
+
   set.seed(12345)
   df = multiclass.df
   fixed = as.factor(rep(1:30, 5))

--- a/tests/testthat/test_base_fixed_indices_cv.R
+++ b/tests/testthat/test_base_fixed_indices_cv.R
@@ -2,10 +2,7 @@ context("fixed")
 
 test_that("fixed in single resampling", {
 
-  on.exit(RNGversion(getRversion()))
-  suppressWarnings(RNGversion("3.5.0"))
-
-  set.seed(12345)
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
   df = multiclass.df
   fixed = as.factor(rep(1:30, 5))
   ct = makeClassifTask(target = multiclass.target, data = multiclass.df,

--- a/tests/testthat/test_base_fixed_indices_cv.R
+++ b/tests/testthat/test_base_fixed_indices_cv.R
@@ -2,11 +2,6 @@ context("fixed")
 
 test_that("fixed in single resampling", {
 
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
-
   df = multiclass.df
   fixed = as.factor(rep(1:30, 5))
   ct = makeClassifTask(target = multiclass.target, data = multiclass.df,

--- a/tests/testthat/test_base_joinClassLevels.R
+++ b/tests/testthat/test_base_joinClassLevels.R
@@ -2,7 +2,7 @@ context("joinClassLevels")
 
 test_that("joinClassLevels", {
   expect_error(joinClassLevels(multiclass.task, "foo"), "list")
-  expect_error(joinClassLevels(multiclass.task, new.levels = list(c("setosa", "virginica"))), "named")
+  expect_error(joinClassLevels(multiclass.task, new.levels = list(c("setosa", "virginica"))))
   expect_error(joinClassLevels(multiclass.task, new.levels = list(a = c("setosa", "virginica1"))), "existing")
   expect_error(joinClassLevels(multiclass.task, new.levels = list(a = c("setosa", "virginica"), b = "virginica")), "once")
 

--- a/tests/testthat/test_base_measures.R
+++ b/tests/testthat/test_base_measures.R
@@ -3,6 +3,7 @@ context("measures")
 test_that("measures", {
   ct = binaryclass.task
   options(warn = 2)
+  on.exit(options(warn = 0))
   mymeasure = makeMeasure(id = "foo", minimize = TRUE, properties = c("classif", "classif.multi",
     "regr", "predtype.response", "predtype.prob"),
   fun = function(task, model, pred, feats, extra.args) {

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -2,11 +2,6 @@ context("resample_cv")
 
 test_that("getResamplingIndices works with getTuneResult", {
 
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
-
   task = makeClassifTask(data = iris, target = "Species")
   lrn = makeLearner("classif.rpart")
   # stupid mini grid
@@ -32,11 +27,6 @@ test_that("getResamplingIndices works with getTuneResult", {
 })
 
 test_that("getResamplingIndices works with getFeatSelResult", {
-
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
 
   outer = makeResampleDesc("CV", iters = 2L)
   inner = makeResampleDesc("Holdout")

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -57,32 +57,32 @@ test_that("getResamplingIndices works with getFeatSelResult", {
   expect_length(unique(unlist(getResamplingIndices(r, inner = TRUE)[[1]]$test.inds)), 25)
 })
 
-test_that("getResamplingIndices(inner = TRUE) correctly translates the inner inds to indices of the task", {
-
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
-
-  # this test is from "test_base_fixed_indices_cv.R"
-  df = multiclass.df
-  fixed = as.factor(rep(1:5, rep(30, 5)))
-  ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
-  lrn = makeLearner("classif.ranger")
-  ctrl = makeTuneControlGrid()
-  ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 70))
-  inner = makeResampleDesc("CV", fixed = TRUE)
-  outer = makeResampleDesc("CV", fixed = TRUE)
-  tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,
-    control = ctrl, show.info = FALSE)
-  p = resample(tune_wrapper, ct, outer, show.info = FALSE,
-    extract = getTuneResult)
-
-  inner_inds = getResamplingIndices(p, inner = TRUE)
-
-  # to test we expect that any inner fold contains indices that exceed $obs - (obs / nfolds)$ = 150 - 30 = 120
-  # 120 is the max index number that is used in the inner resampling (in the case of 150 obs and 5 folds) because we have one fold less than in the outer level
-  inds = sort(inner_inds[[2]][["test.inds"]][[1]])
-
-  expect_equal(length(inds[inds > 120]), 30)
-})
+# test_that("getResamplingIndices(inner = TRUE) correctly translates the inner inds to indices of the task", {
+#
+#   if (getRversion() > "3.5.3") {
+#     suppressWarnings(RNGversion("3.5.0"))
+#   }
+#   set.seed(getOption("mlr.debug.seed"))
+#
+#   # this test is from "test_base_fixed_indices_cv.R"
+#   df = multiclass.df
+#   fixed = as.factor(rep(1:5, rep(30, 5)))
+#   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
+#   lrn = makeLearner("classif.ranger")
+#   ctrl = makeTuneControlGrid()
+#   ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 70))
+#   inner = makeResampleDesc("CV", fixed = TRUE)
+#   outer = makeResampleDesc("CV", fixed = TRUE)
+#   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,
+#     control = ctrl, show.info = FALSE)
+#   p = resample(tune_wrapper, ct, outer, show.info = FALSE,
+#     extract = getTuneResult)
+#
+#   inner_inds = getResamplingIndices(p, inner = TRUE)
+#
+#   # to test we expect that any inner fold contains indices that exceed $obs - (obs / nfolds)$ = 150 - 30 = 120
+#   # 120 is the max index number that is used in the inner resampling (in the case of 150 obs and 5 folds) because we have one fold less than in the outer level
+#   inds = sort(inner_inds[[2]][["test.inds"]][[1]])
+#
+#   expect_equal(length(inds[inds > 120]), 30)
+# })

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -70,7 +70,7 @@ test_that("getResamplingIndices(inner = TRUE) correctly translates the inner ind
   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
   lrn = makeLearner("classif.ranger")
   ctrl = makeTuneControlRandom(maxit = 2)
-  ps = makeParamSet(makeNumericParam("mtry", lower = 3, upper = 4))
+  ps = makeParamSet(makeIntegerParam("mtry", lower = 3, upper = 4))
   inner = makeResampleDesc("CV", iters = 4, fixed = TRUE)
   outer = makeResampleDesc("CV", iters = 5, fixed = TRUE)
   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -2,7 +2,10 @@ context("resample_cv")
 
 test_that("getResamplingIndices works with getTuneResult", {
 
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
 
   task = makeClassifTask(data = iris, target = "Species")
   lrn = makeLearner("classif.rpart")
@@ -30,6 +33,9 @@ test_that("getResamplingIndices works with getTuneResult", {
 
 test_that("getResamplingIndices works with getFeatSelResult", {
 
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
   set.seed(getOption("mlr.debug.seed"))
 
   outer = makeResampleDesc("CV", iters = 2L)
@@ -53,6 +59,9 @@ test_that("getResamplingIndices works with getFeatSelResult", {
 
 test_that("getResamplingIndices(inner = TRUE) correctly translates the inner inds to indices of the task", {
 
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
   set.seed(getOption("mlr.debug.seed"))
 
   # this test is from "test_base_fixed_indices_cv.R"

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -69,8 +69,8 @@ test_that("getResamplingIndices(inner = TRUE) correctly translates the inner ind
   fixed = as.factor(rep(1:5, rep(30, 5)))
   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
   lrn = makeLearner("classif.ranger")
-  ctrl = makeTuneControlRandom(maxit = 10)
-  ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 100))
+  ctrl = makeTuneControlGrid()
+  ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 70))
   inner = makeResampleDesc("CV", fixed = TRUE)
   outer = makeResampleDesc("CV", fixed = TRUE)
   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -47,32 +47,27 @@ test_that("getResamplingIndices works with getFeatSelResult", {
   expect_length(unique(unlist(getResamplingIndices(r, inner = TRUE)[[1]]$test.inds)), 25)
 })
 
-# test_that("getResamplingIndices(inner = TRUE) correctly translates the inner inds to indices of the task", {
-#
-#   if (getRversion() > "3.5.3") {
-#     suppressWarnings(RNGversion("3.5.0"))
-#   }
-#   set.seed(getOption("mlr.debug.seed"))
-#
-#   # this test is from "test_base_fixed_indices_cv.R"
-#   df = multiclass.df
-#   fixed = as.factor(rep(1:5, rep(30, 5)))
-#   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
-#   lrn = makeLearner("classif.ranger")
-#   ctrl = makeTuneControlGrid()
-#   ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 70))
-#   inner = makeResampleDesc("CV", fixed = TRUE)
-#   outer = makeResampleDesc("CV", fixed = TRUE)
-#   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,
-#     control = ctrl, show.info = FALSE)
-#   p = resample(tune_wrapper, ct, outer, show.info = FALSE,
-#     extract = getTuneResult)
-#
-#   inner_inds = getResamplingIndices(p, inner = TRUE)
-#
-#   # to test we expect that any inner fold contains indices that exceed $obs - (obs / nfolds)$ = 150 - 30 = 120
-#   # 120 is the max index number that is used in the inner resampling (in the case of 150 obs and 5 folds) because we have one fold less than in the outer level
-#   inds = sort(inner_inds[[2]][["test.inds"]][[1]])
-#
-#   expect_equal(length(inds[inds > 120]), 30)
-# })
+test_that("getResamplingIndices(inner = TRUE) correctly translates the inner inds to indices of the task", {
+
+  # this test is from "test_base_fixed_indices_cv.R"
+  df = multiclass.df
+  fixed = as.factor(rep(1:5, rep(30, 5)))
+  ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
+  lrn = makeLearner("classif.ranger")
+  ctrl = makeTuneControlGrid()
+  ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 70))
+  inner = makeResampleDesc("CV", fixed = TRUE)
+  outer = makeResampleDesc("CV", fixed = TRUE)
+  tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,
+    control = ctrl, show.info = FALSE)
+  p = resample(tune_wrapper, ct, outer, show.info = FALSE,
+    extract = getTuneResult)
+
+  inner_inds = getResamplingIndices(p, inner = TRUE)
+
+  # to test we expect that any inner fold contains indices that exceed $obs - (obs / nfolds)$ = 150 - 30 = 120
+  # 120 is the max index number that is used in the inner resampling (in the case of 150 obs and 5 folds) because we have one fold less than in the outer level
+  inds = sort(inner_inds[[2]][["test.inds"]][[1]])
+
+  expect_equal(length(inds[inds > 120]), 30)
+})

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -70,7 +70,7 @@ test_that("getResamplingIndices(inner = TRUE) correctly translates the inner ind
   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
   lrn = makeLearner("classif.ranger")
   ctrl = makeTuneControlRandom(maxit = 2)
-  ps = makeParamSet(makeNumericParam("nu", lower = 2, upper = 20))
+  ps = makeParamSet(makeNumericParam("mtry", lower = 3, upper = 4))
   inner = makeResampleDesc("CV", iters = 4, fixed = TRUE)
   outer = makeResampleDesc("CV", iters = 5, fixed = TRUE)
   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -2,7 +2,7 @@ context("resample_cv")
 
 test_that("getResamplingIndices works with getTuneResult", {
 
-  set.seed(getOption("mlr.debug.seed"))
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
 
   task = makeClassifTask(data = iris, target = "Species")
   lrn = makeLearner("classif.rpart")

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -68,7 +68,7 @@ test_that("getResamplingIndices(inner = TRUE) correctly translates the inner ind
   df = multiclass.df
   fixed = as.factor(rep(1:5, rep(30, 5)))
   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
-  lrn = makeLearner("classif.lda")
+  lrn = makeLearner("classif.ranger")
   ctrl = makeTuneControlRandom(maxit = 2)
   ps = makeParamSet(makeNumericParam("nu", lower = 2, upper = 20))
   inner = makeResampleDesc("CV", iters = 4, fixed = TRUE)

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -70,7 +70,7 @@ test_that("getResamplingIndices(inner = TRUE) correctly translates the inner ind
   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
   lrn = makeLearner("classif.ranger")
   ctrl = makeTuneControlRandom(maxit = 2)
-  ps = makeParamSet(makeIntegerParam("mtry", lower = 3, upper = 4))
+  ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 100))
   inner = makeResampleDesc("CV", iters = 4, fixed = TRUE)
   outer = makeResampleDesc("CV", iters = 5, fixed = TRUE)
   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -69,10 +69,10 @@ test_that("getResamplingIndices(inner = TRUE) correctly translates the inner ind
   fixed = as.factor(rep(1:5, rep(30, 5)))
   ct = makeClassifTask(target = multiclass.target, data = df, blocking = fixed)
   lrn = makeLearner("classif.ranger")
-  ctrl = makeTuneControlRandom(maxit = 2)
+  ctrl = makeTuneControlRandom(maxit = 10)
   ps = makeParamSet(makeIntegerParam("num.trees", lower = 50, upper = 100))
-  inner = makeResampleDesc("CV", iters = 4, fixed = TRUE)
-  outer = makeResampleDesc("CV", iters = 5, fixed = TRUE)
+  inner = makeResampleDesc("CV", fixed = TRUE)
+  outer = makeResampleDesc("CV", fixed = TRUE)
   tune_wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,
     control = ctrl, show.info = FALSE)
   p = resample(tune_wrapper, ct, outer, show.info = FALSE,

--- a/tests/testthat/test_base_resample_getResamplingIndices.R
+++ b/tests/testthat/test_base_resample_getResamplingIndices.R
@@ -1,6 +1,9 @@
 context("resample_cv")
 
 test_that("getResamplingIndices works with getTuneResult", {
+
+  set.seed(getOption("mlr.debug.seed"))
+
   task = makeClassifTask(data = iris, target = "Species")
   lrn = makeLearner("classif.rpart")
   # stupid mini grid
@@ -26,6 +29,9 @@ test_that("getResamplingIndices works with getTuneResult", {
 })
 
 test_that("getResamplingIndices works with getFeatSelResult", {
+
+  set.seed(getOption("mlr.debug.seed"))
+
   outer = makeResampleDesc("CV", iters = 2L)
   inner = makeResampleDesc("Holdout")
 
@@ -46,6 +52,8 @@ test_that("getResamplingIndices works with getFeatSelResult", {
 })
 
 test_that("getResamplingIndices(inner = TRUE) correctly translates the inner inds to indices of the task", {
+
+  set.seed(getOption("mlr.debug.seed"))
 
   # this test is from "test_base_fixed_indices_cv.R"
   df = multiclass.df

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -1,7 +1,10 @@
 
 test_that("Nested SpRepCV works without errors", {
 
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
 
   data(spatial.task, package = "mlr", envir = environment())
 
@@ -28,7 +31,10 @@ test_that("Nested SpRepCV works without errors", {
 
 test_that("SpRepCV works without errors", {
 
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
 
   data(spatial.task, package = "mlr", envir = environment())
 

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -25,7 +25,7 @@ test_that("Nested SpRepCV works without errors", {
   out = resample(wrapper, spatial.task,
     resampling = outer, show.info = TRUE, measures = list(auc))
 
-  expect_vector(out$measures.test$auc, ptype = numeric(), size = 4)
+  expect_atomic_vector(out$measures.test$auc, min.len = 4, max.len = 4)
 })
 
 test_that("SpRepCV works without errors", {
@@ -44,5 +44,5 @@ test_that("SpRepCV works without errors", {
   out = resample(learner = learner, task = spatial.task,
     resampling = resampling, measures = list(auc))
 
-  expect_vector(out$measures.test$auc, ptype = numeric(), size = 4)
+  expect_atomic_vector(out$measures.test$auc, min.len = 4, max.len = 4)
 })

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -1,5 +1,8 @@
 
 test_that("Nested SpRepCV works without errors", {
+
+  set.seed(getOption("mlr.debug.seed"))
+
   data(spatial.task, package = "mlr", envir = environment())
 
   lrn.ksvm = makeLearner("classif.ksvm",
@@ -24,6 +27,9 @@ test_that("Nested SpRepCV works without errors", {
 })
 
 test_that("SpRepCV works without errors", {
+
+  set.seed(getOption("mlr.debug.seed"))
+
   data(spatial.task, package = "mlr", envir = environment())
 
   learner = makeLearner("classif.ksvm", predict.type = "prob", kernel = "rbfdot")

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -12,7 +12,7 @@ test_that("Nested SpRepCV works without errors", {
     predict.type = "prob")
 
   ps = makeParamSet(makeNumericParam("mtry", lower = 3, upper = 3),
-    makeNumericParam("ntrees", lower = 10, upper = 10))
+    makeNumericParam("num.trees", lower = 10, upper = 10))
 
   ctrl = makeTuneControlRandom(maxit = 1)
   inner = makeResampleDesc("SpCV", iters = 2)
@@ -25,7 +25,7 @@ test_that("Nested SpRepCV works without errors", {
   out = resample(wrapper, spatial.task,
     resampling = outer, show.info = TRUE, measures = list(auc))
 
-  expect_vector(out$measures.test$auc, any.missing = FALSE, len = 4)
+  expect_vector(out$measures.test$auc, size = 4)
 })
 
 test_that("SpRepCV works without errors", {
@@ -44,5 +44,5 @@ test_that("SpRepCV works without errors", {
   out = resample(learner = learner, task = spatial.task,
     resampling = resampling, measures = list(auc))
 
-  expect_vector(out$measures.test$auc, any.missing = FALSE, len = 4)
+  expect_vector(out$measures.test$auc, size = 4)
 })

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -25,7 +25,7 @@ test_that("Nested SpRepCV works without errors", {
   out = resample(wrapper, spatial.task,
     resampling = outer, show.info = TRUE, measures = list(auc))
 
-  expect_vector(out$measures.test$auc, size = 4)
+  expect_vector(out$measures.test$auc, ptype = numeric(), size = 4)
 })
 
 test_that("SpRepCV works without errors", {
@@ -44,5 +44,5 @@ test_that("SpRepCV works without errors", {
   out = resample(learner = learner, task = spatial.task,
     resampling = resampling, measures = list(auc))
 
-  expect_vector(out$measures.test$auc, size = 4)
+  expect_vector(out$measures.test$auc, ptype = numeric(), size = 4)
 })

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -1,7 +1,7 @@
 
 test_that("Nested SpRepCV works without errors", {
 
-  set.seed(getOption("mlr.debug.seed"))
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
 
   data(spatial.task, package = "mlr", envir = environment())
 
@@ -28,7 +28,7 @@ test_that("Nested SpRepCV works without errors", {
 
 test_that("SpRepCV works without errors", {
 
-  set.seed(getOption("mlr.debug.seed"))
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
 
   data(spatial.task, package = "mlr", envir = environment())
 

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -1,11 +1,6 @@
 
 test_that("Nested SpRepCV works without errors", {
 
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
-
   data(spatial.task, package = "mlr", envir = environment())
 
   lrn = makeLearner("classif.ranger",
@@ -29,11 +24,6 @@ test_that("Nested SpRepCV works without errors", {
 })
 
 test_that("SpRepCV works without errors", {
-
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
 
   data(spatial.task, package = "mlr", envir = environment())
 

--- a/tests/testthat/test_base_spcv.R
+++ b/tests/testthat/test_base_spcv.R
@@ -8,22 +8,21 @@ test_that("Nested SpRepCV works without errors", {
 
   data(spatial.task, package = "mlr", envir = environment())
 
-  lrn.ksvm = makeLearner("classif.ksvm",
-    predict.type = "prob",
-    kernel = "rbfdot")
+  lrn = makeLearner("classif.ranger",
+    predict.type = "prob")
 
-  ps = makeParamSet(makeNumericParam("C", lower = 1, upper = 1),
-    makeNumericParam("sigma", lower = 1, upper = 1))
+  ps = makeParamSet(makeNumericParam("mtry", lower = 3, upper = 3),
+    makeNumericParam("ntrees", lower = 10, upper = 10))
 
   ctrl = makeTuneControlRandom(maxit = 1)
   inner = makeResampleDesc("SpCV", iters = 2)
 
-  wrapper.ksvm = makeTuneWrapper(lrn.ksvm, resampling = inner, par.set = ps,
+  wrapper = makeTuneWrapper(lrn, resampling = inner, par.set = ps,
     control = ctrl, show.info = FALSE, measures = list(auc))
 
   outer = makeResampleDesc("SpRepCV", folds = 2, reps = 2)
 
-  out = resample(wrapper.ksvm, spatial.task,
+  out = resample(wrapper, spatial.task,
     resampling = outer, show.info = TRUE, measures = list(auc))
 
   expect_vector(out$measures.test$auc, any.missing = FALSE, len = 4)
@@ -38,7 +37,7 @@ test_that("SpRepCV works without errors", {
 
   data(spatial.task, package = "mlr", envir = environment())
 
-  learner = makeLearner("classif.ksvm", predict.type = "prob", kernel = "rbfdot")
+  learner = makeLearner("classif.ranger", predict.type = "prob")
 
   resampling = makeResampleDesc("SpRepCV", fold = 2, reps = 2)
 

--- a/tests/testthat/test_classif_mda.R
+++ b/tests/testthat/test_classif_mda.R
@@ -2,6 +2,8 @@ context("classif_mda")
 
 test_that("classif_mda", {
   requirePackagesOrSkip("!mda", default.method = "load")
+  on.exit(RNGversion(getRversion()))
+  suppressWarnings(RNGversion("3.5.0"))
 
   parset.list1 = list(
     list(start.method = "lvq"),

--- a/tests/testthat/test_classif_mda.R
+++ b/tests/testthat/test_classif_mda.R
@@ -2,7 +2,10 @@ context("classif_mda")
 
 test_that("classif_mda", {
   requirePackagesOrSkip("!mda", default.method = "load")
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
 
   parset.list1 = list(
     list(start.method = "lvq"),

--- a/tests/testthat/test_classif_mda.R
+++ b/tests/testthat/test_classif_mda.R
@@ -2,8 +2,7 @@ context("classif_mda")
 
 test_that("classif_mda", {
   requirePackagesOrSkip("!mda", default.method = "load")
-  on.exit(RNGversion(getRversion()))
-  suppressWarnings(RNGversion("3.5.0"))
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
 
   parset.list1 = list(
     list(start.method = "lvq"),

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -86,7 +86,10 @@ test_that("FailureModel works", {
 
 test_that("ModelMultiplexer tuning", {
 
-  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+  if (getRversion() > "3.5.3") {
+    suppressWarnings(RNGversion("3.5.0"))
+  }
+  set.seed(getOption("mlr.debug.seed"))
 
   lrn = makeModelMultiplexer(c("classif.knn", "classif.rpart"))
   rdesc = makeResampleDesc("CV", iters = 2L)

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -109,7 +109,8 @@ test_that("ModelMultiplexer tuning", {
   res = tuneParams(lrn, task, rdesc, par.set = tune.ps, control = ctrl)
   expect_true(setequal(class(res), c("TuneResult", "OptResult")))
   y = getOptPathY(res$opt.path)
-  expect_true(all(!is.na(y) && is.finite(y)))
+  expect_true(all(!is.na(y)))
+  expect_true(all(is.finite(y)))
 })
 
 # we had bug here, see issue #609

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -85,6 +85,9 @@ test_that("FailureModel works", {
 })
 
 test_that("ModelMultiplexer tuning", {
+
+  set.seed(getOption("mlr.debug.seed"), kind = "Rounding")
+
   lrn = makeModelMultiplexer(c("classif.knn", "classif.rpart"))
   rdesc = makeResampleDesc("CV", iters = 2L)
 

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -109,7 +109,7 @@ test_that("ModelMultiplexer tuning", {
   res = tuneParams(lrn, task, rdesc, par.set = tune.ps, control = ctrl)
   expect_true(setequal(class(res), c("TuneResult", "OptResult")))
   y = getOptPathY(res$opt.path)
-  expect_true(!is.na(y) && is.finite(y))
+  expect_true(all(!is.na(y) && is.finite(y)))
 })
 
 # we had bug here, see issue #609

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -101,8 +101,8 @@ test_that("ModelMultiplexer tuning", {
   res = tuneParams(lrn, binaryclass.task, rdesc, par.set = tune.ps, control = ctrl)
   expect_true(setequal(class(res), c("TuneResult", "OptResult")))
   y = getOptPathY(res$opt.path)
-  expect_true(!is.na(y))
-  expect_true(is.finite(y))
+  expect_true(all(!is.na(y)))
+  expect_true(all(is.finite(y)))
   # tune with irace
   task = subsetTask(binaryclass.task, subset = c(1:20, 150:170))
   ctrl = makeTuneControlIrace(maxExperiments = 40L, nbIterations = 2L, minNbSurvival = 1L)

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -95,7 +95,8 @@ test_that("ModelMultiplexer tuning", {
   res = tuneParams(lrn, binaryclass.task, rdesc, par.set = tune.ps, control = ctrl)
   expect_true(setequal(class(res), c("TuneResult", "OptResult")))
   y = getOptPathY(res$opt.path)
-  expect_true(!is.na(y) && is.finite(y))
+  expect_true(!is.na(y))
+  expect_true(is.finite(y))
   # tune with irace
   task = subsetTask(binaryclass.task, subset = c(1:20, 150:170))
   ctrl = makeTuneControlIrace(maxExperiments = 40L, nbIterations = 2L, minNbSurvival = 1L)

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -86,11 +86,6 @@ test_that("FailureModel works", {
 
 test_that("ModelMultiplexer tuning", {
 
-  if (getRversion() > "3.5.3") {
-    suppressWarnings(RNGversion("3.5.0"))
-  }
-  set.seed(getOption("mlr.debug.seed"))
-
   lrn = makeModelMultiplexer(c("classif.knn", "classif.rpart"))
   rdesc = makeResampleDesc("CV", iters = 2L)
 

--- a/tic.R
+++ b/tic.R
@@ -9,10 +9,12 @@ do_package_checks(args = "--as-cran", error_on = "error",
   repos = c(getOption("repos"), remotes::bioc_install_repos()))
 
 # pkgdown
-do_pkgdown(commit_paths = "docs/*", document = FALSE)
+if (ci_is_env("FULL", "true")) {
+  do_pkgdown(commit_paths = "docs/*", document = FALSE)
+}
 
 # only deploy man files in in master branch
-if (ci_get_branch() == "master") {
+if (ci_get_branch() == "master" && ci_is_env("FULL", "true")) {
 
   get_stage("deploy") %>%
     add_code_step(pkgbuild::compile_dll()) %>%

--- a/tic.R
+++ b/tic.R
@@ -1,8 +1,8 @@
 get_stage("before_script") %>%
+  # fix the RWeka warning on Java 9+: http://weka.8497.n7.nabble.com/warnings-td42935.html
+  add_code_step(system("export _JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'")) %>%
   add_code_step(RWeka::WPM("refresh-cache")) %>%
   add_code_step(RWeka::WPM('install-package', 'XMeans'))
-  # add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
-  #   "-install-package", "thirdparty/XMeans1.0.4.zip")))
 
 # R CMD Check
 do_package_checks(args = "--as-cran", error_on = "error",

--- a/tic.R
+++ b/tic.R
@@ -1,4 +1,4 @@
-get_stage("before_script") %>%
+get_stage("script") %>%
   add_code_step(RWeka::WPM("refresh-cache")) %>%
   add_code_step(RWeka::WPM('install-package', 'XMeans'))
 

--- a/tic.R
+++ b/tic.R
@@ -1,6 +1,4 @@
 get_stage("before_script") %>%
-  # fix the RWeka warning on Java 9+: http://weka.8497.n7.nabble.com/warnings-td42935.html
-  add_code_step(system("export _JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'")) %>%
   add_code_step(RWeka::WPM("refresh-cache")) %>%
   add_code_step(RWeka::WPM('install-package', 'XMeans'))
 

--- a/tic.R
+++ b/tic.R
@@ -1,6 +1,8 @@
 get_stage("before_script") %>%
-  add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
-    "-install-package", "thirdparty/XMeans1.0.4.zip")))
+  add_code_step(RWeka::WPM("refresh-cache")) %>%
+  add_code_step(RWeka::WPM('install-package', 'XMeans'))
+  # add_code_step(system2("java", args = c("-cp", "$HOME/R/Library/RWekajars/java/weka.jar weka.core.WekaPackageManager",
+  #   "-install-package", "thirdparty/XMeans1.0.4.zip")))
 
 # R CMD Check
 do_package_checks(args = "--as-cran", error_on = "error",


### PR DESCRIPTION
# Test related changes

- `testthat::expect_vector()` replaced by `checkmate::expect_atomic_vector() ` since `testthat::expect_vector()` now depends on `vctrs`
- for `tests/testthat/test_base_spcv.R` I changed the learner
- `expect_true()` checks throwed a correct "coercion > 1" error (I think there is an automated checking now in R 3.6.0) -> split them into two lines and wrapped them in `all()`
- All tests are now using the old R < 3.6.0 seed (set in the `run_*.R` files in the `testthat` directory`

    ```r
  if (getRversion() > "3.5.3") {
    # set old seed
    suppressWarnings(RNGversion("3.5.0"))
    # restore standard seed when done (so that we are back to defaults for the next tests)
    on.exit(suppressWarnings(RNGversion("3.6.0")))
  }
    ```

# General

- We are now building for 3 R versions in parallel to catch such issues in advance in the future
   - devel
   - release
   - oldrel
- RWeka warning caused by Java 9+ has been silenced using `_Java_options` env var