### PR TITLE
Bugfix: Pass down FSelectorRcpp filter args

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -1032,7 +1032,7 @@ FSelectorRcpp.filter = function(type) {
     data = getTaskData(task)
     X = data[getTaskFeatureNames(task)]
     y = data[[getTaskTargetNames(task)]]
-    res = FSelectorRcpp::information_gain(x = X, y = y, type = type, equal = FALSE)
+    res = FSelectorRcpp::information_gain(x = X, y = y, type = type, ...)
     res = setNames(res$importance, res$attributes)
     replace(res, is.nan(res), 0) # FIXME: this is a technical fix, need to report upstream
   }


### PR DESCRIPTION
fixes #2609 

# New behavior

Filter args are respected.

``` r
library("mlr")
#> Loading required package: ParamHelpers

bh.task_mod = dropFeatures(bh.task, "chas")

# warning appears because `equal = FALSE`
# In this case `equal = FALSE` is even causing a problematic return...
generateFilterValuesData(bh.task_mod, "FSelectorRcpp_information.gain")
#> Warning in .information_gain.data.frame(x, y, type, equal, threads,
#> discIntegers = discIntegers): Dependent variable is a numeric! It will be
#> converted to factor with simple factor(y). We do not discretize dependent
#> variable in FSelectorRcpp by default! You can choose equal frequency
#> binning discretization by setting equal argument to TRUE.

#> Warning in .information_gain.data.frame(x, y, type, equal, threads,
#> discIntegers = discIntegers): Dependent variable is a numeric! It will be
#> converted to factor with simple factor(y). We do not discretize dependent
#> variable in FSelectorRcpp by default! You can choose equal frequency
#> binning discretization by setting equal argument to TRUE.
#> FilterValues:
#> Task: BostonHousing-example
#>    name    type FSelectorRcpp_information.gain
#> 1  crim numeric                              0
#> 2    zn numeric                              0
#> 3 indus numeric                              0
#> 4   nox numeric                              0
#> 5    rm numeric                              0
#> 6   age numeric                              0
#> ... (#rows: 12, #cols: 3)

# equal = TRUE is passed down to the filter -> warning gone
generateFilterValuesData(bh.task_mod, "FSelectorRcpp_information.gain", equal = TRUE)
#> FilterValues:
#> Task: BostonHousing-example
#>    name    type FSelectorRcpp_information.gain
#> 1  crim numeric                      0.2433297
#> 2    zn numeric                      0.1259694
#> 3 indus numeric                      0.3493898
#> 4   nox numeric                      0.3575879
#> 5    rm numeric                      0.4123003
#> 6   age numeric                      0.2516128
#> ... (#rows: 12, #cols: 3)
```

<sup>Created on 2019-06-25 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

