### PR TITLE
Bug fix for Issue 2639

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -276,8 +276,8 @@ rf.min.depth = makeFilter(
   supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, nselect, method = "md", ...) {
     im = randomForestSRC::var.select(getTaskFormula(task), getTaskData(task),
-      method = method, verbose = FALSE, ...)$md.obj$order
-    setNames(-im[, 1L], rownames(im))
+		method = method, verbose = FALSE, ...)$varselect
+    setNames(im[, 1L], rownames(im))
   })
 .FilterRegister[["rf.min.depth"]] = rf.min.depth
 .FilterRegister[["rf.min.depth"]]$desc = "(DEPRECATED)"
@@ -294,8 +294,8 @@ randomForestSRC.var.select = makeFilter(
   supported.features = c("numerics", "factors", "ordered"),
   fun = function(task, nselect, method = "md", ...) {
     im = randomForestSRC::var.select(getTaskFormula(task), getTaskData(task),
-      method = method, verbose = FALSE, ...)$md.obj$order
-    setNames(-im[, 1L], rownames(im))
+		method = method, verbose = FALSE, ...)$varselect
+    setNames(im[, 1L], rownames(im))
   })
 .FilterRegister[["randomForestSRC.var.select"]] = randomForestSRC.var.select
 .FilterRegister[["randomForestSRC.var.select"]]$desc = "(DEPRECATED)"


### PR DESCRIPTION
When using the RF min depth filter with a method other than "md" (i.e.
"vh" or "vh.vimp"), an error is generated at line 298:
	Error in -im[, 1L]: invalid argument to unary operator.
This happens because im = NULL.
From code: im = (result of RF var.select)$md.obj$order
From randomForestSRC documentation: md.obj - Minimal depth object. NULL
unless method = "md".
Therefore the object md.obj cannot be used for methods "vh" and "vh.vimp".
The solution is to use object varselect instead, which is a matrix
containing the tree depth and relative frequency for each variable. Note
also that object topvars contains the names of the top variables.

P.S. This is my first PR and I don;t have access to the coding guidelines or other docs. Could I be added please?
