### PR TITLE
Pkgdown tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Machine Learning in R <img src="man/figures/logo_navbar.png" align="right" />
+# mlr <img src="man/figures/logo_navbar.png" align="right" />
+
+Machine learning in R.
 
 [![Build Status](https://travis-ci.org/mlr-org/mlr.svg?branch=master)](https://travis-ci.org/mlr-org/mlr)
 [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version-ago/mlr)](https://cran.r-project.org/package=mlr)

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,6 +1,7 @@
 url: https://mlr.mlr-org.com
 
 template:
+  package: mlr3pkgdowntemplate
   params:
     bootswatch: journal
     docsearch:
@@ -18,6 +19,7 @@ toc:
   depth: 3
 
 home:
+  strip_header: true
   links:
   - text: Cheatsheet
     href: https://github.com/mlr-org/mlr/blob/master/addon/cheatsheet/MlrCheatsheet.pdf
@@ -123,17 +125,14 @@ navbar:
       href: articles/tutorial/mlr_publications.html
     - text: Talks, Videos and Workshops
       href: articles/tutorial/talks_videos_workshops.html
-
-  - text: mlr-org Packages
-    menu:
     - text: mlrMBO
-      href: https://github.com/mlr-org/mlrMBO
+      href: https://mlrmbo.mlr-org.com
     - text: mlrCPO
-      href: https://github.com/mlr-org/mlrCPO
+      href: https://https://mlrcpo.mlr-org.com
     - text: mlrHyperopt
       href: https://jakob-r.de/mlrHyperopt/index.html
     - text: OpenML
-      href: https://openml.github.io/openml-r/vignettes/OpenML.html
+      href: http://openml.github.io/openml-r/
 
   right:
   - icon: fa-github fa-lg


### PR DESCRIPTION
- depend on mlr3pkgdowntemplate
- fix links in navbar
- move menu "mlr-org packages" into Appendix (caused space problems on some monitors; i.e. there was too less space in the navbar)
- strip header