### PR TITLE
Circle: do not cache `ccache`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
           key: R-package-library-{{ checksum "/tmp/_tmp_file" }}
           paths:
             - /usr/local/lib/R/site-library
-            - $HOME/.ccache
   codecov:
     docker:
       - image: rocker/verse


### PR DESCRIPTION
This leads to pointer problems when libraries are updated as it can be seen in all R v3.5.3 builds right now (when glmnet is updated with old pointers).