### PR TITLE
fix fda.usc learners after v2.0 update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 ## learners - general
 
 - fixed a bug in `classif.xgboost` which prevented passing a watchlist for binary tasks. This was caused by a suboptimal internal label inversion approach. Thanks to @001ben for reporting (#32) (@mllg)
+- update `fda.usc` learners to work with package version >=2.0
 
 ## misc
 

--- a/R/RLearner_classif_fdausc.glm.R
+++ b/R/RLearner_classif_fdausc.glm.R
@@ -32,7 +32,12 @@ trainLearner.classif.fdausc.glm = function(.learner, .task, .subset, .weights = 
   # transform the data into fda.usc:fdata class type and save in a list
   dat = list(df = data.frame(d$target), x = data.fdclass)
 
-  model = classif.glm(d.target ~ x, data = dat)
+  model = fda.usc::classif.glm(d.target ~ x, data = dat)
+
+  # Fix bug in package. The changed slot looks different when called with
+  # `fda.usc::lassif.glm()` than just `classif.glm()`
+  model$C[[1]] = quote(classif.glm)
+
   return(model)
 }
 

--- a/R/RLearner_classif_fdausc.glm.R
+++ b/R/RLearner_classif_fdausc.glm.R
@@ -32,9 +32,7 @@ trainLearner.classif.fdausc.glm = function(.learner, .task, .subset, .weights = 
   # transform the data into fda.usc:fdata class type and save in a list
   dat = list(df = data.frame(d$target), x = data.fdclass)
 
-  model = fda.usc::classif.glm(d.target ~ x, data = dat)
-  # Fix bug in package
-  model$C[[1]] = quote(classif.glm)
+  model = classif.glm(d.target ~ x, data = dat)
   return(model)
 }
 
@@ -46,8 +44,8 @@ predictLearner.classif.fdausc.glm = function(.learner, .model, .newdata, ...) {
   # predict according to predict.type
   type = ifelse(.learner$predict.type == "prob", "probs", "class")
   if (type == "probs") {
-    fda.usc::predict.classif(object = .model$learner.model, new.fdataobj = nd, type = type)$prob.group
+    predict(object = .model$learner.model, new.fdataobj = nd, type = type)$prob.group
   } else {
-    fda.usc::predict.classif(object = .model$learner.model, new.fdataobj = nd, type = type)
+    predict(object = .model$learner.model, new.fdataobj = nd, type = type)
   }
 }

--- a/R/RLearner_classif_fdausc.np.R
+++ b/R/RLearner_classif_fdausc.np.R
@@ -32,11 +32,16 @@ trainLearner.classif.fdausc.np = function(.learner, .task, .subset, .weights = N
   d = getTaskData(.task, subset = .subset, target.extra = TRUE, functionals.as = "matrix")
   fd = getFunctionalFeatures(d$data)
   # transform the data into fda.usc:fdata class type.
-  data.fdclass = fdata(mdata = as.matrix(fd))
+  data.fdclass = fda.usc::fdata(mdata = as.matrix(fd))
 
   par.cv = learnerArgsToControl(list, trim, draw)
-  mod = classif.np(group = d$target, fdataobj = data.fdclass, par.CV = par.cv,
+  mod = fda.usc::classif.np(group = d$target, fdataobj = data.fdclass, par.CV = par.cv,
     par.S = list(w = .weights), ...)
+
+  # Fix bug in package. The changed slot looks different when called with
+  # `fda.usc::lassif.np()` than just `classif.np()`
+  mod$C[[1]] = quote(classif.np)
+
   return(mod)
 }
 
@@ -44,7 +49,7 @@ trainLearner.classif.fdausc.np = function(.learner, .task, .subset, .weights = N
 predictLearner.classif.fdausc.np = function(.learner, .model, .newdata, ...) {
   # transform the data into fda.usc:fdata class type.
   fd = getFunctionalFeatures(.newdata)
-  nd = fdata(mdata = as.matrix(fd))
+  nd = fda.usc::fdata(mdata = as.matrix(fd))
 
   # predict according to predict.type
   type = ifelse(.learner$predict.type == "prob", "probs", "class")

--- a/R/RLearner_classif_fdausc.np.R
+++ b/R/RLearner_classif_fdausc.np.R
@@ -32,13 +32,11 @@ trainLearner.classif.fdausc.np = function(.learner, .task, .subset, .weights = N
   d = getTaskData(.task, subset = .subset, target.extra = TRUE, functionals.as = "matrix")
   fd = getFunctionalFeatures(d$data)
   # transform the data into fda.usc:fdata class type.
-  data.fdclass = fda.usc::fdata(mdata = as.matrix(fd))
+  data.fdclass = fdata(mdata = as.matrix(fd))
 
   par.cv = learnerArgsToControl(list, trim, draw)
-  mod = fda.usc::classif.np(group = d$target, fdataobj = data.fdclass, par.CV = par.cv,
+  mod = classif.np(group = d$target, fdataobj = data.fdclass, par.CV = par.cv,
     par.S = list(w = .weights), ...)
-  # Fix a bug in the package
-  mod$C[[1]] = quote(classif.np)
   return(mod)
 }
 
@@ -46,7 +44,7 @@ trainLearner.classif.fdausc.np = function(.learner, .task, .subset, .weights = N
 predictLearner.classif.fdausc.np = function(.learner, .model, .newdata, ...) {
   # transform the data into fda.usc:fdata class type.
   fd = getFunctionalFeatures(.newdata)
-  nd = fda.usc::fdata(mdata = as.matrix(fd))
+  nd = fdata(mdata = as.matrix(fd))
 
   # predict according to predict.type
   type = ifelse(.learner$predict.type == "prob", "probs", "class")

--- a/tests/testthat/helper_objects.R
+++ b/tests/testthat/helper_objects.R
@@ -162,7 +162,7 @@ costsens.feat = iris
 costsens.costs = matrix(runif(150L * 3L, min = 0, max = 1), 150L, 3L)
 costsens.task = makeCostSensTask("costsens", data = costsens.feat, costs = costsens.costs)
 
-ns.svg = c(svg = "http://www.w3.org/2000/svg")
+ns.svg = c(svg = "https://www.w3.org/2000/svg")
 black.circle.xpath = "/svg:svg//svg:circle[contains(@style, 'fill: #000000')]"
 grey.rect.xpath = "/svg:svg//svg:rect[contains(@style, 'fill: #EBEBEB;')]"
 red.circle.xpath = "/svg:svg//svg:circle[contains(@style, 'fill: #F8766D')]"

--- a/tests/testthat/helper_objects.R
+++ b/tests/testthat/helper_objects.R
@@ -162,7 +162,7 @@ costsens.feat = iris
 costsens.costs = matrix(runif(150L * 3L, min = 0, max = 1), 150L, 3L)
 costsens.task = makeCostSensTask("costsens", data = costsens.feat, costs = costsens.costs)
 
-ns.svg = c(svg = "https://www.w3.org/2000/svg")
+ns.svg = c(svg = "http://www.w3.org/2000/svg")
 black.circle.xpath = "/svg:svg//svg:circle[contains(@style, 'fill: #000000')]"
 grey.rect.xpath = "/svg:svg//svg:rect[contains(@style, 'fill: #EBEBEB;')]"
 red.circle.xpath = "/svg:svg//svg:circle[contains(@style, 'fill: #F8766D')]"

--- a/tests/testthat/test_classif_fdausc.glm.R
+++ b/tests/testthat/test_classif_fdausc.glm.R
@@ -2,7 +2,7 @@ context("RLearner_classif_fdausc.glm")
 
 test_that("classif_fdausc.glm behaves like original api", {
 
-  requirePackagesOrSkip("fda.usc", default.method = "attach")
+  requirePackagesOrSkip("fda.usc", default.method = "load")
 
   data(phoneme, package = "fda.usc")
   # Use only 10 obs. for 5 classes, as knn training is really slow
@@ -16,7 +16,11 @@ test_that("classif_fdausc.glm behaves like original api", {
   dataf = data.frame(glearn)
   dat = list("df" = dataf, "x" = mlearn)
   # glm sometimes does not converge, we dont want to see that
-  a1 = suppressWarnings(classif.glm(glearn ~ x, data = dat))
+  a1 = suppressWarnings(fda.usc::classif.glm(glearn ~ x, data = dat))
+
+  # Fix bug in package. The changed slot looks different when called with
+  # `fda.usc::lassif.glm()` than just `classif.glm()`
+  a1$C[[1]] = quote(classif.glm)
 
   p1 = predict(a1, list("x" = mtest))
   p2 = predict(a1, list("x" = mlearn))

--- a/tests/testthat/test_classif_fdausc.glm.R
+++ b/tests/testthat/test_classif_fdausc.glm.R
@@ -1,7 +1,8 @@
 context("RLearner_classif_fdausc.glm")
 
 test_that("classif_fdausc.glm behaves like original api", {
-  requirePackagesOrSkip("fda.usc", default.method = "load")
+
+  requirePackagesOrSkip("fda.usc", default.method = "attach")
 
   data(phoneme, package = "fda.usc")
   # Use only 10 obs. for 5 classes, as knn training is really slow
@@ -15,10 +16,8 @@ test_that("classif_fdausc.glm behaves like original api", {
   dataf = data.frame(glearn)
   dat = list("df" = dataf, "x" = mlearn)
   # glm sometimes does not converge, we dont want to see that
-  a1 = suppressWarnings(fda.usc::classif.glm(glearn ~ x, data = dat))
+  a1 = suppressWarnings(classif.glm(glearn ~ x, data = dat))
 
-  # FIXME: code looks strange here? the quote?
-  a1$C[[1]] = quote(classif.glm)
   p1 = predict(a1, list("x" = mtest))
   p2 = predict(a1, list("x" = mlearn))
 
@@ -32,7 +31,6 @@ test_that("classif_fdausc.glm behaves like original api", {
   ftest = makeFunctionalData(phtst, fd.features = NULL, exclude.cols = "label")
   task = makeClassifTask(data = fdata, target = "label")
 
-  set.seed(getOption("mlr.debug.seed"))
   # glm sometimes does not converge, we dont want to see that
   m = suppressWarnings(train(lrn, task))
   cp = predict(m, newdata = ftest)
@@ -40,6 +38,7 @@ test_that("classif_fdausc.glm behaves like original api", {
 
   cp2 = predict(m, newdata = fdata)
   cp2 = unlist(cp2$data$response, use.names = FALSE)
+
   # check if the output from the original API matches the mlr learner's output
   expect_equal(as.character(cp2), as.character(p2))
   expect_equal(as.character(cp), as.character(p1))

--- a/tests/testthat/test_classif_fdausc.kernel.R
+++ b/tests/testthat/test_classif_fdausc.kernel.R
@@ -14,8 +14,7 @@ test_that("classif_fdausc.kernel behaves like original api", {
 
   mtest = phoneme[["test"]]
   gtest = phoneme[["classtest"]]
-  set.seed(getOption("mlr.debug.seed"))
-  a1 = fda.usc::classif.kernel(glearn, mlearn)
+  a1 = suppressWarnings(fda.usc::classif.kernel(glearn, mlearn))
   p1 = predict(a1, mtest)
   p2 = predict(a1, mlearn)
 
@@ -29,13 +28,13 @@ test_that("classif_fdausc.kernel behaves like original api", {
   fdata = makeFunctionalData(ph, fd.features = NULL, exclude.cols = "label")
   ftest = makeFunctionalData(phtst, fd.features = NULL, exclude.cols = "label")
   task = makeClassifTask(data = fdata, target = "label")
-  set.seed(getOption("mlr.debug.seed"))
   m = train(lrn, task)
   cp = predict(m, newdata = ftest)
   cp = unlist(cp$data$response, use.names = FALSE)
 
   cp2 = predict(m, newdata = fdata)
   cp2 = unlist(cp2$data$response, use.names = FALSE)
+
   # check if the output from the original API matches the mlr learner's output
   expect_equal(as.character(cp2), as.character(p2))
   expect_equal(as.character(cp), as.character(p1))
@@ -45,7 +44,6 @@ test_that("predicttype prob for fda.usc", {
   requirePackagesOrSkip("fda.usc", default.method = "load")
   lrn = makeLearner("classif.fdausc.kernel", predict.type = "prob")
 
-  set.seed(getOption("mlr.debug.seed"))
   m = train(lrn, fda.binary.gp.task)
   cp = predict(m, newdata = getTaskData(fda.binary.gp.task, target.extra = TRUE, functionals.as = "matrix")$data)
   expect_equal(class(cp)[1], "PredictionClassif")
@@ -55,7 +53,6 @@ test_that("resampling fdausc.kernel", {
   requirePackagesOrSkip("fda.usc", default.method = "load")
   lrn = makeLearner("classif.fdausc.kernel", par.vals = list(trim = 0.5), predict.type = "prob")
 
-  set.seed(getOption("mlr.debug.seed"))
   r = resample(lrn, fda.binary.gp.task.small, cv2)
   expect_class(r, "ResampleResult")
 })

--- a/tests/testthat/test_classif_fdausc.knn.R
+++ b/tests/testthat/test_classif_fdausc.knn.R
@@ -13,8 +13,8 @@ test_that("classif_fdausc.knn behaves like original api", {
 
   mtest = phoneme[["test"]]
   gtest = phoneme[["classtest"]]
-  set.seed(getOption("mlr.debug.seed"))
-  a1 = fda.usc::classif.knn(glearn, mlearn, par.CV = list(trim = 0.5))
+  # suppressing "executing %dopar% sequentially: no parallel backend registered"
+  a1 = suppressWarnings(fda.usc::classif.knn(glearn, mlearn, par.CV = list(trim = 0.5)))
   p1 = predict(a1, mtest)
   p2 = predict(a1, mlearn)
 
@@ -28,13 +28,13 @@ test_that("classif_fdausc.knn behaves like original api", {
   fdata = makeFunctionalData(ph, fd.features = NULL, exclude.cols = "label")
   ftest = makeFunctionalData(phtst, fd.features = NULL, exclude.cols = "label")
   task = makeClassifTask(data = fdata, target = "label")
-  set.seed(getOption("mlr.debug.seed"))
   m = train(lrn, task)
   cp = predict(m, newdata = ftest)
   cp = unlist(cp$data$response, use.names = FALSE)
 
   cp2 = predict(m, newdata = fdata)
   cp2 = unlist(cp2$data$response, use.names = FALSE)
+
   # check if the output from the original API matches the mlr learner's output
   expect_equal(as.character(cp2), as.character(p2))
   expect_equal(as.character(cp), as.character(p1))
@@ -44,7 +44,6 @@ test_that("predicttype prob for fda.usc", {
   requirePackagesOrSkip("fda.usc", default.method = "load")
   lrn = makeLearner("classif.fdausc.knn", par.vals = list(knn = 1L, trim = 0.5), predict.type = "prob")
 
-  set.seed(getOption("mlr.debug.seed"))
   m = train(lrn, fda.binary.gp.task)
   cp = predict(m, newdata = getTaskData(fda.binary.gp.task, target.extra = TRUE, functionals.as = "matrix")$data)
   expect_equal(class(cp)[1], "PredictionClassif")
@@ -54,7 +53,6 @@ test_that("resampling fdausc.knn", {
   requirePackagesOrSkip("fda.usc", default.method = "load")
   lrn = makeLearner("classif.fdausc.knn", par.vals = list(knn = 1L, trim = 0.5), predict.type = "prob")
 
-  set.seed(getOption("mlr.debug.seed"))
   r = resample(lrn, fda.binary.gp.task.small, cv2)
   expect_class(r, "ResampleResult")
 })

--- a/tests/testthat/test_classif_fdausc.np.R
+++ b/tests/testthat/test_classif_fdausc.np.R
@@ -1,7 +1,7 @@
 context("RLearner_classif_fdausc.np")
 
 test_that("classif_fdausc.np behaves like original api", {
-  requirePackagesOrSkip("fda.usc", default.method = "load")
+  requirePackagesOrSkip("fda.usc", default.method = "attach")
 
   data(phoneme, package = "fda.usc")
   mlearn = phoneme[["learn"]]
@@ -12,11 +12,7 @@ test_that("classif_fdausc.np behaves like original api", {
   mtest = phoneme[["test"]]
   gtest = phoneme[["classtest"]]
 
-
-  set.seed(getOption("mlr.debug.seed"))
-  a1 = fda.usc::classif.np(glearn, mlearn)
-  # restructure internal function call (language-object)
-  a1$C[[1]] = quote(classif.np)
+  a1 = classif.np(glearn, mlearn)
   # newdat = list("x"=mtest)
   p1 = predict(a1, mtest)
   p2 = predict(a1, mlearn)
@@ -30,13 +26,13 @@ test_that("classif_fdausc.np behaves like original api", {
   fdata = makeFunctionalData(ph, fd.features = NULL, exclude.cols = "label")
   ftest = makeFunctionalData(phtst, fd.features = NULL, exclude.cols = "label")
   task = makeClassifTask(data = fdata, target = "label")
-  set.seed(getOption("mlr.debug.seed"))
   m = train(lrn, task)
   cp = predict(m, newdata = ftest)
   cp = unlist(cp$data$response, use.names = FALSE)
 
   cp2 = predict(m, newdata = fdata)
   cp2 = unlist(cp2$data$response, use.names = FALSE)
+
   # check if the output from the original API matches the mlr learner's output
   expect_equal(as.character(cp2), as.character(p2))
   expect_equal(as.character(cp), as.character(p1))

--- a/tests/testthat/test_classif_fdausc.np.R
+++ b/tests/testthat/test_classif_fdausc.np.R
@@ -1,7 +1,7 @@
 context("RLearner_classif_fdausc.np")
 
 test_that("classif_fdausc.np behaves like original api", {
-  requirePackagesOrSkip("fda.usc", default.method = "attach")
+  requirePackagesOrSkip("fda.usc", default.method = "load")
 
   data(phoneme, package = "fda.usc")
   mlearn = phoneme[["learn"]]
@@ -12,7 +12,13 @@ test_that("classif_fdausc.np behaves like original api", {
   mtest = phoneme[["test"]]
   gtest = phoneme[["classtest"]]
 
-  a1 = classif.np(glearn, mlearn)
+  # suppressing "executing %dopar% sequentially: no parallel backend registered"
+  a1 = suppressWarnings(fda.usc::classif.np(glearn, mlearn))
+
+  # Fix bug in package. The changed slot looks different when called with
+  # `fda.usc::classif.np()` than just `classif.np()`
+  a1$C[[1]] = quote(classif.np)
+
   # newdat = list("x"=mtest)
   p1 = predict(a1, mtest)
   p2 = predict(a1, mlearn)
@@ -26,7 +32,8 @@ test_that("classif_fdausc.np behaves like original api", {
   fdata = makeFunctionalData(ph, fd.features = NULL, exclude.cols = "label")
   ftest = makeFunctionalData(phtst, fd.features = NULL, exclude.cols = "label")
   task = makeClassifTask(data = fdata, target = "label")
-  m = train(lrn, task)
+  # suppressing "executing %dopar% sequentially: no parallel backend registered"
+  m = suppressWarnings(train(lrn, task))
   cp = predict(m, newdata = ftest)
   cp = unlist(cp$data$response, use.names = FALSE)
 


### PR DESCRIPTION
fixes #2678 

- Update tests
	- remove unnecessary `set.seed()` calls

- update learners to fda.usc v2.0 -> pkg now comes with its own S3 predict.classif method