### PR TITLE
CI: Don't error if packages are not available for certain R ver…

### DIFF
--- a/tests/testthat/test_base_BaggingWrapper.R
+++ b/tests/testthat/test_base_BaggingWrapper.R
@@ -65,6 +65,7 @@ test_that("BaggingWrapper works with 1 obs in newdata", {
 })
 
 test_that("BaggingWrapper with glmnet (#958)", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   lrn = makeLearner("classif.glmnet", predict.type = "response")
   lrn2 = makeBaggingWrapper(lrn)
   mod = train(lrn2, multiclass.task)

--- a/tests/testthat/test_base_PreprocWrapper.R
+++ b/tests/testthat/test_base_PreprocWrapper.R
@@ -40,6 +40,7 @@ test_that("getLearnerModel on nested PreprocWrapper", {
 })
 
 test_that("PreprocWrapper with glmnet (#958)", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   lrn = makeLearner("classif.glmnet", predict.type = "response")
   lrn2 = makePreprocWrapper(lrn, train = function(data, target, args) return(list(data = data, control = list())),
     predict = function(data, target, args, control) return(data))

--- a/tests/testthat/test_base_TuneWrapper.R
+++ b/tests/testthat/test_base_TuneWrapper.R
@@ -42,6 +42,7 @@ test_that("TuneWrapper", {
 
 # see bug in issue 205
 test_that("TuneWrapper passed predict hyper pars correctly to base learner", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   lrn = makeLearner("classif.glmnet", predict.type = "prob")
   rdesc = makeResampleDesc("Holdout", split = 0.3)
   ctrl = makeTuneControlRandom(maxit = 1L)
@@ -111,6 +112,7 @@ test_that("TuneWrapper works with nested sampling and threshold tuning, cf. issu
 })
 
 test_that("TuneWrapper with glmnet (#958)", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   lrn = makeLearner("classif.glmnet", predict.type = "response")
   lrn2 = makeTuneWrapper(lrn, resampling = makeResampleDesc("Holdout"),
     par.set = makeParamSet(makeNumericLearnerParam(id = "alpha", default = 1, lower = 0, upper = 1)),

--- a/tests/testthat/test_base_learnerArgsToControl.R
+++ b/tests/testthat/test_base_learnerArgsToControl.R
@@ -23,6 +23,7 @@ test_that("learnerArgsToControl with list returns the input", {
 
 
 test_that("learnerArgsToControl works with a control object", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   checkLearnerArgsToControlWithControl = function(fdev, devmax, ...) {
     learnerArgsToControl(control = glmnet::glmnet.control, fdev, devmax, ...)
   }

--- a/tests/testthat/test_base_multilabel.R
+++ b/tests/testthat/test_base_multilabel.R
@@ -53,6 +53,7 @@ test_that("multilabel learning", {
 })
 
 test_that("MultilabelBinaryRelevanceWrapper with glmnet (#958)", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   # multilabelBinaryRelevanceWrapper was not working properly for classif.glmnet, we had a bug here
   lrn = makeLearner("classif.glmnet", predict.type = "response")
   lrn2 = makeMultilabelBinaryRelevanceWrapper(lrn)

--- a/tests/testthat/test_regr_glmnet.R
+++ b/tests/testthat/test_regr_glmnet.R
@@ -43,6 +43,7 @@ test_that("regr_glmnet", {
 
 
 test_that("regr_glmnet works with poisson", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   # set some dummy counts
   d = regr.df
   d[, regr.target] = sample(1:100, getTaskSize(regr.task), replace = TRUE)

--- a/tests/testthat/test_surv_measures.R
+++ b/tests/testthat/test_surv_measures.R
@@ -1,6 +1,7 @@
 context("survival measures")
 
 test_that("survival measures do not do stupid things", {
+  requirePackagesOrSkip("glmnet", default.method = "load")
   set.seed(1)
   n = 100
   time = sort(rexp(n, 0.1)) + 1

--- a/tests/testthat/test_tune_ModelMultiplexer.R
+++ b/tests/testthat/test_tune_ModelMultiplexer.R
@@ -131,6 +131,7 @@ test_that("ModelMultiplexer inherits predict.type from base learners", {
 
 # we had bug here, see issue #647
 test_that("ModelMultiplexer passes on hyper pars in predict", {
+  requirePackagesOrSkip("glmnet")
   base.learners = list(
     makeLearner("regr.glmnet"),
     makeLearner("regr.rpart")
@@ -142,6 +143,7 @@ test_that("ModelMultiplexer passes on hyper pars in predict", {
 
 # issue #707
 test_that("ModelMultiplexer handles tasks with no features", {
+  requirePackagesOrSkip("glmnet")
   base.learners = list(
     makeLearner("regr.glmnet"),
     makeLearner("regr.rpart")

--- a/tic.R
+++ b/tic.R
@@ -1,3 +1,7 @@
+get_stage("install") %>%
+  # avoid build failure if packages are not avail for specific R versions
+  add_code_step(Sys.setenv("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = "true"))
+
 get_stage("script") %>%
   add_code_step(RWeka::WPM("refresh-cache")) %>%
   add_code_step(RWeka::WPM('install-package', 'XMeans'))


### PR DESCRIPTION
This came up due to the new R >= 3.6.0 req of _glmnet_.