### PR TITLE
Fix for issue #2685 - Ensemble filters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 
 ## filters - general
 
+- Bugfix: Ensured that ensemble filters select the top-ranked features
 - Bugfix: Allow `method = "vh"` for filter `randomForestSRC_var.select` and return informative error message for not supported values. Also argument `conservative` can now be passed. See #2646 and #2639 for more information (@pat-s, #2649)
 * Bugfix: With the new _praznik_ v7.0.0 release filter `praznik_CMIM` does no longer return a result for logical features. See https://gitlab.com/mbq/praznik/issues/19 for more information
 

--- a/R/FilterEnsemble.R
+++ b/R/FilterEnsemble.R
@@ -272,9 +272,9 @@ calcBaseFilters = function(task, method = method,
     nselect = nselect, more.args = more.args)
 
   # rank base filters by method
-  fval.all.calced.simple = transform(fval.calc$data,
-    rank = ave(1:nrow(fval.calc$data), method,
-      FUN = function(x) order(fval.calc$data$value[x])))
+  fval.all.calced.simple = transform(fval.calc$data, 
+                  rank = ave(value, method, 
+                            FUN = function(x) rank(x, ties.method = "first")))
 
   fval.all.calced.simple = fval.all.calced.simple[with(fval.all.calced.simple,
     order(value, rank)), ]

--- a/R/filterFeatures.R
+++ b/R/filterFeatures.R
@@ -150,9 +150,7 @@ filterFeatures = function(task, method = "randomForestSRC_importance", fval = NU
     # Set the the filter values of the mandatory features to infinity to always select them
     fval[fval$name %in% mandatory.feat, "value"] = Inf
   }
-  if (select == "threshold") {
-    nselect = sum(fval[["value"]] >= threshold, na.rm = TRUE)
-  }
+
   # in case multiple filters have been calculated, choose which ranking is used
   # for the final subsetting
   if (length(levels(as.factor(fval$method))) >= 2) {
@@ -163,12 +161,17 @@ filterFeatures = function(task, method = "randomForestSRC_importance", fval = NU
       stopf("You supplied multiple filters. Please choose which should be used for the final subsetting of the features.")
     }
     if (is.null(select.method)) {
-      fval = fval[fval$method == fval$method, ]
+      fval = fval[fval$method == method[[1]], ]
     } else {
       assertSubset(select.method, choices = unique(fval$method))
       fval = fval[fval$method == select.method, ]
     }
   }
+  
+  if (select == "threshold") {
+    nselect = sum(fval[["value"]] >= threshold, na.rm = TRUE)
+  }
+
   if (nselect > 0L) {
 
     # order by method and (desc(value))


### PR DESCRIPTION
## The Problem: 
Ensemble filters do not select the top-ranked features - see Issue #2685

## The Reasons

1. The ranking calculation in calcBaseFilters  (FilterEnsemble.R )  is incorrect. See evidence in issue #2685.

2. In filterFeatures.R, the method to use for the final ranking must be selected. This is done by the line below, but this has no effect:
`fval = fval[fval$method == fval$method, ]`
As a result fval still contains the data for all methods, not just the ensemble method and the final ranking is done using one of the base methods.

3. When the top features are selected by setting a threshold, this must be done after the subsetting referred to in point 2. If not nselect can be greater than the total number of features.

```
  if (select == "threshold") {
    nselect = sum(fval[["value"]] >= threshold, na.rm = TRUE)
  }
```

If fval contains data for all methods, there will be multiple rows for each feature - one per method. So the calculation above can include the same feature multiple times and thus nselect could be greater than the number of features.
                                        