### PR TITLE
Enable passing filter params via more.args w/o filter name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - Fixed an issue which caused the random forest minimal depth filter to only return NA values when using thresholding. 
   NAs should only be returned for features below the given threshold. (@annette987, #2710)
-- Fixed problem which prevented passing filter options via argument `more.args` for simple filters (@annete987, #2709)
+- Fixed problem which prevented passing filter options via argument `more.args` for simple filters (@annette987, #2709)
   
 # mlr 2.17.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ PR: #2638 (@pfistl)
 
 - `filterFeatures()`: Arg `thresh` was not working correctly when applied to ensemble filters. (@annette987, #2699)
 - Fixed incorrect ranking of ensemble filters. Thanks @annette987 (#2698)
+- Fixed problem of not being able to pass arguments using more.args to a simple filter (@annete987, #2709)
 
 # mlr 2.16.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - Fixed an issue which caused the random forest minimal depth filter to only return NA values when using thresholding. 
   NAs should only be returned for features below the given threshold. (@annette987, #2710)
+- Fixed problem which prevented passing filter options via argument `more.args` for simple filters (@annete987, #2709)
   
 # mlr 2.17.0
 
@@ -46,7 +47,6 @@ PR: #2638 (@pfistl)
 
 - `filterFeatures()`: Arg `thresh` was not working correctly when applied to ensemble filters. (@annette987, #2699)
 - Fixed incorrect ranking of ensemble filters. Thanks @annette987 (#2698)
-- Fixed problem which prevented passing filter options via argument `more.args` for simple filters (@annete987, #2709)
 
 # mlr 2.16.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,7 +39,7 @@ PR: #2638 (@pfistl)
 
 - `filterFeatures()`: Arg `thresh` was not working correctly when applied to ensemble filters. (@annette987, #2699)
 - Fixed incorrect ranking of ensemble filters. Thanks @annette987 (#2698)
-- Fixed problem of not being able to pass arguments using more.args to a simple filter (@annete987, #2709)
+- Fixed problem which prevented passing filter options via argument `more.args` for simple filters (@annete987, #2709)
 
 # mlr 2.16.0
 
@@ -1107,4 +1107,3 @@ In this case, the package name is omitted.
 
 # mlr 1.1-18:
 * Initial release to CRAN
-

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -114,7 +114,6 @@ generateFilterValuesData = function(task, method = "randomForestSRC_importance",
   }
   assertList(more.args, names = "unique", max.len = length(method))
 
-
   fn = getTaskFeatureNames(task)
 
   if (!is.null(ens.method)) {

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -109,7 +109,7 @@ generateFilterValuesData = function(task, method = "randomForestSRC_importance",
     } else {
       stopf("You use more than 1 filter method. Please pass extra arguments via 'more.args' and not '...' to filter methods!")
     }
-  } else if (length(method) == 1L && length(more.args > 1L)) { # simple filter with 1 method and more.args
+  } else if (length(method) == 1L && length(more.args) > 1L) { # simple filter with 1 method and more.args
     more.args = namedList(method, more.args)
   }
   assertList(more.args, names = "unique", max.len = length(method))

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -109,9 +109,9 @@ generateFilterValuesData = function(task, method = "randomForestSRC_importance",
     } else {
       stopf("You use more than 1 filter method. Please pass extra arguments via 'more.args' and not '...' to filter methods!")
     }
-	} else if (length(method) == 1L && length(more.args > 1L)) {  # simple filter with 1 method and more.args
-      more.args = namedList(method, more.args)
-	}
+  } else if (length(method) == 1L && length(more.args > 1L)) { # simple filter with 1 method and more.args
+    more.args = namedList(method, more.args)
+  }
   assertList(more.args, names = "unique", max.len = length(method))
 
 

--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -96,7 +96,6 @@ generateFilterValuesData = function(task, method = "randomForestSRC_importance",
       stri_paste(sapply(check.feat[check.length], function(x) stri_paste("'", x, "'", collapse = ", ")), collapse = ", and "))
   }
   assertCount(nselect)
-  assertList(more.args, names = "unique", max.len = length(method))
   dot.args = list(...)
   if (length(dot.args) > 0L && length(more.args) > 0L) {
     stopf("Do not use both 'more.args' and '...' here!")
@@ -110,7 +109,11 @@ generateFilterValuesData = function(task, method = "randomForestSRC_importance",
     } else {
       stopf("You use more than 1 filter method. Please pass extra arguments via 'more.args' and not '...' to filter methods!")
     }
-  }
+	} else if (length(method) == 1L && length(more.args > 1L)) {  # simple filter with 1 method and more.args
+      more.args = namedList(method, more.args)
+	}
+  assertList(more.args, names = "unique", max.len = length(method))
+
 
   fn = getTaskFeatureNames(task)
 

--- a/tests/testthat/test_featsel_filters.R
+++ b/tests/testthat/test_featsel_filters.R
@@ -108,7 +108,7 @@ test_that("randomForestSRC_var.select minimal depth filter returns NA for featur
   dat = generateFilterValuesData(task = multiclass.task,
     method = "randomForestSRC_var.select",
     nselect = 5,
-    more.args = list("randomForestSRC_var.select" = list(method = "md", nrep = 5)))
+    more.args = list(method = "md", nrep = 5))
   expect_equal(is.na(dat$data$value[dat$data$name %in% c("Sepal.Length", "Sepal.width")]), TRUE)
 })
 


### PR DESCRIPTION
Fixes #2709 

When using a filter via makeFilterWrapper() or generateFilterValuesData(), additional parameters can be passed down to the filter using the argument more.args. If more than one filter is passed to these functions, or an ensemble filter is used,  more.args must be a named list, using the filter name to determine which filter the parameters belong to. For example:
```
generateFilterValuesData(task = iris.task,
                         method = c("randomForestSRC_var.select", "FSelectorRcpp_information.gain"),
                         more.args = list("randomForestSRC_var.select" = list("metho" = "md", ntree=100, nsplit = 10, nodesize = 3) ,
                                          "FSelectorRcpp_information.gain" = list(equal = TRUE)))
```
But if only one simple filter is passed, the filter name need not be included in more.args. For example:
```
generateFilterValuesData(task = iris.task,
       method = "randomForestSRC_var.select",
       more.args = list("metho" = "md", ntree=100, nsplit = 10, nodesize = 3) )
```
However, the latter method, without the filter name included, currently does not work. To overcome this issue, more.args is converted to a named list of the correct format for this particular case. This will maintain backwards compatibility.

Rather than adding an additional test, the test for this PR uses an exiting test but removes the filter name from the parameter list, as it was not necessary and this case had not been tested. 