### PR TITLE
* `listLearners()` should not fail if a package is not installed

### DIFF
--- a/R/RLearner_classif_adaboostm1.R
+++ b/R/RLearner_classif_adaboostm1.R
@@ -9,7 +9,7 @@ makeRLearner.classif.adaboostm1 = function() {
       makeNumericLearnerParam(id = "S", default = 1L),
       makeIntegerLearnerParam(id = "I", default = 10L, lower = 1L),
       makeLogicalLearnerParam(id = "D", default = FALSE, requires = quote(!U)),
-      makeUntypedLearnerParam(id = "W", default = RWeka::DecisionStump),
+      makeUntypedLearnerParam(id = "W", default = list("DecisionStump")),
       makeLogicalLearnerParam(id = "output-debug-info", default = FALSE, tunable = FALSE)
     ),
     properties = c("twoclass", "multiclass", "numerics", "factors", "prob"),

--- a/tests/testthat/test_classif_adaboostm1.R
+++ b/tests/testthat/test_classif_adaboostm1.R
@@ -6,7 +6,6 @@ test_that("classif_adaboostm1", {
   parset.list = list(
     list(),
     list(W = list(RWeka::J48, M = 30)),
-    list(W = list("DecisionStump")),
     list(P = 100),
     list(I = 10, S = 1),
     list(I = 5, Q = FALSE)
@@ -19,7 +18,8 @@ test_that("classif_adaboostm1", {
     parset = parset.list[[i]]
     set.seed(getOption("mlr.debug.seed"))
     ctrl = do.call(RWeka::Weka_control, parset)
-    m = RWeka::AdaBoostM1(formula = binaryclass.formula, data = binaryclass.train, control = ctrl)
+    m = RWeka::AdaBoostM1(formula = binaryclass.formula,
+      data = binaryclass.train, control = ctrl)
     set.seed(getOption("mlr.debug.seed"))
     p = predict(m, newdata = binaryclass.test, type = "probability")
     old.probs.list[[i]] = p[, 1]
@@ -36,7 +36,8 @@ test_that("classif_adaboostm1", {
     parset = parset.list[[i]]
     set.seed(getOption("mlr.debug.seed"))
     ctrl = do.call(RWeka::Weka_control, parset)
-    m = RWeka::AdaBoostM1(formula = multiclass.formula, data = multiclass.train, control = ctrl)
+    m = RWeka::AdaBoostM1(formula = multiclass.formula, data = multiclass.train,
+      control = ctrl)
     set.seed(getOption("mlr.debug.seed"))
     p = predict(m, newdata = multiclass.test, type = "class")
     set.seed(getOption("mlr.debug.seed"))
@@ -53,7 +54,8 @@ test_that("classif_adaboostm1", {
     multiclass.train.inds, old.probs.list, parset.list)
 
   tt = function(formula, data, subset, ...) {
-    RWeka::AdaBoostM1(formula, data = data[subset, ], control = RWeka::Weka_control(...))
+    RWeka::AdaBoostM1(formula, data = data[subset, ],
+      control = RWeka::Weka_control(...))
   }
 
   tp = function(model, newdata) predict(model, newdata, type = "class")


### PR DESCRIPTION
fixes #2715 

``` r
library(mlr)
#> Loading required package: ParamHelpers
#> 'mlr' is in maintenance mode since July 2019. Future development
#> efforts will go into its successor 'mlr3' (<https://mlr3.mlr-org.com>).

library("RWeka")
#> Error in library("RWeka"): there is no package called 'RWeka'
foo = listLearners(iris.task, check.packages = FALSE, 
                   warn.missing.packages = FALSE)
is.data.frame(foo)
#> [1] TRUE
```

<sup>Created on 2020-01-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>