### PR TITLE
simplify data.table() call in generateFeatureValuesData()

### DIFF
--- a/R/generateFilterValues.R
+++ b/R/generateFilterValues.R
@@ -145,7 +145,7 @@ generateFilterValuesData = function(task, method = "randomForestSRC_importance",
     types = vcapply(getTaskData(task, target.extra = TRUE)$data[fn], getClass1)
 
     out = data.table(name = row.names(fval),
-      type = types, fval, row.names = NULL, stringsAsFactors = FALSE)
+      type = types, fval, stringsAsFactors = FALSE)
 
     # variable.factor = FALSE has no effect
     out = melt(out, value.name = "value", measure.vars = index_names,


### PR DESCRIPTION
Fixes #2714 

Argument "row.names = NULL" in data.table() function call is removed in generateFilterValuesData function, because it's not needed for data.table, and when assigning to NULL, its behavior depends on how it's handled in data.table package.