### PR TITLE
Enable tuneThreshold to also maximize measures

### DIFF
--- a/R/tuneThreshold.R
+++ b/R/tuneThreshold.R
@@ -53,7 +53,7 @@ tuneThreshold = function(pred, measure, task, model, nsub = 20L, control = list(
     if (ttype == "multilabel" || k > 2) {
       names(x) = cls
     }
-    performance(setThreshold(pred, x), measure, task, model, simpleaggr = TRUE)
+    ifelse(measure$minimize, 1, -1) * performance(setThreshold(pred, x), measure, task, model, simpleaggr = TRUE)
   }
 
   if (ttype == "multilabel" || k > 2L) {

--- a/tests/testthat/test_base_tuneThreshold.R
+++ b/tests/testthat/test_base_tuneThreshold.R
@@ -14,6 +14,11 @@ test_that("tuneThreshold", {
   rf2 = resample(lrn, task = multiclass.task, resampling = res, measures = list(mmce))
   th2 = tuneThreshold(rf2$pred, measure = mmce, control = list(max.call = 5))
 
+  # a measure that has to be maximized
+  rf3 = resample(lrn, task = multiclass.task, resampling = res, measures = list(acc))
+  th3 = tuneThreshold(rf2$pred, measure = acc, control = list(max.call = 5))
+  expect_equal(th3$th, th2$th, tolreance = 0.0001)
+
   expect_equal(length(th2$perf), 1L) # 1d-performance value
   expect_equal(length(th2$th), length(getTaskClassLevels(multiclass.task))) # no. of threshold = no. of classes
   expect_equal(names(th2$th), getTaskClassLevels(multiclass.task)) # threshold names = class names


### PR DESCRIPTION
Fixes #2731.
`tuneThreshold` always minimized the performance measure and did not check the "direction" of the measure.
