### PR TITLE
Account for {checkmate} v2.0.0 update

### DIFF
--- a/tests/testthat/test_tune_tuneParamsMultiCrit.R
+++ b/tests/testthat/test_tune_tuneParamsMultiCrit.R
@@ -8,8 +8,8 @@ test_that("tuneParamsMultiCrit", {
   )
   ctrl = makeTuneMultiCritControlRandom(maxit = 2)
   expect_error(tuneParamsMultiCrit(lrn, binaryclass.task, rdesc,
-    par.set = ps, measures = mmce, control = ctrl),
-  ".* May only contain the following types: Measure.")
+    par.set = ps, measures = list(mmce), control = ctrl),
+  ".* Must have length >= 2, but has length 1.")
 
   mycheck = function(res, k) {
     expect_output(print(res), "Points on front")


### PR DESCRIPTION
fixes #2733 

Actually fixed the test to check for two measures in `tuneParamsMultiCrit()` and fail if only one is provided.

Beforehand the error was triggered to due a class check (the supplied `Measure` object is a list and passing it without being wrapped in a `list` causes the issue that `tuneParamsMultiCrit()` tries to use all elements of `Measure` as a measure instead of treating the passed object as a single measure) and not the fact that only one measure was supplied.