### PR TITLE
Explicitly return value in `getNestedTuneResultsOptPathDf()`

### DIFF
--- a/R/getNestedTuneResults.R
+++ b/R/getNestedTuneResults.R
@@ -48,7 +48,6 @@ getNestedTuneResultsOptPathDf = function(r, trafo = FALSE) {
   assertFlag(trafo)
   ops = extractSubList(r$extract, "opt.path", simplify = FALSE)
   if (trafo) ops = lapply(ops, trafoOptPath)
-  browser()
   op.dfs = lapply(ops, as.data.frame)
   op.dfs = setDF(rbindlist(lapply(seq_along(op.dfs), function(i) {
     op.dfs[[i]][, "iter"] = i

--- a/R/getNestedTuneResults.R
+++ b/R/getNestedTuneResults.R
@@ -48,9 +48,11 @@ getNestedTuneResultsOptPathDf = function(r, trafo = FALSE) {
   assertFlag(trafo)
   ops = extractSubList(r$extract, "opt.path", simplify = FALSE)
   if (trafo) ops = lapply(ops, trafoOptPath)
+  browser()
   op.dfs = lapply(ops, as.data.frame)
   op.dfs = setDF(rbindlist(lapply(seq_along(op.dfs), function(i) {
     op.dfs[[i]][, "iter"] = i
     op.dfs[[i]]
   }), fill = TRUE, use.names = TRUE))
+  return(op.dfs)
 }


### PR DESCRIPTION
Explicitly return value in `getNestedTuneResultsOptPathDf()` so that the printer is not returned empty.

Fixes #2753 

``` r
library(caret)
#> Loading required package: lattice
#> Loading required package: ggplot2
library(mlr)
#> Loading required package: ParamHelpers
#> 'mlr' is in maintenance mode since July 2019. Future development
#> efforts will go into its successor 'mlr3' (<https://mlr3.mlr-org.com>).
#> 
#> Attaching package: 'mlr'
#> The following object is masked from 'package:caret':
#> 
#>     train
library(mlbench)
library(randomForest)
#> randomForest 4.6-14
#> Type rfNews() to see new features/changes/bug fixes.
#> 
#> Attaching package: 'randomForest'
#> The following object is masked from 'package:ggplot2':
#> 
#>     margin

# data
data(BreastCancer, package = "mlbench")
df = BreastCancer
df$Id = NULL
for (x in colnames(df)[1:9]) {
  df[, x] = as.numeric(df[, x])
}
BC = makeClassifTask(id = "BreastCancer", data = df, target = "Class")
BC = dropFeatures(BC, c("Bare.nuclei"))

## hyperparams
ps = makeParamSet(
  makeDiscreteParam("mtry", values = c(2, 4)),
  makeDiscreteParam("ntree", values = c(50, 60))
)

## tuning (inner)
ctrl = makeTuneControlGrid()
inner = makeResampleDesc("CV", iters = 2, stratify = TRUE)
lrn = makeLearner("classif.randomForest", predict.type = "prob")
lrn = makeTuneWrapper(lrn,
  resampling = inner,
  par.set = ps, control = ctrl,
  measures = list(auc, f1),
  show.info = FALSE)

## evaluation (outer)
outer = makeResampleDesc("CV", iters = 3, stratify = TRUE)
res = resample(lrn, BC,
  resampling = outer,
  extract = getTuneResult,
  models = TRUE,
  measures = list(auc, f1),
  show.info = FALSE)
res$measures.test
#>   iter       auc        f1
#> 1    1 0.9927220 0.9666667
#> 2    2 0.9943219 0.9803922
#> 3    3 0.9788994 0.9736842

## results
getNestedTuneResultsOptPathDf(res)
#>    mtry ntree auc.test.mean f1.test.mean dob eol error.message exec.time iter
#> 1     2    50     0.9870443    0.9720988   1  NA          <NA>     0.055    1
#> 2     4    50     0.9829175    0.9655198   2  NA          <NA>     0.038    1
#> 3     2    60     0.9851696    0.9752801   3  NA          <NA>     0.042    1
#> 4     4    60     0.9840838    0.9673203   4  NA          <NA>     0.051    1
#> 5     2    50     0.9851799    0.9704161   1  NA          <NA>     0.030    2
#> 6     4    50     0.9822764    0.9671038   2  NA          <NA>     0.032    2
#> 7     2    60     0.9834421    0.9704151   3  NA          <NA>     0.039    2
#> 8     4    60     0.9826305    0.9622403   4  NA          <NA>     0.042    2
#> 9     2    50     0.9899370    0.9719683   1  NA          <NA>     0.029    3
#> 10    4    50     0.9873766    0.9735753   2  NA          <NA>     0.029    3
#> 11    2    60     0.9901208    0.9703718   3  NA          <NA>     0.033    3
#> 12    4    60     0.9895272    0.9673203   4  NA          <NA>     0.040    3
```

<sup>Created on 2020-04-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>