### PR TITLE
Issue a warning if `blocking` was set in the Task but `blocking.cv` was not set within `makeResampleDesc()`

### DIFF
--- a/R/ResampleInstance.R
+++ b/R/ResampleInstance.R
@@ -75,7 +75,7 @@ makeResampleInstance = function(desc, task, size, ...) {
     blocking.cv = desc$blocking.cv
   }
 
-  if (length(blocking) > 0 && blocking.cv == FALSE) {
+  if (length(blocking) > 0 && fixed && blocking.cv == FALSE) {
     warningf("'Blocking' features in the task were detected but 'blocking.cv' was not set in 'resample()'.")
     warningf("Setting 'blocking.cv' to TRUE to prevent undesired behavior. Set `blocking.cv' = TRUE` in `makeResampleDesc()` to silence this warning'.")
     blocking.cv = TRUE

--- a/R/ResampleInstance.R
+++ b/R/ResampleInstance.R
@@ -75,6 +75,11 @@ makeResampleInstance = function(desc, task, size, ...) {
     blocking.cv = desc$blocking.cv
   }
 
+  if (length(blocking) > 0 && blocking.cv == FALSE) {
+    warningf("'Blocking' features in the task were detected but 'blocking.cv' was not set in 'resample()'.")
+    warningf("Setting 'blocking.cv' to TRUE to prevent undesired behavior. Set `blocking.cv' = TRUE` in `makeResampleDesc()` to silence this warning'.")
+    blocking.cv = TRUE
+  }
   if (length(blocking) > 0 && !fixed && blocking.cv) {
     if (is.null(task)) {
       stop("Blocking always needs the task!")


### PR DESCRIPTION
fixes #2787 

@mllg I'd argue that this is the most lightweight fix here.