### PR TITLE
add error and warning on new factor levels for prediction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # mlr 2.18.0.9000
 
-- Internal changes only.
+- Warning if `fix.factors.prediction = TRUE` causes the generation of NAs for new factor levels in prediction.
+- Clear error message if prediction of wrapped learner has not the same length as `newdata`.
+- Internal changes.
 
 
 # mlr 2.18.0

--- a/R/predict.R
+++ b/R/predict.R
@@ -144,6 +144,12 @@ predict.WrappedModel = function(object, task, newdata, subset = NULL, ...) {
         dump = addClasses(get("last.dump", envir = .GlobalEnv), "mlr.dump")
       }
     }
+    # did the prediction fail otherwise?
+    np = nrow(p)
+    if (is.null(np)) np = length(p)
+    if (np != nrow(newdata)) {
+      stopf("predictLearner for %s has returned %i predictions instead of %i!", learner$id, np, nrow(newdata))
+    }
   }
   if (missing(task)) {
     ids = NULL

--- a/R/predictLearner.R
+++ b/R/predictLearner.R
@@ -55,8 +55,13 @@ predictLearner2 = function(.learner, .model, .newdata, ...) {
     ns = intersect(colnames(.newdata), ns)
     fls = fls[ns]
     if (length(ns) > 0L) {
-      .newdata[ns] = mapply(factor, x = .newdata[ns],
-        levels = fls, SIMPLIFY = FALSE)
+      safe_factor = function(x, levels) {
+        if (length(setdiff(levels(x), levels)) > 0) {
+          warning("fix.factors.prediction = TRUE produced NAs because of new factor levels in prediction data.")
+        }
+        factor(x, levels)
+      }
+      .newdata[ns] = mapply(safe_factor, x = .newdata[ns], levels = fls, SIMPLIFY = FALSE)
     }
   }
   p = predictLearner(.learner, .model, .newdata, ...)

--- a/man/getFeatureImportance.Rd
+++ b/man/getFeatureImportance.Rd
@@ -54,7 +54,7 @@ This is identical to randomForest.
 \item randomForestSRC \cr
 This method can calculate feature importance for various measures. By
 default the Breiman-Cutler permutation method is used. See
-\code{\link[randomForestSRC:vimp.rfsrc]{randomForestSRC::vimp()}} for details.
+\code{\link[randomForestSRC:vimp]{randomForestSRC::vimp()}} for details.
 \item ranger \cr
 Supports both measures mentioned above for the randomForest
 learner. Note, that you need to specifically set the learners parameter

--- a/tests/testthat/test_base_resample.R
+++ b/tests/testthat/test_base_resample.R
@@ -203,8 +203,8 @@ test_that("resample drops unseen factors in predict data set", {
 
   lrn = makeLearner("classif.logreg", fix.factors.prediction = TRUE)
   model = train(lrn, subsetTask(task, 1:4))
-  predict(model, subsetTask(task, 5:6))
-  resample(lrn, task, resinst)
+  expect_warning(predict(model, subsetTask(task, 5:6)), "produced NAs because of new factor levels")
+  expect_warning(resample(lrn, task, resinst), "produced NAs because of new factor levels")
 
   # do it manually
   train_task = makeClassifTask("unseen.factors", data[1:4,], "trg", fixup = "quiet") # quiet becasue

--- a/tests/testthat/test_base_resample.R
+++ b/tests/testthat/test_base_resample.R
@@ -210,6 +210,5 @@ test_that("resample drops unseen factors in predict data set", {
   train_task = makeClassifTask("unseen.factors", data[1:4,], "trg", fixup = "quiet") # quiet becasue
   # we get dropped factors warning (which we want here)
   model = train(lrn, train_task)
-  predict(model, newdata = data[5:6,])
-
+  expect_warning(predict(model, newdata = data[5:6,]), "produced NAs because of new factor levels")
 })

--- a/tests/testthat/test_base_resample.R
+++ b/tests/testthat/test_base_resample.R
@@ -186,7 +186,8 @@ test_that("resample printer respects show.info", {
 })
 
 test_that("resample drops unseen factors in predict data set", {
-  data = data.frame(a = c("a", "b", "a", "b", "a", "c"),
+  data = data.frame(
+    a = c("a", "b", "a", "b", "a", "c"),
     b = c(1, 1, 2, 2, 2, 1),
     trg = c("a", "b", "a", "b", "a", "b"),
     stringsAsFactors = TRUE)
@@ -204,4 +205,11 @@ test_that("resample drops unseen factors in predict data set", {
   model = train(lrn, subsetTask(task, 1:4))
   predict(model, subsetTask(task, 5:6))
   resample(lrn, task, resinst)
+
+  # do it manually
+  train_task = makeClassifTask("unseen.factors", data[1:4,], "trg", fixup = "quiet") # quiet becasue
+  # we get dropped factors warning (which we want here)
+  model = train(lrn, train_task)
+  predict(model, newdata = data[5:6,])
+
 })

--- a/tests/testthat/test_classif_ksvm.R
+++ b/tests/testthat/test_classif_ksvm.R
@@ -49,7 +49,7 @@ test_that("classif_ksvm", {
     parset = list(kernel = "polydot", degree = 3, offset = 2, scale = 1.5))
 })
 
-test_that("classif_ksvm produces error for new factor levels on predict" {
+test_that("classif_ksvm produces error for new factor levels on predict", {
   # https://github.com/mlr-org/mlr/issues/2771
   train_data = data.frame(
     A = sample(c("A","B"), 10, TRUE),


### PR DESCRIPTION
General problem: New factor levels appeared during prediction.

Behaviour: `fix.factors.prediction = TRUE` will convert new factors to NAs

Concrete problem: There is no warning that this happens.

More concrete problem: Some learners (eg. ksvm) will just drop rows with NAs in prediction, leading to fewer predictions than in newdata. (#2771)

Less heavy problem: Some learners (eg. ranger) will complain about NAs, but the user does not now where these are comming from (#2611)

Solution: Create a warning, when NAs are created, throw an error if prediction has not the right number of items. Both in combination will hopefully give the user a clue of what is happening.

Also related: #2602