### PR TITLE
Add par.set to `RemoveConstantFeaturesWrapper()`

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -41,7 +41,7 @@ jobs:
       # [Custom env var] setting some ccache options - 4
       CCACHE_SLOPPINESS: include_file_ctime
       # [Custom env var] fake virtual display for rgl package
-      DISPLAY: ":99"
+      DISPLAY: ""
       # otherwise remotes::fun() errors cause the build to fail. Example: Unavailability of binaries
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       CRAN: ${{ matrix.config.cran }}

--- a/R/RemoveConstantFeaturesWrapper.R
+++ b/R/RemoveConstantFeaturesWrapper.R
@@ -8,10 +8,10 @@
 #' @export
 #' @family wrapper
 #' @template ret_learner
-makeRemoveConstantFeaturesWrapper = function(learner, perc = 0, dont.rm = character(0L), na.ignore = FALSE, tol = .Machine$double.eps^.5) {
+makeRemoveConstantFeaturesWrapper = function(learner, perc = 0, dont.rm = character(0L), na.ignore = FALSE, wrap.tol = .Machine$double.eps^.5) {
 
   learner = checkLearner(learner)
-  args = list(perc = perc, dont.rm = dont.rm, na.ignore = na.ignore, tol = tol)
+  args = list(perc = perc, dont.rm = dont.rm, na.ignore = na.ignore, wrap.tol = wrap.tol)
   rm(list = names(args))
 
   trainfun = function(data, target, args) {
@@ -24,6 +24,13 @@ makeRemoveConstantFeaturesWrapper = function(learner, perc = 0, dont.rm = charac
     dropNamed(data, control$dropped.cols)
   }
 
-  lrn = makePreprocWrapper(learner, trainfun, predictfun, par.vals = args)
+  lrn = makePreprocWrapper(learner, trainfun, predictfun,
+    par.set = makeParamSet(
+      makeNumericLearnerParam(id = "perc", lower = 0),
+      makeUntypedLearnerParam(id = "dont.rm", default = character(0L)),
+      makeLogicalLearnerParam(id = "na.ignore", default = FALSE),
+      makeNumericLearnerParam(id = "wrap.tol")
+    ),
+    par.vals = args)
   addClasses(lrn, "RemoveConstantFeaturesWrapper")
 }

--- a/R/removeConstantFeatures.R
+++ b/R/removeConstantFeatures.R
@@ -23,6 +23,7 @@
 #'   Numerical tolerance to treat two numbers as equal.
 #'   Variables stored as `double` will get rounded accordingly before computing the mode.
 #'   Default is `sqrt(.Maschine$double.eps)`.
+#' @param ... To ensure backward compatibility with old argument `tol`
 #'
 #' @template arg_showinfo
 #' @template ret_taskdf

--- a/man/makeRemoveConstantFeaturesWrapper.Rd
+++ b/man/makeRemoveConstantFeaturesWrapper.Rd
@@ -9,7 +9,7 @@ makeRemoveConstantFeaturesWrapper(
   perc = 0,
   dont.rm = character(0L),
   na.ignore = FALSE,
-  tol = .Machine$double.eps^0.5
+  wrap.tol = .Machine$double.eps^0.5
 )
 }
 \arguments{
@@ -31,7 +31,7 @@ Should NAs be ignored in the percentage calculation?
 Note that if the feature has only missing values, it is always removed.
 Default is \code{FALSE}.}
 
-\item{tol}{(\code{numeric(1)})\cr
+\item{wrap.tol}{(\code{numeric(1)})\cr
 Numerical tolerance to treat two numbers as equal.
 Variables stored as \code{double} will get rounded accordingly before computing the mode.
 Default is \code{sqrt(.Maschine$double.eps)}.}

--- a/man/removeConstantFeatures.Rd
+++ b/man/removeConstantFeatures.Rd
@@ -40,6 +40,8 @@ Default is \code{sqrt(.Maschine$double.eps)}.}
 \item{show.info}{(\code{logical(1)})\cr
 Print verbose output on console?
 Default is set via \link{configureMlr}.}
+
+\item{...}{To ensure backward compatibility with old argument \code{tol}}
 }
 \value{
 \link{data.frame} | \link{Task}. Same type as \code{obj}.

--- a/man/removeConstantFeatures.Rd
+++ b/man/removeConstantFeatures.Rd
@@ -9,8 +9,9 @@ removeConstantFeatures(
   perc = 0,
   dont.rm = character(0L),
   na.ignore = FALSE,
-  tol = .Machine$double.eps^0.5,
-  show.info = getMlrOption("show.info")
+  wrap.tol = .Machine$double.eps^0.5,
+  show.info = getMlrOption("show.info"),
+  ...
 )
 }
 \arguments{
@@ -31,7 +32,7 @@ Should NAs be ignored in the percentage calculation?
 Note that if the feature has only missing values, it is always removed.
 Default is \code{FALSE}.}
 
-\item{tol}{(\code{numeric(1)})\cr
+\item{wrap.tol}{(\code{numeric(1)})\cr
 Numerical tolerance to treat two numbers as equal.
 Variables stored as \code{double} will get rounded accordingly before computing the mode.
 Default is \code{sqrt(.Maschine$double.eps)}.}


### PR DESCRIPTION
fixes #2516 

Due to a name clash with popular base learner hyperpars `tol`, the wrapper hyperpar `tol` was renamed to `wrap.tol` and backward comp for `tol` was added.

``` r
library(mlr)
#> Loading required package: ParamHelpers
#> Warning message: 'mlr' is in 'maintenance-only' mode since July 2019.
#> Future development will only happen in 'mlr3'
#> (<https://mlr3.mlr-org.com>). Due to the focus on 'mlr3' there might be
#> uncaught bugs meanwhile in {mlr} - please consider switching.
lrn <- makeLearner("classif.ksvm", C = 123)
lrn <- makeRemoveConstantFeaturesWrapper(lrn, perc = 5)
p <- getHyperPars(lrn)
print(p)
#> $fit
#> [1] FALSE
#> 
#> $C
#> [1] 123
#> 
#> $perc
#> [1] 5
#> 
#> $dont.rm
#> character(0)
#> 
#> $na.ignore
#> [1] FALSE
#> 
#> $wrap.tol
#> [1] 1.490116e-08
```

<sup>Created on 2021-02-15 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>