### PR TITLE
Install GGally for pkgdown build

### DIFF
--- a/tic.R
+++ b/tic.R
@@ -10,7 +10,8 @@ do_package_checks(error_on = "warning", codecov = FALSE)
 # pkgdown
 if (ci_on_ghactions() && ci_has_env("BUILD_PKGDOWN")) {
   get_stage("before_deploy") %>%
-    add_step(step_install_github("mlr-org/mlr3pkgdowntemplate"))
+    add_step(step_install_github("mlr-org/mlr3pkgdowntemplate")) %>%
+    add_step(step_install_cran("GGally"))
   do_pkgdown()
 }
 


### PR DESCRIPTION
Seems `GGally` was pulled in as dep from some package.