### PR TITLE
FSelector filters: Chi Squared was calculated instead of Information Gain

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -606,7 +606,7 @@ makeFilter(
   })
 
 chi.squared = makeFilter(
-  name = "FSelector_gain.ratio",
+  name = "FSelector_chi.squared",
   desc = "Chi-squared statistic of independence between feature and target",
   pkg = "FSelector",
   supported.tasks = c("classif", "regr"),


### PR DESCRIPTION
Fixed FSelector filter bug: Chi Squared was calculated instead of Information Gain due to wrong filter name.


### Code to reproduce / investigate the problem the long way:

Gain ratio is different for FSelector and FSelectorRcpp:
```
generateFilterValuesData(
  makeClassifTask(data = iris, target = "Species"),
  method = c(
    "FSelector_gain.ratio",
    "FSelectorRcpp_gain.ratio"
    )
)
```
```
FilterValues:
Task: iris
           name    type                   filter     value
1:  Petal.Width numeric     FSelector_gain.ratio 0.9432359
2: Petal.Length numeric     FSelector_gain.ratio 0.9346311
3: Sepal.Length numeric     FSelector_gain.ratio 0.6288067
4:  Sepal.Width numeric     FSelector_gain.ratio 0.4922162
5:  Petal.Width numeric FSelectorRcpp_gain.ratio 0.8713692
6: Petal.Length numeric FSelectorRcpp_gain.ratio 0.8584937
7: Sepal.Length numeric FSelectorRcpp_gain.ratio 0.4196464
8:  Sepal.Width numeric FSelectorRcpp_gain.ratio 0.2472972
```

Docs look like it should be the same: 

- [FSelector](https://cran.r-project.org/web/packages/FSelector/FSelector.pdf)
- [FSelectorRcpp](https://cran.r-project.org/web/packages/FSelectorRcpp/FSelectorRcpp.pdf)


Indeed Gain Ratio is the same using base packages:

```
FSelector::gain.ratio(formula = Species~., data = iris)
FSelectorRcpp::information_gain(formula = Species~., data = iris, type = "gainratio")
```
```
            attr_importance
Sepal.Length       0.4196464
Sepal.Width        0.2472972
Petal.Length       0.8584937
Petal.Width        0.8713692

    attributes importance
1 Sepal.Length  0.4196464
2  Sepal.Width  0.2472972
3 Petal.Length  0.8584937
4  Petal.Width  0.8713692
```

mlr Docs hint that there is maybe a problem with the FSelector Chi Squared call, as it has the same description as the Info Gain:
`listFilterMethods()` (or see [filters docs](https://mlr.mlr-org.com/articles/tutorial/filter_methods.html))

Indeed the results are the same:
```
generateFilterValuesData(
  makeClassifTask(data = iris, target = "Species"),
  method = c(
    "FSelector_gain.ratio",
    "FSelector_chi.squared"
  )
)
```
```
FilterValues:
Task: iris
           name    type                filter     value
1:  Petal.Width numeric  FSelector_gain.ratio 0.9432359
2: Petal.Length numeric  FSelector_gain.ratio 0.9346311
3: Sepal.Length numeric  FSelector_gain.ratio 0.6288067
4:  Sepal.Width numeric  FSelector_gain.ratio 0.4922162
5:  Petal.Width numeric FSelector_chi.squared 0.9432359
6: Petal.Length numeric FSelector_chi.squared 0.9346311
7: Sepal.Length numeric FSelector_chi.squared 0.6288067
8:  Sepal.Width numeric FSelector_chi.squared 0.4922162
```

After the fix it seems to work correctly now (Info Gain is the same for FSelector and FSelectorRcpp):

```
FilterValues:
Task: iris
            name    type                   filter     value
 1:  Petal.Width numeric FSelectorRcpp_gain.ratio 0.8713692
 2: Petal.Length numeric FSelectorRcpp_gain.ratio 0.8584937
 3: Sepal.Length numeric FSelectorRcpp_gain.ratio 0.4196464
 4:  Sepal.Width numeric FSelectorRcpp_gain.ratio 0.2472972
 5:  Petal.Width numeric     FSelector_gain.ratio 0.8713692
 6: Petal.Length numeric     FSelector_gain.ratio 0.8584937
 7: Sepal.Length numeric     FSelector_gain.ratio 0.4196464
 8:  Sepal.Width numeric     FSelector_gain.ratio 0.2472972
 9:  Petal.Width numeric    FSelector_chi.squared 0.9432359
10: Petal.Length numeric    FSelector_chi.squared 0.9346311
11: Sepal.Length numeric    FSelector_chi.squared 0.6288067
12:  Sepal.Width numeric    FSelector_chi.squared 0.4922162
```
