### PR TITLE
- R 4.2 fixes

### DIFF
--- a/R/ClassifTask.R
+++ b/R/ClassifTask.R
@@ -57,7 +57,7 @@ makeClassifTaskDesc = function(id, data, target, weights, blocking, positive, co
   td$class.levels = levs
   td$positive = positive
   td$negative = NA_character_
-  td$class.distribution = table(data[target])
+  td$class.distribution = table(data[target], dnn = "")
   if (length(td$class.levels) == 1L) {
     td$negative = stri_paste("not_", positive)
   } else if (length(td$class.levels) == 2L) {

--- a/tests/testthat/test_base_checkData.R
+++ b/tests/testthat/test_base_checkData.R
@@ -1,4 +1,3 @@
-
 test_that("checkData", {
   expect_error(
     makeClassifTask(data = binaryclass.df, target = "foo"),


### PR DESCRIPTION
There has been a change to how dimnames are returned by `table()` in [R 4.2](https://developer.r-project.org/blosxom.cgi/R-devel/NEWS): 

> ‘dimnames(table(d))’ is more consistent in the case where ‘d’ is a list with a single component, thanks to Thomas Soeiro's report to R-devel.