### PR TITLE
Adjust behavior of "positive" arg for classif.logreg

### DIFF
--- a/R/RLearner_classif_logreg.R
+++ b/R/RLearner_classif_logreg.R
@@ -20,6 +20,14 @@ makeRLearner.classif.logreg = function() {
 #' @export
 trainLearner.classif.logreg = function(.learner, .task, .subset, .weights = NULL, ...) {
   f = getTaskFormula(.task)
+
+  # logreg expects the first label to be the negative class, contrary
+  # to the mlr3 convention that the positive class comes first.
+  # see https://github.com/mlr-org/mlr/issues/2817
+  tn = getTaskTargetNames(.task)
+  data = getTaskData(.task, .subset)
+  data[[tn]] = swap_levels(data[[tn]])
+
   stats::glm(f, data = getTaskData(.task, .subset), family = "binomial", weights = .weights, ...)
 }
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -181,3 +181,8 @@ makeResamplingWindow = function(desc, size, task = NULL, coords, window.type) {
   desc$iters = length(test.inds)
   makeResampleInstanceInternal(desc, size, train.inds = train.inds, test.inds = test.inds)
 }
+
+# taken from mlr3learners
+swap_levels = function(x) {
+  factor(x, levels = rev(levels(x)))
+}


### PR DESCRIPTION
fix #2817 

@berndbischl This should reflect the current behavior in {mlr3learners}. Will this change have side-effects that we should note in the NEWS?

``` r
library(mlr)
#> Loading required package: ParamHelpers
#> Warning message: 'mlr' is in 'maintenance-only' mode since July 2019.
#> Future development will only happen in 'mlr3'
#> (<https://mlr3.mlr-org.com>). Due to the focus on 'mlr3' there might be
#> uncaught bugs meanwhile in {mlr} - please consider switching.
library(tidyverse)
data(titanic_train, package = "titanic")
titanicTib <- as_tibble(titanic_train)
fctrs <- c("Survived", "Sex", "Pclass")
titanicClean <- titanicTib %>%
  mutate_at(.vars = fctrs, .funs = factor) %>%
  mutate(FamSize = SibSp + Parch) %>%
  select(Survived, Pclass, Sex, Age, Fare, FamSize)

logReg <- makeLearner("classif.logreg", predict.type = "prob")

imp <- impute(titanicClean, cols = list(Age = imputeMean()))
titanicTask <- makeClassifTask(data = imp$data, target = "Survived")
logRegModel <- train(logReg, titanicTask)

titanicTask1 <- makeClassifTask(data = imp$data, target = "Survived", positive = "1")
logRegModel1 <- train(logReg, titanicTask1)

waldo::compare(getLearnerModel(logRegModel), getLearnerModel(logRegModel1))
#> attr(old$formula, '.Environment')$.GenericCallEnv$pars$.task$task.desc$positive vs attr(new$formula, '.Environment')$.GenericCallEnv$pars$.task$task.desc$positive
#> - "0"
#> + "1"
#> 
#> attr(old$formula, '.Environment')$.GenericCallEnv$pars$.task$task.desc$negative vs attr(new$formula, '.Environment')$.GenericCallEnv$pars$.task$task.desc$negative
#> - "1"
#> + "0"
#> 
#> `attr(old$formula, '.Environment')$.GenericCallEnv$task$task.desc$positive`: "0"
#> `attr(new$formula, '.Environment')$.GenericCallEnv$task$task.desc$positive`: "1"
#> 
#> `attr(old$formula, '.Environment')$.GenericCallEnv$task$task.desc$negative`: "1"
#> `attr(new$formula, '.Environment')$.GenericCallEnv$task$task.desc$negative`: "0"
#> 
#> `attr(old$formula, '.Environment')$.GenericCallEnv$time.train`: 0.009
#> `attr(new$formula, '.Environment')$.GenericCallEnv$time.train`: 0.003
#> 
#> `attr(old$formula, '.Environment')$.task$task.desc$positive`: "0"
#> `attr(new$formula, '.Environment')$.task$task.desc$positive`: "1"
#> 
#> `attr(old$formula, '.Environment')$.task$task.desc$negative`: "1"
#> `attr(new$formula, '.Environment')$.task$task.desc$negative`: "0"
```

<sup>Created on 2022-08-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.1 (2022-06-23)
#>  os       macOS Monterey 12.5
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Europe/Zurich
#>  date     2022-08-14
#>  pandoc   2.19 @ /opt/homebrew/bin/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package       * version     date (UTC) lib source
#>  assertthat      0.2.1       2019-03-21 [1] CRAN (R 4.2.0)
#>  backports       1.4.1       2021-12-13 [1] CRAN (R 4.2.0)
#>  BBmisc          1.12        2022-03-10 [1] CRAN (R 4.2.0)
#>  broom           1.0.0       2022-07-01 [1] CRAN (R 4.2.0)
#>  cellranger      1.1.0       2016-07-27 [1] CRAN (R 4.2.0)
#>  checkmate       2.1.0       2022-04-21 [1] CRAN (R 4.2.0)
#>  cli             3.3.0       2022-04-25 [1] CRAN (R 4.2.0)
#>  colorspace      2.0-3       2022-02-21 [1] CRAN (R 4.2.0)
#>  crayon          1.5.1       2022-03-26 [1] CRAN (R 4.2.0)
#>  data.table      1.14.2      2021-09-27 [1] CRAN (R 4.2.0)
#>  DBI             1.1.3       2022-06-18 [1] CRAN (R 4.2.0)
#>  dbplyr          2.2.1       2022-06-27 [1] CRAN (R 4.2.0)
#>  diffobj         0.3.5       2021-10-05 [1] CRAN (R 4.2.0)
#>  digest          0.6.29      2021-12-01 [1] CRAN (R 4.2.0)
#>  dplyr         * 1.0.9       2022-04-28 [1] CRAN (R 4.2.0)
#>  ellipsis        0.3.2       2021-04-29 [1] CRAN (R 4.2.0)
#>  evaluate        0.16        2022-08-09 [1] CRAN (R 4.2.1)
#>  fansi           1.0.3       2022-03-24 [1] CRAN (R 4.2.0)
#>  fastmap         1.1.0       2021-01-25 [1] CRAN (R 4.2.0)
#>  fastmatch       1.1-3       2021-07-23 [1] CRAN (R 4.2.0)
#>  forcats       * 0.5.1       2021-01-27 [1] CRAN (R 4.2.0)
#>  fs              1.5.2       2021-12-08 [1] CRAN (R 4.2.0)
#>  gargle          1.2.0       2021-07-02 [1] CRAN (R 4.2.0)
#>  generics        0.1.3       2022-07-05 [1] CRAN (R 4.2.0)
#>  ggplot2       * 3.3.6       2022-05-03 [1] CRAN (R 4.2.0)
#>  glue            1.6.2       2022-02-24 [1] CRAN (R 4.2.0)
#>  googledrive     2.0.0       2021-07-08 [1] CRAN (R 4.2.0)
#>  googlesheets4   1.0.0       2021-07-21 [1] CRAN (R 4.2.0)
#>  gtable          0.3.0       2019-03-25 [1] CRAN (R 4.2.0)
#>  haven           2.5.0       2022-04-15 [1] CRAN (R 4.2.0)
#>  highr           0.9         2021-04-16 [1] CRAN (R 4.2.0)
#>  hms             1.1.1       2021-09-26 [1] CRAN (R 4.2.0)
#>  htmltools       0.5.3       2022-07-18 [1] CRAN (R 4.2.0)
#>  httr            1.4.3       2022-05-04 [1] CRAN (R 4.2.0)
#>  jsonlite        1.8.0       2022-02-22 [1] CRAN (R 4.2.0)
#>  knitr           1.39        2022-04-26 [1] CRAN (R 4.2.0)
#>  lattice         0.20-45     2021-09-22 [1] CRAN (R 4.2.1)
#>  lifecycle       1.0.1       2021-09-24 [1] CRAN (R 4.2.0)
#>  lubridate       1.8.0       2021-10-07 [1] CRAN (R 4.2.0)
#>  magrittr        2.0.3       2022-03-30 [1] CRAN (R 4.2.0)
#>  Matrix          1.4-1       2022-03-23 [1] CRAN (R 4.2.0)
#>  mlr           * 2.19.0.9001 2022-08-14 [1] local
#>  modelr          0.1.8       2020-05-19 [1] CRAN (R 4.2.0)
#>  munsell         0.5.0       2018-06-12 [1] CRAN (R 4.2.0)
#>  parallelMap     1.5.1       2021-06-28 [1] CRAN (R 4.2.0)
#>  ParamHelpers  * 1.14.1      2022-07-04 [1] CRAN (R 4.2.0)
#>  pillar          1.8.0       2022-07-18 [1] CRAN (R 4.2.0)
#>  pkgconfig       2.0.3       2019-09-22 [1] CRAN (R 4.2.0)
#>  purrr         * 0.3.4       2020-04-17 [1] CRAN (R 4.2.0)
#>  R.cache         0.16.0      2022-07-21 [1] CRAN (R 4.2.0)
#>  R.methodsS3     1.8.2       2022-06-13 [1] CRAN (R 4.2.0)
#>  R.oo            1.25.0      2022-06-12 [1] CRAN (R 4.2.0)
#>  R.utils         2.12.0      2022-06-28 [1] CRAN (R 4.2.0)
#>  R6              2.5.1       2021-08-19 [1] CRAN (R 4.2.0)
#>  readr         * 2.1.2       2022-01-30 [1] CRAN (R 4.2.0)
#>  readxl          1.4.0       2022-03-28 [1] CRAN (R 4.2.0)
#>  rematch2        2.1.2       2020-05-01 [1] CRAN (R 4.2.0)
#>  reprex          2.0.1       2021-08-05 [1] CRAN (R 4.2.0)
#>  rlang           1.0.4       2022-07-12 [1] CRAN (R 4.2.0)
#>  rmarkdown       2.14        2022-04-25 [1] CRAN (R 4.2.0)
#>  rstudioapi      0.13        2020-11-12 [1] CRAN (R 4.2.0)
#>  rvest           1.0.2       2021-10-16 [1] CRAN (R 4.2.0)
#>  scales          1.2.0       2022-04-13 [1] CRAN (R 4.2.0)
#>  sessioninfo     1.2.2       2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi         1.7.8       2022-07-11 [1] CRAN (R 4.2.0)
#>  stringr       * 1.4.0       2019-02-10 [1] CRAN (R 4.2.0)
#>  styler          1.7.0.9001  2022-08-08 [1] Github (r-lib/styler@a3b69e4)
#>  survival        3.3-1       2022-03-03 [1] CRAN (R 4.2.0)
#>  tibble        * 3.1.8       2022-07-22 [1] CRAN (R 4.2.0)
#>  tidyr         * 1.2.0       2022-02-01 [1] CRAN (R 4.2.0)
#>  tidyselect      1.1.2       2022-02-21 [1] CRAN (R 4.2.0)
#>  tidyverse     * 1.3.2       2022-07-18 [1] CRAN (R 4.2.0)
#>  tzdb            0.3.0       2022-03-28 [1] CRAN (R 4.2.0)
#>  utf8            1.2.2       2021-07-24 [1] CRAN (R 4.2.0)
#>  vctrs           0.4.1       2022-04-13 [1] CRAN (R 4.2.0)
#>  waldo           0.4.0       2022-03-16 [1] CRAN (R 4.2.0)
#>  withr           2.5.0       2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun            0.32        2022-08-10 [1] CRAN (R 4.2.1)
#>  XML             3.99-0.10   2022-06-09 [1] CRAN (R 4.2.0)
#>  xml2            1.3.3       2021-11-30 [1] CRAN (R 4.2.0)
#>  yaml            2.3.5       2022-02-21 [1] CRAN (R 4.2.0)
#> 
#>  [1] /Users/pjs/Library/R/arm64/4.2/library
#>  [2] /opt/R/4.2.1-arm64/Resources/site-library
#>  [3] /opt/R/4.2.1-arm64/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>


