### PR TITLE
Fix: tuneThreshold - Minimization for measures needing maximization

### DIFF
--- a/R/tuneThreshold.R
+++ b/R/tuneThreshold.R
@@ -53,7 +53,7 @@ tuneThreshold = function(pred, measure, task, model, nsub = 20L, control = list(
     if (ttype == "multilabel" || k > 2) {
       names(x) = cls
     }
-    ifelse(measure$minimize, 1, -1) * performance(setThreshold(pred, x), measure, task, model, simpleaggr = TRUE)
+    ifelse(measure$minimize, 1, -1) * performance(setThreshold(pred, x), measure, task, model, simpleaggr = TRUE) # always a minimization
   }
 
   if (ttype == "multilabel" || k > 2L) {
@@ -68,9 +68,9 @@ tuneThreshold = function(pred, measure, task, model, nsub = 20L, control = list(
     names(th) = cls
     perf = or$value
   } else { # classif with k = 2
-    or = optimizeSubInts(f = fitn, lower = 0, upper = 1, maximum = !measure$minimize, nsub = nsub)
+    or = optimizeSubInts(f = fitn, lower = 0, upper = 1, maximum = FALSE, nsub = nsub) # maximum = false, because callback makes it a minimization
     th = or[[1]]
-    perf = or$objective
+    perf = ifelse(measure$minimize, 1, -1) * or$objective # flip sign if minimization for negative performance measure was done
   }
   return(list(th = th, perf = perf))
 }


### PR DESCRIPTION
When using `tuneThreshold` to get the best threshold for a measure that needs maximization it does not work, but provides the minima (worst threshold) and returns it with the wrong sign.

### Reproduce:
```
model = train(makeLearner("classif.rpart", predict.type = "prob"), sonar.task)
preds = predict(model, sonar.task)

performance(preds, bac)
# bac
# 0.8763815

tuneThreshold(preds, bac) # minimum instead of maximum returned (with wrong sign)
# $th
# [1] 0.9309793
#
# $perf
# bac
# -0.545045

d = generateThreshVsPerfData(preds, bac)$data
min(d$bac[2:99]) # min bac
# 0.545045
max(d$bac[2:99]) # max bac
# 0.8763815
```

### Cause
The defined callback function in tune threshold always makes it a minimization problem for all measures (e.g. for measures that need maximization as well):
`ifelse(measure$minimize, 1, -1) * performance(setThreshold(pred, x), measure, task, model, simpleaggr = TRUE)`

When `optimizeSubInts` is called the `maximum` flag is set depending on the measure's `minimize` flag (even though it was already handled and it will be always a minimization problem at this point). This leads to finding the overall minima not maxima of a measure that needs to be maximized (e.g. bac, acc etc.).

### Fix
After changing the call of optimizeSubInts to search for the minima always it works correctly:

```
> model = train(makeLearner("classif.rpart", predict.type = "prob"), sonar.task)
> preds = predict(model, sonar.task)
> performance(preds, bac)
      bac 
0.8763815 
> tuneThreshold(preds, bac) 
$th
[1] 0.5309993

$perf
      bac 
0.8763815 

> d = generateThreshVsPerfData(preds, bac)$data
> min(d$bac[2:99]) 
[1] 0.545045
> max(d$bac[2:99]) 
[1] 0.8763815
```